### PR TITLE
Add queue parameter to unsafe_copyto

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -232,11 +232,12 @@ end
 Base.copyto!(dest::MtlArray{T}, src::MtlArray{T}) where {T} =
     copyto!(dest, 1, src, 1, length(src))
 
-function Base.unsafe_copyto!(dev::MtlDevice, dest::MtlArray{T}, doffs, src::Array{T}, soffs, n, queue=global_queue(dev)) where T
+function Base.unsafe_copyto!(dev::MtlDevice, dest::MtlArray{T}, doffs, src::Array{T}, soffs, n;
+                             queue::MtlCommandQueue=global_queue(dev)) where T
   # these copies are implemented using pure memcpy's, not API calls, so aren't ordered.
   synchronize()
 
-  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n, queue)
+  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n, queue=queue)
   if Base.isbitsunion(T)
     # copy selector bytes
     error("Not implemented")
@@ -244,11 +245,12 @@ function Base.unsafe_copyto!(dev::MtlDevice, dest::MtlArray{T}, doffs, src::Arra
   return dest
 end
 
-function Base.unsafe_copyto!(dev::MtlDevice, dest::Array{T}, doffs, src::MtlArray{T}, soffs, n, queue=global_queue(dev)) where T
+function Base.unsafe_copyto!(dev::MtlDevice, dest::Array{T}, doffs, src::MtlArray{T}, soffs, n;
+                             queue::MtlCommandQueue=global_queue(dev)) where T
   # these copies are implemented using pure memcpy's, not API calls, so aren't ordered.
   synchronize()
 
-  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n, queue)
+  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n, queue=queue)
   if Base.isbitsunion(T)
     # copy selector bytes
     error("Not implemented")
@@ -256,11 +258,12 @@ function Base.unsafe_copyto!(dev::MtlDevice, dest::Array{T}, doffs, src::MtlArra
   return dest
 end
 
-function Base.unsafe_copyto!(dev::MtlDevice, dest::MtlArray{T}, doffs, src::MtlArray{T}, soffs, n, queue=global_queue(dev)) where T
+function Base.unsafe_copyto!(dev::MtlDevice, dest::MtlArray{T}, doffs, src::MtlArray{T}, soffs, n;
+                             queue::MtlCommandQueue=global_queue(dev)) where T
   # these copies are implemented using pure memcpy's, not API calls, so aren't ordered.
   synchronize()
 
-  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n, queue)
+  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n, queue=queue)
   if Base.isbitsunion(T)
     # copy selector bytes
     error("Not implemented")

--- a/src/array.jl
+++ b/src/array.jl
@@ -232,12 +232,11 @@ end
 Base.copyto!(dest::MtlArray{T}, src::MtlArray{T}) where {T} =
     copyto!(dest, 1, src, 1, length(src))
 
-function Base.unsafe_copyto!(dev::MtlDevice, dest::MtlArray{T}, doffs, src::Array{T}, soffs, n;
-                             queue::MtlCommandQueue=global_queue(dev), async::Bool=false) where T
+function Base.unsafe_copyto!(dev::MtlDevice, dest::MtlArray{T}, doffs, src::Array{T}, soffs, n) where T
   # these copies are implemented using pure memcpy's, not API calls, so aren't ordered.
-  async || synchronize(queue)
+  synchronize()
 
-  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n, queue=queue, async=async)
+  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n)
   if Base.isbitsunion(T)
     # copy selector bytes
     error("Not implemented")
@@ -245,12 +244,11 @@ function Base.unsafe_copyto!(dev::MtlDevice, dest::MtlArray{T}, doffs, src::Arra
   return dest
 end
 
-function Base.unsafe_copyto!(dev::MtlDevice, dest::Array{T}, doffs, src::MtlArray{T}, soffs, n;
-                             queue::MtlCommandQueue=global_queue(dev), async::Bool=false) where T
+function Base.unsafe_copyto!(dev::MtlDevice, dest::Array{T}, doffs, src::MtlArray{T}, soffs, n) where T
   # these copies are implemented using pure memcpy's, not API calls, so aren't ordered.
-  async || synchronize(queue)
+  synchronize()
 
-  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n, queue=queue, async=async)
+  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n)
   if Base.isbitsunion(T)
     # copy selector bytes
     error("Not implemented")
