### PR TITLE
Add GPU profiling capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,29 @@ julia> Array(c)
 
 This package also supports profiling GPU execution for later visualization with Apple's
 Xcode tools. The easiest way to generate a GPU report is to use the `Metal.@profile` macro as seen
-below (using the kernel and setup from above).
+below. To profile GPU code from a Julia process,
+you must set the `METAL_CAPTURE_ENABLED` environment variable. On the first Metal
+command detected, you should get a message stating "Metal GPU Frame Capture Enabled" if the
+variable was set correctly.
 
 ```julia
-julia> Metal.@profile @metal threads=length(c) vadd(a, b, c)
+$ METAL_CAPTURE_ENABLED=1 julia
+...
+
+julia> using Metal
+
+julia> function vadd(a, b, c)
+           i = thread_position_in_grid_1d()
+           c[i] = a[i] + b[i]
+           return
+       end
+vadd (generic function with 1 method)
+
+julia> a = MtlArray([1]); b = MtlArray([2]); c = similar(a);
+... Metal GPU Frame Capture Enabled
+
+julia> Metal.@profile @metal threads=length(c) vadd(a, b, c);
+[ Info: GPU frame capture saved to /var/folders/x3/75r5z4sd2_bdwqs68_nfnxw40000gn/T/jl_WzKxYVMlon/jl_metal.gputrace/
 ```
 
 This will generate a `.gputrace` folder in a temporary directory. To view the profile, open

