### PR TITLE
Reduce multiple consecutive values in each thread to improve efficiency

### DIFF
--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -211,9 +211,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::WrappedMtlArray{T},
     #
     # also, make sure the grain size is not too high so as to starve threads of work.
     other_groups = length(Rother)
-    while grain > 1 && length(Rreduce) <= reduce_threads * prevpow(2, grain)
-        grain >>= 1
-    end
+    grain = min(grain, prevpow(2, cld(length(Rreduce), reduce_threads)))
     reduce_groups = cld(length(Rreduce), reduce_threads * grain)
 
     # determine the launch configuration

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -174,7 +174,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::WrappedMtlArray{T},
     # when the reduction dimension is contiguous in memory, we can improve performance
     # by having each thread read multiple consecutive elements. base on experiments,
     # 16 / sizeof(T) elements is usually a good choice.
-    reduce_dim_start = findfirst(axis -> length(axis) > 1, axes(Rreduce))
+    reduce_dim_start = something(findfirst(axis -> length(axis) > 1, axes(Rreduce)), 1)
     contiguous = prod(size(R)[1:reduce_dim_start-1]) == 1
     grain = contiguous ? prevpow(2, cld(16, sizeof(T))) : 1
 

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -91,11 +91,11 @@ Base.@propagate_inbounds _map_getindex(args::Tuple{}, I) = ()
 # product of the two iterators `Rreduce` and `Rother`, where the latter iterator will have
 # singleton entries for the dimensions that should be reduced (and vice versa).
 function partial_mapreduce_device(f, op, neutral, maxthreads, ::Val{Rreduce},
-    ::Val{Rother}, ::Val{Rlen}, ::Val{stride}, shuffle, R, As...) where {Rreduce, Rother, Rlen, stride}
+    ::Val{Rother}, ::Val{Rlen}, ::Val{grain}, shuffle, R, As...) where {Rreduce, Rother, Rlen, grain}
     # decompose the 1D hardware indices into separate ones for reduction (across items
     # and possibly groups if it doesn't fit) and other elements (remaining groups)
     localIdx_reduce = thread_position_in_threadgroup_1d()
-    localDim_reduce = threads_per_threadgroup_1d() * stride
+    localDim_reduce = threads_per_threadgroup_1d() * grain
     groupIdx_reduce, groupIdx_other = fldmod1(threadgroup_position_in_grid_1d(), Rlen)
 
     # group-based indexing into the values outside of the reduction dimension
@@ -115,8 +115,8 @@ function partial_mapreduce_device(f, op, neutral, maxthreads, ::Val{Rreduce},
         val = op(neutral, neutral)
 
         # read multiple consecutive values in reduction dimension to improve efficiency
-        ireduce = (localIdx_reduce - 1) * stride + (groupIdx_reduce - 1) * localDim_reduce
-        limit = ireduce + stride
+        ireduce = (localIdx_reduce - 1) * grain + (groupIdx_reduce - 1) * localDim_reduce
+        limit = ireduce + grain
         while ireduce < limit
             ireduce += 1
             next = if ireduce <= length(Rreduce)
@@ -171,9 +171,9 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::WrappedMtlArray{T},
     # but allows us to write a generalized kernel supporting partial reductions.
     R′ = reshape(R, (size(R)..., 1))
 
-    # number of consecutive values in reduction dimension read by each thread
-    # TODO: experiment and document this choice
-    stride = 16 ÷ sizeof(T)
+    # number of consecutive values in reduction dimension read by each thread.
+    # based on experiments, 4 is a good value for all scalar types.
+    grain = 4
 
     # how many threads can we launch?
     #
@@ -182,7 +182,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::WrappedMtlArray{T},
     # so that we can span the entire reduction dimension using a single item group.
     # XXX: can we query the 1024?
     kernel = @metal launch=false partial_mapreduce_device(f, op, init, Val(1024), Val(Rreduce), Val(Rother),
-                                                          Val(UInt64(length(Rother))), Val(stride), Val(shuffle), R′, A)
+                                                          Val(UInt64(length(Rother))), Val(grain), Val(shuffle), R′, A)
     pipeline = MTLComputePipelineState(kernel.fun.device, kernel.fun)
 
     # how many threads do we want?
@@ -206,7 +206,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::WrappedMtlArray{T},
     # optimal as it might not saturate the GPU. we already launch some groups to process
     # independent dimensions in parallel; pad that number to ensure full occupancy.
     other_groups = length(Rother)
-    reduce_groups = cld(length(Rreduce), reduce_threads * stride)
+    reduce_groups = cld(length(Rreduce), reduce_threads * grain)
 
     # determine the launch configuration
     threads = reduce_threads
@@ -217,7 +217,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::WrappedMtlArray{T},
         # we can cover the dimensions to reduce using a single group
         @metal threads=threads grid=groups partial_mapreduce_device(
             f, op, init, Val(threads), Val(Rreduce), Val(Rother),
-            Val(UInt64(length(Rother))), Val(stride), Val(shuffle), R′, A)
+            Val(UInt64(length(Rother))), Val(grain), Val(shuffle), R′, A)
     else
         # we need multiple steps to cover all values to reduce
         partial = similar(R, (size(R)..., reduce_groups))
@@ -232,7 +232,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::WrappedMtlArray{T},
         end
         @metal threads=threads grid=groups partial_mapreduce_device(
             f, op, init, Val(threads), Val(Rreduce), Val(Rother),
-            Val(UInt64(length(Rother))), Val(stride), Val(shuffle), partial, A)
+            Val(UInt64(length(Rother))), Val(grain), Val(shuffle), partial, A)
 
         GPUArrays.mapreducedim!(identity, op, R′, partial; init=init)
     end


### PR DESCRIPTION
Using ideas from:
* https://kieber-emmons.medium.com/optimizing-parallel-reduction-in-metal-for-apple-m1-8e8677b49b01
* https://developer.download.nvidia.com/assets/cuda/files/reduction.pdf

This replaces the old "reduce serially across chunks of input vector that don't fit in a group" loop, which doesn't seem to apply to Metal.jl since we always launch enough threadgroups to cover the entire input.
  
In a simple test this is 2-3x faster than HEAD and achieves > 130GB/s in the 1D reduction case. I'll need to experiment with the ~~stride~~ grain size parameter and document it, and test more complex cases like such as non-power-of-2 sizes or reducing only certain dimensions.

- [x] Experiment with grain size parameter and document it
- [x] Test performance of non-power-of-2 sizes
- [x] Test performance of reducing certain dimensions of N-D arrays
- [x] Check the behavior when number of threadgroups is too high
- [x] Write more tests as needed

Before:

```julia
function init(dims...)
  a = Array{Float32}(undef, dims...)
  for i in 1:length(a)
    a[i] = 1
  end
  return (a, MtlArray(a))
end

a, da = init(8192 * 8192);
b, db = init(8192, 8192);

julia> @btime sum(da)
  6.033 ms (754 allocations: 20.80 KiB)
6.7108864f7

julia> @btime sum(db)
  7.424 ms (759 allocations: 21.33 KiB)
6.7108864f7
```

After:

```julia
julia> @btime sum(da)
  2.030 ms (775 allocations: 21.20 KiB)
6.7108864f7

julia> @btime sum(db)
  3.009 ms (780 allocations: 21.72 KiB)
6.7108864f7
```

Helps with #46 