@@ -258,12 +256,11 @@ function Base.unsafe_copyto!(dev::MtlDevice, dest::Array{T}, doffs, src::MtlArra
   return dest
 end
 
-function Base.unsafe_copyto!(dev::MtlDevice, dest::MtlArray{T}, doffs, src::MtlArray{T}, soffs, n;
-                             queue::MtlCommandQueue=global_queue(dev), async::Bool=false) where T
+function Base.unsafe_copyto!(dev::MtlDevice, dest::MtlArray{T}, doffs, src::MtlArray{T}, soffs, n) where T
   # these copies are implemented using pure memcpy's, not API calls, so aren't ordered.
-  async || synchronize(queue)
+  synchronize()
 
-  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n, queue=queue, async=async)
+  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n)
   if Base.isbitsunion(T)
     # copy selector bytes
     error("Not implemented")

--- a/src/array.jl
+++ b/src/array.jl
@@ -233,11 +233,11 @@ Base.copyto!(dest::MtlArray{T}, src::MtlArray{T}) where {T} =
     copyto!(dest, 1, src, 1, length(src))
 
 function Base.unsafe_copyto!(dev::MtlDevice, dest::MtlArray{T}, doffs, src::Array{T}, soffs, n;
-                             queue::MtlCommandQueue=global_queue(dev)) where T
+                             queue::MtlCommandQueue=global_queue(dev), async::Bool=false) where T
   # these copies are implemented using pure memcpy's, not API calls, so aren't ordered.
-  synchronize()
+  async || synchronize(queue)
 
-  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n, queue=queue)
+  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n, queue=queue, async=async)
   if Base.isbitsunion(T)
     # copy selector bytes
     error("Not implemented")
@@ -246,11 +246,11 @@ function Base.unsafe_copyto!(dev::MtlDevice, dest::MtlArray{T}, doffs, src::Arra
 end
 
 function Base.unsafe_copyto!(dev::MtlDevice, dest::Array{T}, doffs, src::MtlArray{T}, soffs, n;
-                             queue::MtlCommandQueue=global_queue(dev)) where T
+                             queue::MtlCommandQueue=global_queue(dev), async::Bool=false) where T
   # these copies are implemented using pure memcpy's, not API calls, so aren't ordered.
-  synchronize()
+  async || synchronize(queue)
 
-  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n, queue=queue)
+  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n, queue=queue, async=async)
   if Base.isbitsunion(T)
     # copy selector bytes
     error("Not implemented")
@@ -259,11 +259,11 @@ function Base.unsafe_copyto!(dev::MtlDevice, dest::Array{T}, doffs, src::MtlArra
 end
 
 function Base.unsafe_copyto!(dev::MtlDevice, dest::MtlArray{T}, doffs, src::MtlArray{T}, soffs, n;
-                             queue::MtlCommandQueue=global_queue(dev)) where T
+                             queue::MtlCommandQueue=global_queue(dev), async::Bool=false) where T
   # these copies are implemented using pure memcpy's, not API calls, so aren't ordered.
-  synchronize()
+  async || synchronize(queue)
 
-  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n, queue=queue)
+  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n, queue=queue, async=async)
   if Base.isbitsunion(T)
     # copy selector bytes
     error("Not implemented")

--- a/src/array.jl
+++ b/src/array.jl
@@ -232,11 +232,11 @@ end
 Base.copyto!(dest::MtlArray{T}, src::MtlArray{T}) where {T} =
     copyto!(dest, 1, src, 1, length(src))
 