--- a/README.md
+++ b/README.md
@@ -112,6 +112,24 @@ julia> Array(c)
  3
 ```
 
+## Profiling
+
+This package also supports profiling GPU execution for later visualization with Apple's
+Xcode tools. The easiest way to generate a GPU report is to use the `Metal.@profile` macro as seen
+below (using the kernel and setup from above).
+
+```julia
+julia> Metal.@profile @metal threads=length(c) vadd(a, b, c)
+```
+
+This will generate a `.gputrace` folder in a temporary directory. To view the profile, open
+the folder with Xcode. Since the temporary directory is destroyed when the Julia process
+ends though, be sure to copy the `.gputrace` directory to a stable location on your system
+for later viewing.
+
+Note: Xcode is a large install, and there are some peculiarities with viewing Julia-created
+GPU traces. It's recommended to only have one trace open at a time, and the shader profiler
+may fail to start.
 
 ## Metal API wrapper
 

--- a/deps/cmt/CMakeLists.txt
+++ b/deps/cmt/CMakeLists.txt
@@ -54,7 +54,10 @@ set(SOURCES
     src/device.m
     src/error.m
     src/event.m
-    src/resource.m)
+    src/resource.m
+    src/capture/capture_descriptor.m
+    src/capture/capture_manager.m
+    src/capture/capture_scope.m)
 
 add_library(cmt SHARED ${SOURCES})
 

--- a/deps/cmt/include/cmt/capture/capture_descriptor.h
+++ b/deps/cmt/include/cmt/capture/capture_descriptor.h
@@ -1,0 +1,60 @@
+#ifndef cmt_capture_descriptor_h
+#define cmt_capture_descriptor_h
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "cmt/common.h"
+#include "cmt/types.h"
+#include "cmt/enums.h"
+#include "cmt/resource.h"
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.15), mt_ios(13.0))
+MtCaptureDescriptor*
+mtNewCaptureDescriptor(void);
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.15), mt_ios(13.0))
+void*
+mtCaptureDescriptorCaptureObject(MtCaptureDescriptor *desc);
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.15), mt_ios(13.0))
+void
+mtCaptureDescriptorCaptureObjectSetQueue(MtCaptureDescriptor *desc, MtCommandQueue *cmdq);
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.15), mt_ios(13.0))
+void
+mtCaptureDescriptorCaptureObjectSetDevice(MtCaptureDescriptor *desc, MtDevice *dev);
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.15), mt_ios(13.0))
+void
+mtCaptureDescriptorCaptureObjectSetScope(MtCaptureDescriptor *desc, MtCaptureScope *scope);
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.15), mt_ios(13.0))
+MtCaptureDestination
+mtCaptureDescriptorDestination(MtCaptureDescriptor *desc);
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.15), mt_ios(13.0))
+void
+mtCaptureDescriptorDestinationSet(MtCaptureDescriptor *desc, MtCaptureDestination dest);
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.15), mt_ios(13.0))
+void
+mtCaptureDescriptorOutputURLSet(MtCaptureDescriptor *desc, const char *path);
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.15), mt_ios(13.0))
+const char*
+mtCaptureDescriptorOutputURL(MtCaptureDescriptor *desc);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/deps/cmt/include/cmt/capture/capture_manager.h
+++ b/deps/cmt/include/cmt/capture/capture_manager.h
@@ -1,0 +1,50 @@
+#ifndef cmt_capture_manager_h
+#define cmt_capture_manager_h
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "cmt/common.h"
+#include "cmt/types.h"
+#include "cmt/enums.h"
+#include "cmt/resource.h"
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+MtCaptureManager*
+mtSharedCaptureManager(void);
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+bool
+mtSupportsDestination(MtCaptureManager *manager, MtCaptureDestination destination);
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+bool
+mtStartCaptureWithDescriptor(MtCaptureManager *manager, MtCaptureDescriptor *descriptor, NsError **error);
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+void
+mtStopCapture(MtCaptureManager *manager);
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+bool
+mtIsCapturing(MtCaptureManager *manager);
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+MtCaptureScope*
+mtDefaultCaptureScope(MtCaptureManager *manager);
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+void
+mtDefaultCaptureScopeSet(MtCaptureManager *manager, MtCaptureScope *scope);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/deps/cmt/include/cmt/capture/capture_scope.h
+++ b/deps/cmt/include/cmt/capture/capture_scope.h
@@ -1,0 +1,50 @@
+#ifndef cmt_capture_scope_h
+#define cmt_capture_scope_h
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "cmt/common.h"
+#include "cmt/types.h"
+#include "cmt/enums.h"
+#include "cmt/resource.h"
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+MtCaptureScope*
+mtNewCaptureScopeWithCommandQueue(MtCaptureManager *manager, MtCommandQueue *queue);
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+void
+mtBeginScope(MtCaptureScope *scope);
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+void
+mtEndScope(MtCaptureScope *scope);
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+const char*
+mtCaptureScopeLabel(MtCaptureScope *scope);
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+void
+mtCaptureScopeLabelSet(MtCaptureScope *scope, const char* label);
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+MtDevice*
+mtCaptureScopeDevice(MtCaptureScope *scope);
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+MtCommandQueue*
+mtCaptureScopeCommandQueue(MtCaptureScope *scope);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/deps/cmt/include/cmt/cmt.h
+++ b/deps/cmt/include/cmt/cmt.h
@@ -56,6 +56,10 @@ extern "C" {
 #include "argument_descriptor.h"
 #include "argument_encoder.h"
 
+#include "capture/capture_descriptor.h"
+#include "capture/capture_manager.h"
+#include "capture/capture_scope.h"
+
 MT_EXPORT
 void*
 mtRetain(void *obj);

--- a/deps/cmt/include/cmt/enums.h
+++ b/deps/cmt/include/cmt/enums.h
@@ -491,5 +491,28 @@ typedef enum MtArgumentType {
     MtArgumentTypeSampler = 3,
 } MtArgumentType;
 
+typedef enum MtCaptureError {
+    /// Capturing is not supported, maybe the destination is not supported.
+    MtCaptureErrorNotSupported = 1,
+    /// A capture is already in progress.
+    MtCaptureErrorAlreadyCapturing,
+    /// The MTLCaptureDescriptor contains an invalid parameters.
+    MtCaptureErrorInvalidDescriptor,
+} MtCaptureError;
+
+/// The destination where you want the GPU trace to be captured to.
+typedef enum MtCaptureDestination {
+    /// Capture to Developer Tools (Xcode) and stop the execution after capturing.
+    MtCaptureDestinationDeveloperTools = 1,
+    /// Capture to a GPU Trace document and continue execution after capturing.
+    MtCaptureDestinationGPUTraceDocument,
+} MtCaptureDestination;
+
+typedef enum MtCaptureDescriptorCaptureObjectType {
+  MtCaptureDescriptorCaptureObjectTypeNull  = 0,
+  MtCaptureDescriptorCaptureObjectTypeDevice  = 1,
+  MtCaptureDescriptorCaptureObjectTypeQueue   = 2,
+  MtCaptureDescriptorCaptureObjectTypeScope   = 3
+} MtCaptureDescriptorCaptureObjectType;
 
 #endif /* cmt_enums_h */

--- a/deps/cmt/include/cmt/types_metal.h
+++ b/deps/cmt/include/cmt/types_metal.h
@@ -88,6 +88,9 @@ typedef void MtStructType;
 typedef void MtComputePipelineReflection;
 typedef void MtRenderPipelineReflection;
 
+typedef void MtCaptureManager;
+typedef void MtCaptureScope;
+typedef void MtCaptureDescriptor;
 
 typedef struct {
     uint32_t threadgroupsPerGrid[3];

--- a/deps/cmt/include/impl/conversion.h
+++ b/deps/cmt/include/impl/conversion.h
@@ -9,10 +9,24 @@
 
 MT_HIDE
 MT_INLINE
+const char*
+mtNSURLFileSystemRepresentation(NSURL *url) {
+    return (const char*)[(NSURL*)url fileSystemRepresentation];
+}
+
+MT_HIDE
+MT_INLINE
 NSString*
 mtNSString(const char *str) {
   return [NSString stringWithCString: str
                             encoding: NSUTF8StringEncoding];
+}
+
+MT_HIDE
+MT_INLINE
+NSURL*
+mtNSURL(const char *str){
+    return [NSURL fileURLWithPath: mtNSString(str)];
 }
 
 MT_HIDE

--- a/deps/cmt/src/capture/capture_descriptor.m
+++ b/deps/cmt/src/capture/capture_descriptor.m
@@ -1,0 +1,66 @@
+#include "cmt/capture/capture_descriptor.h"
+#include "impl/common.h"
+
+CF_RETURNS_RETAINED
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.15), mt_ios(13.0))
+MtCaptureDescriptor*
+mtNewCaptureDescriptor() {
+    return [MTLCaptureDescriptor new];
+}
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.15), mt_ios(13.0))
+void*
+mtCaptureDescriptorCaptureObject(MtCaptureDescriptor *desc) {
+    return (void*)[(MTLCaptureDescriptor*)desc captureObject];
+}
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.15), mt_ios(13.0))
+void
+mtCaptureDescriptorCaptureObjectSetQueue(MtCaptureDescriptor *desc, MtCommandQueue *cmdq) {
+    [(MTLCaptureDescriptor*)desc setCaptureObject:(id<MTLCommandQueue>)cmdq];
+}
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.15), mt_ios(13.0))
+void
+mtCaptureDescriptorCaptureObjectSetDevice(MtCaptureDescriptor *desc, MtDevice *dev) {
+    [(MTLCaptureDescriptor*)desc setCaptureObject:(id<MTLDevice>)dev];
+}
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.15), mt_ios(13.0))
+void
+mtCaptureDescriptorCaptureObjectSetScope(MtCaptureDescriptor *desc, MtCaptureScope *scope) {
+    [(MTLCaptureDescriptor*)desc setCaptureObject:(id<MTLCaptureScope>)scope];
+}
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.15), mt_ios(13.0))
+MtCaptureDestination
+mtCaptureDescriptorDestination(MtCaptureDescriptor *desc) {
+    return (MtCaptureDestination)[(MTLCaptureDescriptor*)desc destination];
+}
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.15), mt_ios(13.0))
+void
+mtCaptureDescriptorDestinationSet(MtCaptureDescriptor *desc, MtCaptureDestination dest) {
+    [(MTLCaptureDescriptor*)desc setDestination:(MTLCaptureDestination)dest];
+}
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.15), mt_ios(13.0))
+const char*
+mtCaptureDescriptorOutputURL(MtCaptureDescriptor *desc) {
+    return (const char*)mtNSURLFileSystemRepresentation((NSURL*)[(MTLCaptureDescriptor*)desc outputURL]);
+}
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.15), mt_ios(13.0))
+void
+mtCaptureDescriptorOutputURLSet(MtCaptureDescriptor *desc, const char *path) {
+    [(MTLCaptureDescriptor*)desc setOutputURL:mtNSURL(path)];
+}

--- a/deps/cmt/src/capture/capture_manager.m
+++ b/deps/cmt/src/capture/capture_manager.m
@@ -1,0 +1,51 @@
+#include "cmt/capture/capture_manager.h"
+#include "impl/common.h"
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+MtCaptureManager*
+mtSharedCaptureManager(void){
+    return [MTLCaptureManager sharedCaptureManager];
+}
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+bool
+mtSupportsDestination(MtCaptureManager *manager, MtCaptureDestination destination){
+    return (bool)[(MTLCaptureManager*)manager supportsDestination:(MTLCaptureDestination)destination];
+}
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+bool
+mtStartCaptureWithDescriptor(MtCaptureManager *manager, MtCaptureDescriptor *descriptor, NsError **error){
+    return (bool)[(MTLCaptureManager*)manager startCaptureWithDescriptor:descriptor error:(NSError **)error];
+}
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+void
+mtStopCapture(MtCaptureManager *manager){
+    [(MTLCaptureManager*)manager stopCapture];
+}
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+bool
+mtIsCapturing(MtCaptureManager *manager){
+    return (bool)[(MTLCaptureManager*)manager isCapturing];
+}
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+MtCaptureScope*
+mtDefaultCaptureScope(MtCaptureManager *manager){
+    return [(MTLCaptureManager*) manager defaultCaptureScope];
+}
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+void
+mtDefaultCaptureScopeSet(MtCaptureManager *manager, MtCaptureScope *scope){
+    [(MTLCaptureManager*) manager setDefaultCaptureScope: scope];
+}

--- a/deps/cmt/src/capture/capture_scope.m
+++ b/deps/cmt/src/capture/capture_scope.m
@@ -1,0 +1,52 @@
+#include "impl/common.h"
+#include "cmt/command_queue.h"
+#include "cmt/capture/capture_scope.h"
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+MtCaptureScope*
+mtNewCaptureScopeWithCommandQueue(MtCaptureManager *manager, MtCommandQueue *queue){
+    return (MtCaptureScope*)[(MTLCaptureManager*)manager newCaptureScopeWithCommandQueue: queue];
+}
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+void
+mtBeginScope(MtCaptureScope *scope){
+[(id<MTLCaptureScope>)scope beginScope];
+}
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+void
+mtEndScope(MtCaptureScope *scope){
+    [(id<MTLCaptureScope>)scope endScope];
+}
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+const char*
+mtCaptureScopeLabel(MtCaptureScope *scope) {
+    return Cstring([(id<MTLCaptureScope>)scope label]);
+}
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+void
+mtCaptureScopeLabelSet(MtCaptureScope *scope, const char* label) {
+    [(id<MTLCaptureScope>)scope setLabel: mtNSString(label)];
+}
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+MtDevice*
+mtCaptureScopeDevice(MtCaptureScope *scope) {
+    return [(id<MTLCaptureScope>)scope device];
+}
+
+MT_EXPORT
+MT_API_AVAILABLE(mt_macos(10.13), mt_ios(11.0))
+MtCommandQueue*
+mtCaptureScopeCommandQueue(MtCaptureScope *scope) {
+    return [(id<MTLCaptureScope>)scope commandQueue];
+}

--- a/lib/core/MTL.jl
+++ b/lib/core/MTL.jl
@@ -53,5 +53,6 @@ include("compute_pipeline/reflection.jl")
 include("command_enc.jl")
 include("command_enc/blit.jl")
 include("command_enc/compute.jl")
+include("profile.jl")
 
 end # module

--- a/lib/core/libcmt.jl
+++ b/lib/core/libcmt.jl
@@ -445,6 +445,24 @@ end
     MtArgumentTypeSampler = 3
 end
 
+@cenum MtCaptureError::UInt32 begin
+    MtCaptureErrorNotSupported = 1
+    MtCaptureErrorAlreadyCapturing = 2
+    MtCaptureErrorInvalidDescriptor = 3
+end
+
+@cenum MtCaptureDestination::UInt32 begin
+    MtCaptureDestinationDeveloperTools = 1
+    MtCaptureDestinationGPUTraceDocument = 2
+end
+
+@cenum MtCaptureDescriptorCaptureObjectType::UInt32 begin
+    MtCaptureDescriptorCaptureObjectTypeNull = 0
+    MtCaptureDescriptorCaptureObjectTypeDevice = 1
+    MtCaptureDescriptorCaptureObjectTypeQueue = 2
+    MtCaptureDescriptorCaptureObjectTypeScope = 3
+end
+
 struct MtSize
     width::NsUInteger
     height::NsUInteger
@@ -666,7 +684,18 @@ struct MtComputePipelineReflection
 end
 
 struct MtRenderPipelineReflection
-    #= /Users/maxhawkins/workspace_julia/src/Metal.jl/res/wrap.jl:42 =#
+end
+
+struct MtCaptureManager
+    #= /Users/maxhawkins/workspace_julia/Metal.jl/res/wrap.jl:39 =#
+end
+
+struct MtCaptureScope
+    #= /Users/maxhawkins/workspace_julia/Metal.jl/res/wrap.jl:39 =#
+end
+
+struct MtCaptureDescriptor
+    #= /Users/maxhawkins/workspace_julia/Metal.jl/res/wrap.jl:39 =#
 end
 
 struct MtDispatchThreadgroupsIndirectArguments
@@ -2168,6 +2197,98 @@ end
 
 function mtArgumentEncoderAlignment(cce)
     ccall((:mtArgumentEncoderAlignment, libcmt), NsUInteger, (Ptr{MtArgumentEncoder},), cce)
+end
+
+function mtNewCaptureDescriptor()
+    ccall((:mtNewCaptureDescriptor, libcmt), Ptr{MtCaptureDescriptor}, ())
+end
+
+function mtCaptureDescriptorCaptureObject(desc)
+    ccall((:mtCaptureDescriptorCaptureObject, libcmt), Ptr{Cvoid}, (Ptr{MtCaptureDescriptor},), desc)
+end
+
+function mtCaptureDescriptorCaptureObjectSetQueue(desc, cmdq)
+    ccall((:mtCaptureDescriptorCaptureObjectSetQueue, libcmt), Cvoid, (Ptr{MtCaptureDescriptor}, Ptr{MtCommandQueue}), desc, cmdq)
+end
+
+function mtCaptureDescriptorCaptureObjectSetDevice(desc, dev)
+    ccall((:mtCaptureDescriptorCaptureObjectSetDevice, libcmt), Cvoid, (Ptr{MtCaptureDescriptor}, Ptr{MtDevice}), desc, dev)
+end
+
+function mtCaptureDescriptorCaptureObjectSetScope(desc, scope)
+    ccall((:mtCaptureDescriptorCaptureObjectSetScope, libcmt), Cvoid, (Ptr{MtCaptureDescriptor}, Ptr{MtCaptureScope}), desc, scope)
+end
+
+function mtCaptureDescriptorDestination(desc)
+    ccall((:mtCaptureDescriptorDestination, libcmt), MtCaptureDestination, (Ptr{MtCaptureDescriptor},), desc)
+end
+
+function mtCaptureDescriptorDestinationSet(desc, dest)
+    ccall((:mtCaptureDescriptorDestinationSet, libcmt), Cvoid, (Ptr{MtCaptureDescriptor}, MtCaptureDestination), desc, dest)
+end
+
+function mtCaptureDescriptorOutputURLSet(desc, path)
+    ccall((:mtCaptureDescriptorOutputURLSet, libcmt), Cvoid, (Ptr{MtCaptureDescriptor}, Cstring), desc, path)
+end
+
+function mtCaptureDescriptorOutputURL(desc)
+    ccall((:mtCaptureDescriptorOutputURL, libcmt), Cstring, (Ptr{MtCaptureDescriptor},), desc)
+end
+
+function mtSharedCaptureManager()
+    ccall((:mtSharedCaptureManager, libcmt), Ptr{MtCaptureManager}, ())
+end
+
+function mtSupportsDestination(manager, destination)
+    ccall((:mtSupportsDestination, libcmt), Bool, (Ptr{MtCaptureManager}, MtCaptureDestination), manager, destination)
+end
+
+function mtStartCaptureWithDescriptor(manager, descriptor, error)
+    ccall((:mtStartCaptureWithDescriptor, libcmt), Bool, (Ptr{MtCaptureManager}, Ptr{MtCaptureDescriptor}, Ptr{Ptr{NsError}}), manager, descriptor, error)
+end
+
+function mtStopCapture(manager)
+    ccall((:mtStopCapture, libcmt), Cvoid, (Ptr{MtCaptureManager},), manager)
+end
+
+function mtIsCapturing(manager)
+    ccall((:mtIsCapturing, libcmt), Bool, (Ptr{MtCaptureManager},), manager)
+end
+
+function mtDefaultCaptureScope(manager)
+    ccall((:mtDefaultCaptureScope, libcmt), Ptr{MtCaptureScope}, (Ptr{MtCaptureManager},), manager)
+end
+
+function mtDefaultCaptureScopeSet(manager, scope)
+    ccall((:mtDefaultCaptureScopeSet, libcmt), Cvoid, (Ptr{MtCaptureManager}, Ptr{MtCaptureScope}), manager, scope)
+end
+
+function mtNewCaptureScopeWithCommandQueue(manager, queue)
+    ccall((:mtNewCaptureScopeWithCommandQueue, libcmt), Ptr{MtCaptureScope}, (Ptr{MtCaptureManager}, Ptr{MtCommandQueue}), manager, queue)
+end
+
+function mtBeginScope(scope)
+    ccall((:mtBeginScope, libcmt), Cvoid, (Ptr{MtCaptureScope},), scope)
+end
+
+function mtEndScope(scope)
+    ccall((:mtEndScope, libcmt), Cvoid, (Ptr{MtCaptureScope},), scope)
+end
+
+function mtCaptureScopeLabel(scope)
+    ccall((:mtCaptureScopeLabel, libcmt), Cstring, (Ptr{MtCaptureScope},), scope)
+end
+
+function mtCaptureScopeLabelSet(scope, label)
+    ccall((:mtCaptureScopeLabelSet, libcmt), Cvoid, (Ptr{MtCaptureScope}, Cstring), scope, label)
+end
+
+function mtCaptureScopeDevice(scope)
+    ccall((:mtCaptureScopeDevice, libcmt), Ptr{MtDevice}, (Ptr{MtCaptureScope},), scope)
+end
+
+function mtCaptureScopeCommandQueue(scope)
+    ccall((:mtCaptureScopeCommandQueue, libcmt), Ptr{MtCommandQueue}, (Ptr{MtCaptureScope},), scope)
 end
 
 function mtRetain(obj)

--- a/lib/core/profile.jl
+++ b/lib/core/profile.jl
@@ -1,0 +1,320 @@
+export MtlCaptureDescriptor, MtlCaptureManager, MtlCaptureScope, startCapture, stopCapture,
+       beginScope, endScope
+
+### Capture Scope
+const MTLCaptureScope = Ptr{MtCaptureScope}
+
+"""
+    MtlCaptureScope(handle::MTLCaptureScope)
+An object that defines custom boundaries for a GPU frame capture.
+
+Use [`beginScope()`](@ref) and [`endScope()`](@ref) to set the boundaries for a capture scope.
+"""
+mutable struct MtlCaptureScope
+    handle::MTLCaptureScope
+
+    function MtlCaptureScope(handle::MTLCaptureScope)
+        obj = new(handle)
+        # No finalizer because handled by Metal
+        return obj
+    end
+end
+
+Base.unsafe_convert(::Type{MTLCaptureScope}, scope::MtlCaptureScope) = scope.handle
+
+Base.:(==)(a::MtlCaptureScope, b::MtlCaptureScope) = a.handle == b.handle
+Base.hash(scope::MtlCaptureScope, h::UInt) = hash(scope.handle, h)
+
+"""
+    beginScope(scope::MtlCaptureScope)
+Begin recording GPU command information.
+"""
+function beginScope(scope::MtlCaptureScope)
+    mtBeginScope(scope)
+end
+
+"""
+    endScope(scope::MtlCaptureScope)
+Stop recording GPU command information.
+"""
+function endScope(scope::MtlCaptureScope)
+    mtEndScope(scope)
+end
+
+## properties
+
+Base.propertynames(::MtlCaptureScope) = (
+    :device, :commandQueue, :label,
+)
+
+function Base.getproperty(o::MtlCaptureScope, f::Symbol)
+    if f === :device
+        MtlDevice(mtCaptureScopeDevice(o))
+    elseif f === :commandQueue
+        MtlCommandQueue(mtCaptureScopeCommandQueue(o), o.device)
+    elseif f === :label
+        ptr = mtCaptureScopeLabel(o)
+        ptr == C_NULL ? nothing : unsafe_string(ptr)
+    else
+        getfield(o, f)
+    end
+end
+
+function Base.setproperty!(o::MtlCaptureScope, f::Symbol, val)
+    if f === :label
+		mtCaptureScopeLabelSet(o, val)
+    else
+        setfield!(o, f, val)
+    end
+end
+
+## display
+
+function show(io::IO, ::MIME"text/plain", scope::MtlCaptureScope)
+    println(io, "MtlCaptureScope:")
+    println(io, " label:  ", scope.label)
+    print(io,   " device: ", scope.device)
+    print(io,   " command queue: ", scope.commandQueue)
+end
+
+### Capture Descriptor
+
+const MTLCaptureDescriptor = Ptr{MtCaptureDescriptor}
+
+"""
+    MtlCaptureDescriptor()
+    MtlCaptureDescriptor(obj::Union{MtlDevice,MtlCommandQueue},
+                         destination::MtCaptureDestination;
+                         folder::String=nothing)
+Create a GPU frame capture descriptor to alter the parameters of a profiling session.
+"""
+mutable struct MtlCaptureDescriptor
+    handle::MTLCaptureDescriptor
+    cap_obj_type::MtCaptureDescriptorCaptureObjectType
+
+    function MtlCaptureDescriptor()
+        handle = mtNewCaptureDescriptor()
+        obj = new(handle, MtCaptureDescriptorCaptureObjectTypeNull)
+        finalizer(unsafe_destroy!, obj)
+        return obj
+    end
+
+    # TODO: Add capture state
+    function MtlCaptureDescriptor(obj::Union{MtlDevice,MtlCommandQueue, MtlCaptureScope},
+                                  destination::MtCaptureDestination;
+                                  folder::String=nothing)
+        desc = MtlCaptureDescriptor()
+        desc.destination = destination
+        desc.captureObject = obj
+        if folder != nothing
+            desc.outputFolder = folder
+        end
+        return desc
+    end
+end
+
+Base.unsafe_convert(::Type{MTLCaptureDescriptor}, desc::MtlCaptureDescriptor) = desc.handle
+
+Base.:(==)(a::MtlCaptureDescriptor, b::MtlCaptureDescriptor) = a.handle == b.handle
+Base.hash(desc::MtlCaptureDescriptor, h::UInt) = hash(desc.handle, h)
+
+function unsafe_destroy!(desc::MtlCaptureDescriptor)
+    mtRelease(desc.handle)
+end
+
+## properties
+
+# Mapping between capture object types and Julia types
+const obj_enum_to_jl_typ = Dict(MtCaptureDescriptorCaptureObjectTypeDevice => MTLDevice,
+                                MtCaptureDescriptorCaptureObjectTypeQueue  => MTLCommandQueue,
+                                MtCaptureDescriptorCaptureObjectTypeScope  => MTLCaptureScope)
+
+Base.propertynames(::MtlCaptureDescriptor) = (:captureObject, :destination, :outputFolder)
+
+function Base.getproperty(desc::MtlCaptureDescriptor, f::Symbol)
+    if f === :captureObject
+        ptr = mtCaptureDescriptorCaptureObject(desc)
+        ptr == C_NULL ? nothing : obj_enum_to_jl_typ[desc.cap_obj_type](ptr)
+    elseif f === :destination
+        mtCaptureDescriptorDestination(desc)
+    elseif f === :outputFolder
+        # TODO: Redo this if users want full NSURL capabilities
+        ptr = mtCaptureDescriptorOutputURL(desc)
+        ptr == C_NULL ? nothing : unsafe_string(ptr)
+    else
+        getfield(desc, f)
+    end
+end
+
+function Base.setproperty!(desc::MtlCaptureDescriptor, f::Symbol, val)
+    if f === :captureObject
+        if isa(val, MtlCommandQueue)
+            mtCaptureDescriptorCaptureObjectSetQueue(desc.handle, val.handle)
+            desc.cap_obj_type = MtCaptureDescriptorCaptureObjectTypeQueue
+        elseif isa(val, MtlDevice)
+            mtCaptureDescriptorCaptureObjectSetDevice(desc.handle, val.handle)
+            desc.cap_obj_type = MtCaptureDescriptorCaptureObjectTypeDevice
+        elseif isa(val, MtlCaptureScope)
+            mtCaptureDescriptorCaptureObjectSetScope(desc.handle, val.handle)
+            desc.cap_obj_type = MtCaptureDescriptorCaptureObjectTypeScope
+        else
+            throw(ArgumentError("captureObject property should be a MtlCommandQueue, MtlDevice, or MtlCaptureScope."))
+        end
+    elseif f === :destination
+        isa(val, MtCaptureDestination) ||
+            throw(ArgumentError("destination property must be a MtlCaptureDestination"))
+        mtCaptureDescriptorDestinationSet(desc.handle, val)
+    elseif f === :outputFolder
+        # TODO: Check that it doesn't already exist and allow for path or other compatible objects
+        isa(val, String) ||
+            throw(ArgumentError("outputFolder property must be a String"))
+        mtCaptureDescriptorOutputURLSet(desc.handle, val)
+    else
+        setfield!(desc, f, val)
+    end
+end
+
+## display
+
+function Base.show(io::IO, desc::MtlCaptureDescriptor)
+    print(io, "MtlCaptureDescriptor(...)")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", desc::MtlCaptureDescriptor)
+    println(io, "MtlCaptureDescriptor:")
+    println(io, " capture object:   ", desc.captureObject)
+    println(io, " destination:      ", desc.destination)
+    print(io,   " output folder:    ", desc.outputFolder)
+end
+
+### Capture Manager
+
+const MTLCaptureManager = Ptr{MtCaptureManager}
+
+"""
+    struct MtlCaptureManager
+Metal-managed object that handles GPU frame capture support and usage.
+Note: There is only one (shared) capture manager per process.
+"""
+struct MtlCaptureManager
+    handle::MTLCaptureManager
+
+    """
+        MtlCaptureManager()
+    Return the unique shared GPU frame capture manager for this process.
+    """
+    function MtlCaptureManager()
+        # Inexpensive dummy metal command to trigger GPU framce capture enable on Metal's end
+        # Without this, two separate capture managers are potentially handled
+        # One with capture enabled and one without
+        MtlDevice(1)
+        handle = mtSharedCaptureManager()
+        obj = new(handle)
+        # No finalizer needed since the manager is handled by Metal
+        return obj
+    end
+end
+
+Base.unsafe_convert(::Type{MTLCaptureManager}, capman::MtlCaptureManager) = capman.handle
+
+Base.:(==)(a::MtlCaptureManager, b::MtlCaptureManager) = a.handle == b.handle
+Base.hash(capman::MtlCaptureManager, h::UInt) = hash(capman.handle, h)
+
+
+"""
+    startCapture(obj::Union{MtlDevice,MtlCommandQueue},
+                 destination::MtCaptureDestination=MtCaptureDestinationGPUTraceDocument;
+                 folder::String=nothing)
+Start GPU frame capture using the default capture object and specifying capture descriptor parameters directly.
+"""
+function startCapture(obj::Union{MtlDevice,MtlCommandQueue, MtlCaptureScope},
+                      destination::MtCaptureDestination=MtCaptureDestinationGPUTraceDocument;
+                      folder::String=nothing)
+    destination == MtCaptureDestinationGPUTraceDocument && folder == nothing &&
+        throw(ArgumentError("Must specify output folder if destination is GPUTraceDocument"))
+    startCapture(MtlCaptureManager(), MtlCaptureDescriptor(obj, destination; folder=folder))
+end
+
+"""
+    startCapture(manager::MtlCaptureManager, desc::MtlCaptureDescriptor)
+Start a GPU frame capture session with the given capture manager and descriptor.
+"""
+function startCapture(manager::MtlCaptureManager, desc::MtlCaptureDescriptor)
+    # Check not already capturing
+    manager.isCapturing && throw(error("Capture manager is already capturing."))
+    # Warn users if environment variable isn't set (required in most cases)
+    haskey(ENV, "METAL_CAPTURE_ENABLED") ||
+        @warn """Environment variable 'METAL_CAPTURE_ENABLED' is not set. In most cases, this
+        will need to be set to 1 before launching Julia to enable GPU frame capture."""
+    # Error if explicitly disallowed
+    haskey(ENV, "METAL_CAPTURE_ENABLED") && ENV["METAL_CAPTURE_ENABLED"] == 0 &&
+        throw(error("Metal GPU frame capture explicitly disallowed via environment vairable."))
+
+    # Validate outputFolder
+    if desc.destination == MtCaptureDestinationGPUTraceDocument
+        dir = desc.outputFolder
+        # Append required suffix if not already there
+        if !(endswith(dir, ".gputrace"))
+            desc.outputFolder = dir * ".gputrace"
+        end
+        isdir(dir) &&
+            throw(ArgumentError("`dir` keyword argument to @profile should not be an existing directory"))
+    end
+
+    _errptr = Ref{MTLError}()
+    success = mtStartCaptureWithDescriptor(manager.handle, desc.handle, _errptr)
+    success || throw(MtlError(_errptr[]))
+    return
+end
+
+"""
+    stopCapture(manager::MtlCaptureManager=MtlCaptureManager())
+Stop GPU frame capture.
+"""
+function stopCapture(manager::MtlCaptureManager=MtlCaptureManager())
+    mtStopCapture(manager)
+end
+
+## properties
+
+Base.propertynames(::MtlCaptureManager) = (:supportsTraceXcode,
+                                           :supportsTraceFile,
+                                           :isCapturing,
+                                           :defaultCaptureScope)
+
+function Base.getproperty(manager::MtlCaptureManager, f::Symbol)
+    if f === :supportsTraceXcode
+        mtSupportsDestination(manager, MTL.MtCaptureDestinationDeveloperTools)
+    elseif f === :supportsTraceFile
+        mtSupportsDestination(manager, MTL.MtCaptureDestinationGPUTraceDocument)
+    elseif f === :isCapturing
+        mtIsCapturing(manager)
+    elseif f === :defaultCaptureScope
+        ptr = mtDefaultCaptureScope(manager)
+        ptr == C_NULL ? nothing : MtlCaptureScope(ptr)
+    else
+        getfield(manager, f)
+    end
+end
+
+function Base.setproperty!(o::MtlCaptureManager, f::Symbol, val)
+    if f === :defaultCaptureScope
+        mtDefaultCaptureScopeSet(o, val)
+    else
+        setfield!(o, f, val)
+    end
+end
+
+## display
+
+function Base.show(io::IO, capman::MtlCaptureManager)
+    print(io, "MtlCaptureManager(...)")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", capman::MtlCaptureManager)
+    println(io, "MtlCaptureManager:")
+    println(io, " is capturing:         ", capman.isCapturing)
+    println(io, " default capture scope:         ", capman.defaultCaptureScope)
+    println(io, " supports Xcode trace: ", capman.supportsTraceXcode)
+    print(io,   " supports file trace:  ", capman.supportsTraceFile)
+end

--- a/test/profiling.jl
+++ b/test/profiling.jl
@@ -1,0 +1,74 @@
+@testset "profiling" begin
+
+# Verify Metal capture is enabled via environment variable
+@test haskey(ENV, "METAL_CAPTURE_ENABLED")
+
+function tester(A)
+    idx = thread_position_in_grid_1d()
+    A[idx] = Int(5)
+    return nothing
+end
+
+# Capture Manager
+manager = MtlCaptureManager()
+@test manager.supportsTraceXcode isa Bool
+@test manager.supportsTraceFile  isa Bool
+@test manager.isCapturing isa Bool
+
+# Capture Descriptor
+desc = MtlCaptureDescriptor()
+# Capture Object
+@test desc.captureObject == nothing
+cmdq = global_queue(current_device())
+desc.captureObject = cmdq
+@test desc.captureObject == cmdq.handle
+dev = current_device()
+desc.captureObject = dev
+@test desc.captureObject == dev.handle
+
+# Capture Destination
+@test desc.destination == MTL.MtCaptureDestinationDeveloperTools
+desc.destination = MTL.MtCaptureDestinationGPUTraceDocument
+@test desc.destination == MTL.MtCaptureDestinationGPUTraceDocument
+
+# Output URL
+@test desc.outputFolder == nothing
+path = tempname()*"/jl_metal.gputrace"
+desc.outputFolder = path
+@test desc.outputFolder == path
+
+
+# Capture Scope
+queue = MtlCommandQueue(current_device())
+default_scope = manager.defaultCaptureScope
+@test default_scope == nothing
+new_scope = MtlCaptureScope(Metal.MTL.mtNewCaptureScopeWithCommandQueue(manager, queue))
+@test new_scope.commandQueue == queue
+@test new_scope.device == current_device()
+@test new_scope.label == nothing
+new_label = "Metal.jl profiling test"
+new_scope.label = new_label
+@test new_scope.label == new_label
+
+# Assign new scope
+manager.defaultCaptureScope = new_scope
+@test manager.defaultCaptureScope == new_scope
+
+
+# Capturing
+bufferA = MtlArray{Float32,1}(undef, tuple(4), storage=Shared)
+
+@test manager.isCapturing == false
+startCapture(manager, desc)
+@test manager.isCapturing
+@test_throws ErrorException startCapture(manager, desc)
+@metal threads=4 tester(bufferA)
+stopCapture(manager)
+@test manager.isCapturing == false
+
+# Profile Macro
+Metal.@profile @metal threads=4 tester(bufferA)
+Metal.@profile capture=current_device() @metal threads=4 tester(bufferA)
+@test_throws ArgumentError Metal.@profile dir=path @metal threads=4 tester(bufferA)
+
+end

--- a/test/profiling.jl
+++ b/test/profiling.jl
@@ -2,6 +2,7 @@
 
 # Verify Metal capture is enabled via environment variable
 @test haskey(ENV, "METAL_CAPTURE_ENABLED")
+@test ENV["METAL_CAPTURE_ENABLED"]=="1"
 
 function tester(A)
     idx = thread_position_in_grid_1d()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -275,9 +275,10 @@ try
                         end
                     end
 
-                    # make sure the `profiling` test environment variables doesn't leak
+                    # make sure the `profiling` test environment variable doesn't leak
                     if test == "profiling"
                         recycle_worker(p)
+                        p = addworker(1; env=["METAL_CAPTURE_ENABLED"=>0])[1]
                     end
                 end
 


### PR DESCRIPTION
This would add profiling for later viewing by Xcode. However, I've run into some odd errors when trying to view with Xcode. Sometimes trying to replay the GPU trace will result in "Failed to enable shader profiler. (516)" while other times it works flawlessly. I haven't been able to determine what causes this. Additionally, if I try to replay more than one GPU trace at a time, all but the first GPU trace report that no performance data was found.

My testing has been on an M1 Macbook Air with the 7-core GPU running MacOS 13.0 and Julia 1.8.2.