### PR TITLE
Switch default storage mode to Private

### DIFF
--- a/examples/unified_memory.jl
+++ b/examples/unified_memory.jl
@@ -26,7 +26,7 @@ end
 # be allocated, then wrapped by a CPU array...not the other way around.
 
 dims = tuple(16,16)
-# Create a Metal array with a default storage mode of shared (both CPU and GPU get access)
+# Create a Metal array with a storage mode of shared (both CPU and GPU get access)
 arr_mtl = MtlArray{Float32}(undef, dims)
 # Unsafe wrap the contents of the Metal array with a CPU array
 arr_cpu = unsafe_wrap(Array{Float32}, arr_mtl, dims)

--- a/src/array.jl
+++ b/src/array.jl
@@ -33,7 +33,7 @@ mutable struct MtlArray{T,N} <: AbstractGPUArray{T,N}
   offset::Int   # offset of the data in the buffer, in number of elements
   dims::Dims{N}
 
-  function MtlArray{T,N}(::UndefInitializer, dims::Dims{N}; storage=Shared) where {T,N}
+  function MtlArray{T,N}(::UndefInitializer, dims::Dims{N}; storage=Private) where {T,N}
       Base.allocatedinline(T) || error("MtlArray only supports element types that are stored inline")
       contains_double(T) && @warn "Metal does not support Float64 values, try using Float32 instead" maxlog=1
       maxsize = prod(dims) * sizeof(T)

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -45,9 +45,10 @@ function Base.unsafe_copyto!(dev::MtlDevice, dst::Ptr{T}, src::MtlPointer{T}, N:
                              queue::MtlCommandQueue=global_queue(dev), async::Bool=false) where T
     storage_type = src.buffer.storageMode
     if storage_type ==  MTL.MtStorageModePrivate
-        tmp_buf = alloc(T, dev, N, storage=Shared)
-        unsafe_copyto!(dev, tmp_buf, 1, src.buffer, src.offset, N; queue, async)
-        unsafe_copyto!(dst, contents(tmp_buf), N)
+        bytes = N*sizeof(T)
+        tmp_buf = alloc(dev, bytes; storage=MTL.Shared)
+        unsafe_copyto!(dev, tmp_buf, 1, src.buffer, src.offset, bytes; queue, async)
+        unsafe_copyto!(dst, contents(tmp_buf), bytes)
         free(tmp_buf)
     elseif storage_type ==  MTL.MtStorageModeShared
         unsafe_copyto!(dst, contents(src), N)


### PR DESCRIPTION
WIP -- Tried switching default storage mode to Private.  Did not update storage mode in unifiedmemory example to see if it would now fail.  It looks like doing so triggers some code that has become stale causing to the code to fail before it really should.  See comment below.  