-function Base.unsafe_copyto!(dev::MtlDevice, dest::MtlArray{T}, doffs, src::Array{T}, soffs, n) where T
+function Base.unsafe_copyto!(dev::MtlDevice, dest::MtlArray{T}, doffs, src::Array{T}, soffs, n, queue=global_queue(dev)) where T
   # these copies are implemented using pure memcpy's, not API calls, so aren't ordered.
   synchronize()
 
-  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n)
+  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n, queue)
   if Base.isbitsunion(T)
     # copy selector bytes
     error("Not implemented")
@@ -244,11 +244,11 @@ function Base.unsafe_copyto!(dev::MtlDevice, dest::MtlArray{T}, doffs, src::Arra
   return dest
 end
 
-function Base.unsafe_copyto!(dev::MtlDevice, dest::Array{T}, doffs, src::MtlArray{T}, soffs, n) where T
+function Base.unsafe_copyto!(dev::MtlDevice, dest::Array{T}, doffs, src::MtlArray{T}, soffs, n, queue=global_queue(dev)) where T
   # these copies are implemented using pure memcpy's, not API calls, so aren't ordered.
   synchronize()
 
-  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n)
+  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n, queue)
   if Base.isbitsunion(T)
     # copy selector bytes
     error("Not implemented")
@@ -256,11 +256,11 @@ function Base.unsafe_copyto!(dev::MtlDevice, dest::Array{T}, doffs, src::MtlArra
   return dest
 end
 
-function Base.unsafe_copyto!(dev::MtlDevice, dest::MtlArray{T}, doffs, src::MtlArray{T}, soffs, n) where T
+function Base.unsafe_copyto!(dev::MtlDevice, dest::MtlArray{T}, doffs, src::MtlArray{T}, soffs, n, queue=global_queue(dev)) where T
   # these copies are implemented using pure memcpy's, not API calls, so aren't ordered.
   synchronize()
 
-  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n)
+  GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n, queue)
   if Base.isbitsunion(T)
     # copy selector bytes
     error("Not implemented")

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -30,8 +30,8 @@ MTL.contents(ptr::MtlPointer{T}) where {T} = convert(Ptr{T}, contents(ptr.buffer
 ## operations
 
 # GPU -> GPU
-function Base.unsafe_copyto!(dev::MtlDevice, dst::MtlPointer{T}, src::MtlPointer{T}, N::Integer) where T
-    cmdbuf = MtlCommandBuffer(global_queue(dev))
+function Base.unsafe_copyto!(dev::MtlDevice, dst::MtlPointer{T}, src::MtlPointer{T}, N::Integer, queue=global_queue(dev)) where T
+    cmdbuf = MtlCommandBuffer(queue)
     MtlBlitCommandEncoder(cmdbuf) do enc
         MTL.append_copy!(enc, dst.buffer, dst.offset, src.buffer, src.offset, N * sizeof(T))
     end
@@ -40,11 +40,11 @@ function Base.unsafe_copyto!(dev::MtlDevice, dst::MtlPointer{T}, src::MtlPointer
 end
 
 # GPU -> CPU
-function Base.unsafe_copyto!(dev::MtlDevice, dst::Ptr{T}, src::MtlPointer{T}, N::Integer) where T
+function Base.unsafe_copyto!(dev::MtlDevice, dst::Ptr{T}, src::MtlPointer{T}, N::Integer, queue=global_queue(dev)) where T
     storage_type = src.buffer.storageMode
     if storage_type ==  MTL.MtStorageModePrivate
         tmp_buf = alloc(T, dev, N, storage=Shared)
-        unsafe_copyto!(dev, tmp_buf, 1, src.buffer, src.offset, N)
+        unsafe_copyto!(dev, tmp_buf, 1, src.buffer, src.offset, N, queue)
         unsafe_copyto!(dst, contents(tmp_buf), N)
         free(tmp_buf)
     elseif storage_type ==  MTL.MtStorageModeShared
@@ -56,12 +56,12 @@ function Base.unsafe_copyto!(dev::MtlDevice, dst::Ptr{T}, src::MtlPointer{T}, N:
 end
 
 # CPU -> GPU
-function Base.unsafe_copyto!(dev::MtlDevice, dst::MtlPointer{T}, src::Ptr{T}, N::Integer) where T
+function Base.unsafe_copyto!(dev::MtlDevice, dst::MtlPointer{T}, src::Ptr{T}, N::Integer, queue=global_queue(dev)) where T
     storage_type = dst.buffer.storageMode
     if storage_type == MTL.MtStorageModePrivate
         tmp_buf = alloc(T, dev, N, src, storage=Shared)
-        unsafe_copyto!(dev, tmp_buf, src, N)
-        unsafe_copyto!(dev, dst.buffer, dst.offset, tmp_buf, 1, N)
+        unsafe_copyto!(dev, tmp_buf, src, N, queue)
+        unsafe_copyto!(dev, dst.buffer, dst.offset, tmp_buf, 1, N, queue)
         free(tmp_buf)
     elseif storage_type == MTL.MtStorageModeShared
         unsafe_copyto!(contents(dst), src, N)

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -30,7 +30,8 @@ MTL.contents(ptr::MtlPointer{T}) where {T} = convert(Ptr{T}, contents(ptr.buffer
 ## operations
 
 # GPU -> GPU
-function Base.unsafe_copyto!(dev::MtlDevice, dst::MtlPointer{T}, src::MtlPointer{T}, N::Integer, queue=global_queue(dev)) where T
+function Base.unsafe_copyto!(dev::MtlDevice, dst::MtlPointer{T}, src::MtlPointer{T}, N::Integer; 
+                             queue::MtlCommandQueue=global_queue(dev)) where T
     cmdbuf = MtlCommandBuffer(queue)
     MtlBlitCommandEncoder(cmdbuf) do enc
         MTL.append_copy!(enc, dst.buffer, dst.offset, src.buffer, src.offset, N * sizeof(T))
@@ -40,11 +41,12 @@ function Base.unsafe_copyto!(dev::MtlDevice, dst::MtlPointer{T}, src::MtlPointer
 end
 
 # GPU -> CPU
-function Base.unsafe_copyto!(dev::MtlDevice, dst::Ptr{T}, src::MtlPointer{T}, N::Integer, queue=global_queue(dev)) where T
+function Base.unsafe_copyto!(dev::MtlDevice, dst::Ptr{T}, src::MtlPointer{T}, N::Integer;
+                             queue::MtlCommandQueue=global_queue(dev)) where T
     storage_type = src.buffer.storageMode
     if storage_type ==  MTL.MtStorageModePrivate
         tmp_buf = alloc(T, dev, N, storage=Shared)
-        unsafe_copyto!(dev, tmp_buf, 1, src.buffer, src.offset, N, queue)
+        unsafe_copyto!(dev, tmp_buf, 1, src.buffer, src.offset, N, queue=queue)
         unsafe_copyto!(dst, contents(tmp_buf), N)
         free(tmp_buf)
     elseif storage_type ==  MTL.MtStorageModeShared
@@ -56,12 +58,13 @@ function Base.unsafe_copyto!(dev::MtlDevice, dst::Ptr{T}, src::MtlPointer{T}, N:
 end
 
 # CPU -> GPU
-function Base.unsafe_copyto!(dev::MtlDevice, dst::MtlPointer{T}, src::Ptr{T}, N::Integer, queue=global_queue(dev)) where T
+function Base.unsafe_copyto!(dev::MtlDevice, dst::MtlPointer{T}, src::Ptr{T}, N::Integer;
+                             queue::MtlCommandQueue=global_queue(dev)) where T
     storage_type = dst.buffer.storageMode
     if storage_type == MTL.MtStorageModePrivate
         tmp_buf = alloc(T, dev, N, src, storage=Shared)
-        unsafe_copyto!(dev, tmp_buf, src, N, queue)
-        unsafe_copyto!(dev, dst.buffer, dst.offset, tmp_buf, 1, N, queue)
+        unsafe_copyto!(dev, tmp_buf, src, N, queue=queue)
+        unsafe_copyto!(dev, dst.buffer, dst.offset, tmp_buf, 1, N, queue=queue)
         free(tmp_buf)
     elseif storage_type == MTL.MtStorageModeShared
         unsafe_copyto!(contents(dst), src, N)

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -30,7 +30,7 @@ MTL.contents(ptr::MtlPointer{T}) where {T} = convert(Ptr{T}, contents(ptr.buffer
 ## operations
 
 # GPU -> GPU
-function Base.unsafe_copyto!(dev::MtlDevice, dst::MtlPointer{T}, src::MtlPointer{T}, N::Integer; 
+function Base.unsafe_copyto!(dev::MtlDevice, dst::MtlPointer{T}, src::MtlPointer{T}, N::Integer;
                              queue::MtlCommandQueue=global_queue(dev), async::Bool=false) where T
     cmdbuf = MtlCommandBuffer(queue)
     MtlBlitCommandEncoder(cmdbuf) do enc
@@ -46,7 +46,7 @@ function Base.unsafe_copyto!(dev::MtlDevice, dst::Ptr{T}, src::MtlPointer{T}, N:
     storage_type = src.buffer.storageMode
     if storage_type ==  MTL.MtStorageModePrivate
         tmp_buf = alloc(T, dev, N, storage=Shared)
-        unsafe_copyto!(dev, tmp_buf, 1, src.buffer, src.offset, N, queue=queue, async=async)
+        unsafe_copyto!(dev, tmp_buf, 1, src.buffer, src.offset, N; queue, async)
         unsafe_copyto!(dst, contents(tmp_buf), N)
         free(tmp_buf)
     elseif storage_type ==  MTL.MtStorageModeShared
@@ -63,8 +63,8 @@ function Base.unsafe_copyto!(dev::MtlDevice, dst::MtlPointer{T}, src::Ptr{T}, N:
     storage_type = dst.buffer.storageMode
     if storage_type == MTL.MtStorageModePrivate
         tmp_buf = alloc(T, dev, N, src, storage=Shared)
-        unsafe_copyto!(dev, tmp_buf, src, N, queue=queue, async=async)
-        unsafe_copyto!(dev, dst.buffer, dst.offset, tmp_buf, 1, N, queue=queue, async=async)
+        unsafe_copyto!(dev, tmp_buf, src, N; queue, async)
+        unsafe_copyto!(dev, dst.buffer, dst.offset, tmp_buf, 1, N; queue, async)
         free(tmp_buf)
     elseif storage_type == MTL.MtStorageModeShared
         unsafe_copyto!(contents(dst), src, N)

--- a/test/metal.jl
+++ b/test/metal.jl
@@ -357,8 +357,8 @@ end
     Metal.encode_wait!(buf2, event, signal_value)
     Metal.commit!(buf2)
 
-    unsafe_copyto!(dev, a, 1, B, 1, N, queue=queue1, async=true)
-    unsafe_copyto!(dev, A, 1, a, 1, N, queue=queue1, async=true)
+    unsafe_copyto!(dev, pointer(a), pointer(B), N, queue=queue1, async=true)
+    unsafe_copyto!(dev, pointer(A), pointer(a), N, queue=queue1, async=true)
 
     Metal.encode_signal!(buf1, event, signal_value)
     Metal.commit!(buf1)


### PR DESCRIPTION
Used to implement `async_copy!` in [KernelAbstractions.jl](https://github.com/tgymnich/KernelAbstractions.jl/blob/83951cdcfa3e63d9b3ef50fbb8f1b45baaa33896/lib/MetalKernels/src/MetalKernels.jl#L125).