### PR TITLE
Fix memory leak.

### DIFF
--- a/lib/mtl/command_enc/blit.jl
+++ b/lib/mtl/command_enc/blit.jl
@@ -12,7 +12,7 @@ Base.unsafe_convert(::Type{MTLBlitCommandEncoder}, e::MtlBlitCommandEncoder) = e
 function MtlBlitCommandEncoder(cmdbuf::MtlCommandBuffer)
     handle = mtNewBlitCommandEncoder(cmdbuf)
     obj = MtlBlitCommandEncoder(handle, cmdbuf)
-    #finalizer(unsafe_destroy!, obj)
+    finalizer(unsafe_destroy!, obj)
     return obj
 end
 


### PR DESCRIPTION
This looks like a three year old typo that probably snuck in during a debugging session.  

I will one day create a way to run the tests so that they will report objective-C memory issues, but as far as I can tell for now, this fix is correct, or at least consistent with everything else.  