### PR TITLE
Improve reduce performance by passing CartesianIndices and length statically

### DIFF
--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -204,7 +204,6 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::WrappedMtlArray{T},
     groups = reduce_groups*other_groups
 
     # perform the actual reduction
-    #@info "mapreducedim!" threads groups Rreduce Rother shuffle R′ A reduce_groups
     if reduce_groups == 1
         # we can cover the dimensions to reduce using a single group
         @metal threads=threads grid=groups partial_mapreduce_device(


### PR DESCRIPTION
Improve indexing performance by passing `CartesianIndices` statically, using a similar trick as https://github.com/JuliaGPU/GPUArrays.jl/pull/454. Still slow, but not as bad as before. Helps with https://github.com/JuliaGPU/Metal.jl/issues/46.

Before:

```julia
julia> a = fill(Float32(1.0), 4096 * 4096);
julia> da = MtlArray(a);
julia> b = fill(Float32(1.0), 4096, 4096);
julia> db = MtlArray(b);

julia> @btime sum(a)
  1.393 ms (1 allocation: 16 bytes)
1.6777216f7

julia> @btime sum(b)
  1.392 ms (1 allocation: 16 bytes)
1.6777216f7

julia> @btime sum(da)
  4.026 ms (868 allocations: 23.95 KiB)
1.6777216f7

julia> @btime sum(db)
  11.196 ms (873 allocations: 25.23 KiB)
1.6777216f7
```

After:

```julia
julia> @btime sum(da)
  1.811 ms (754 allocations: 20.80 KiB)
1.6777216f7

julia> @btime sum(db)
  2.181 ms (759 allocations: 21.33 KiB)
1.6777216f7
```

Passing `length(Rother)` as `Rlen` may look redundant, but the 2D case (`sum(db)`) runs 3x slower without it.

```julia
julia> @btime sum(db)
  6.648 ms (759 allocations: 21.33 KiB)
1.6777216f7
```

There were some test failures, but they also happen on `main` (complains about symbol not found) and seems unrelated to this PR -- https://gist.github.com/maxwindiff/fe0480dcfd1bcd4cb28e91f2c1a0cfa6