### PR TITLE
Specialize GPUArrays.global_index() to improve broadcast performance

### DIFF
--- a/src/gpuarrays.jl
+++ b/src/gpuarrays.jl
@@ -29,10 +29,11 @@ end
 ## on-device
 
 # indexing
-GPUArrays.blockidx(ctx::mtlKernelContext)  = Metal.threadgroup_position_in_grid_1d()
-GPUArrays.blockdim(ctx::mtlKernelContext)  = Metal.threads_per_threadgroup_1d()
-GPUArrays.threadidx(ctx::mtlKernelContext) = Metal.thread_position_in_threadgroup_1d()
-GPUArrays.griddim(ctx::mtlKernelContext)   = Metal.threadgroups_per_grid_1d()
+GPUArrays.blockidx(ctx::mtlKernelContext)     = Metal.threadgroup_position_in_grid_1d()
+GPUArrays.blockdim(ctx::mtlKernelContext)     = Metal.threads_per_threadgroup_1d()
+GPUArrays.threadidx(ctx::mtlKernelContext)    = Metal.thread_position_in_threadgroup_1d()
+GPUArrays.griddim(ctx::mtlKernelContext)      = Metal.threadgroups_per_grid_1d()
+GPUArrays.global_index(ctx::mtlKernelContext) = Metal.thread_position_in_grid_1d()
 
 # math
 


### PR DESCRIPTION
This reduces the overhead incurred by the broadcast kernel over a handwritten kernel (at sufficiently large array sizes) by ~45%.

These benchmarks are ran on a M1 Pro laptop.
First number is the speed of a handwritten addition kernel. Second number is the speed of `@. c = a + b`.

=== At https://github.com/JuliaGPU/Metal.jl/commit/6bb5bb08a44444efdee9c2b747f6aa6399d79e3c

```julia
julia> include("bench.jl"); bench(1024*1000); bench(1024*10000); bench(1024*100000);
[ Info: Precompiling Metal [dde4c033-4e86-420c-a63e-0dd931031962]
n = 1024000
  285.167 μs (160 allocations: 4.16 KiB)
  337.250 μs (202 allocations: 6.05 KiB)
n = 10240000
  632.333 μs (160 allocations: 4.16 KiB)
  842.916 μs (202 allocations: 6.05 KiB)
n = 102400000
  3.624 ms (160 allocations: 4.16 KiB)
  5.553 ms (202 allocations: 6.05 KiB)
```

=== With the patch

```julia
julia> include("bench.jl"); bench(1024*1000); bench(1024*10000); bench(1024*100000);
[ Info: Precompiling Metal [dde4c033-4e86-420c-a63e-0dd931031962]
n = 1024000
  276.875 μs (160 allocations: 4.16 KiB)
  333.916 μs (202 allocations: 6.05 KiB)
n = 10240000
  631.583 μs (160 allocations: 4.16 KiB)
  748.667 μs (202 allocations: 6.05 KiB)
n = 102400000
  3.611 ms (160 allocations: 4.16 KiB)
  4.633 ms (202 allocations: 6.05 KiB)
```

=== bench.jl contents

```julia
using Metal, BenchmarkTools

function setup(n)
  a = MtlArray(rand(Float16, n))
  b = MtlArray(rand(Float16, n))
  c = MtlArray(zeros(Float16, n))
  return (a, b, c)
end

function add(a, b, c)
  i = thread_position_in_grid_1d()
  c[i] = a[i] + b[i]
  return
end

function kernel_add(a, b, c, n)
  @Metal.sync begin
    @metal threads=1024 grid=Int(n/1024) add(a, b, c)
  end
end

function broadcast_add(a, b, c)
  @Metal.sync begin
    @. c = a + b
  end
end

function bench(n)
  a, b, c = setup(n)
  println("n = $n")
  @btime kernel_add($a, $b, $c, $n)
  @btime broadcast_add($a, $b, $c)
  return
end
```