### PR TITLE
Rename grid to groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,12 +109,15 @@ julia> function vadd(a, b, c)
        end
 vadd (generic function with 1 method)
 
-julia> a = MtlArray([1]); b = MtlArray([2]); c = similar(a);
+julia> a = MtlArray([1,1,1,1]); b = MtlArray([2,2,2,2]); c = similar(a);
 
-julia> @metal threads=length(c) vadd(a, b, c)
+julia> @metal threads=2 groups=2 vadd(a, b, c)
 
 julia> Array(c)
-1-element Vector{Int64}:
+4-element Vector{Int64}:
+ 3
+ 3
+ 3
  3
 ```
 

--- a/examples/gtk.jl
+++ b/examples/gtk.jl
@@ -30,7 +30,9 @@ img = MtlArray{RGB{N0f8}}(undef, 800,600)
 host = unsafe_wrap(Array{RGB{N0f8}}, img, size(img))
 
 ## initial image
-Metal.@sync @metal threads=16,16 grid=size(img) generate(img, 0)
+threads = 16,16
+groups = cld.(size(img), threads)
+Metal.@sync @metal threads=16,16 groups=groups generate(img, 0)
 
 win = GtkWindow("Test", 800, 600);
 
@@ -41,7 +43,7 @@ view = GtkImage(pixbuf)
 push!(win,view)
  
 for i=1:400
-    Metal.@sync @metal threads=16,16 grid=size(img) generate(img, i*2)
+    Metal.@sync @metal threads=16,16 groups=groups generate(img, i*2)
     #forces redraw without copy
     Gtk4.G_.set_from_pixbuf(view, pixbuf)
     sleep(0.01)

--- a/examples/peakflops.jl
+++ b/examples/peakflops.jl
@@ -28,7 +28,7 @@ function peakflops(len=1024*1024*100)
     grid = cld(len, threads)
 
     bench = @benchmark Metal.@sync begin
-        @metal threads=$threads grid=$grid kernel_fma($a, $b, $c, $out)
+        @metal threads=$threads groups=$grid kernel_fma($a, $b, $c, $out)
     end
 
     # Cleanup memory

--- a/examples/unified_memory.jl
+++ b/examples/unified_memory.jl
@@ -38,7 +38,7 @@ arr_cpu .= pi
 Metal.@allowscalar @test arr_mtl[1] == Float32(pi)
 
 # Now launch a kernel altering the Metal array
-Metal.@sync @metal threads=1024 grid=1024 simple_kernel(arr_mtl)
+Metal.@sync @metal threads=1024 groups=1024 simple_kernel(arr_mtl)
 
 # These changes are reflected in the wrapped CPU array
 @test all(arr_cpu .== -1.0)
@@ -79,7 +79,7 @@ dummy_mtl = MtlArray{Float32}(undef, 1)
 
 rand!(arr_cpu)
 # Now launch a kernel altering the Metal array
-@metal threads=1024 grid=1024 long_kernel(arr_mtl, dummy_mtl)
+@metal threads=1024 groups=1024 long_kernel(arr_mtl, dummy_mtl)
 
 # we need to synchronize the device as the kernel may not have finished yet
 synchronize()

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -199,7 +199,7 @@ function (kernel::HostKernel)(args...; groups=1, threads=1, queue=global_queue(c
         throw(ArgumentError("All thread dimensions should be non-zero"))
 
     (threads.width * threads.height * threads.depth) > kernel.pipeline_state.maxTotalThreadsPerThreadgroup &&
-        throw(ArgumentError("Maximum number of threads in a group should not exceed $(kernel.pipeline_state.maxTotalThreadsPerThreadgroup)"))
+        throw(ArgumentError("Number of threads in group ($(threads.width * threads.height * threads.depth)) should not exceed $(kernel.pipeline_state.maxTotalThreadsPerThreadgroup)"))
 
     cmdbuf = MTLCommandBuffer(queue)
     cmdbuf.label = "MTLCommandBuffer($(nameof(kernel.f)))"

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -194,12 +194,12 @@ function (kernel::HostKernel)(args...; groups=1, threads=1, queue=global_queue(c
     groups = MTLSize(groups)
     threads = MTLSize(threads)
     (groups.width>0 && groups.height>0 && groups.depth>0) ||
-        throw(ArgumentError("Threadgroups dimensions should be non-null"))
+        throw(ArgumentError("All group dimensions should be non-zero"))
     (threads.width>0 && threads.height>0 && threads.depth>0) ||
-        throw(ArgumentError("Threads dimensions should be non-null"))
+        throw(ArgumentError("All thread dimensions should be non-zero"))
 
     (threads.width * threads.height * threads.depth) > kernel.pipeline_state.maxTotalThreadsPerThreadgroup &&
-        throw(ArgumentError("Max total thread size should not exceed $(kernel.pipeline_state.maxTotalThreadsPerThreadgroup)"))
+        throw(ArgumentError("Maximum number of threads in a group should not exceed $(kernel.pipeline_state.maxTotalThreadsPerThreadgroup)"))
 
     cmdbuf = MTLCommandBuffer(queue)
     cmdbuf.label = "MTLCommandBuffer($(nameof(kernel.f)))"

--- a/src/gpuarrays.jl
+++ b/src/gpuarrays.jl
@@ -22,7 +22,7 @@ end
 
 function GPUArrays.gpu_call(::mtlArrayBackend, f, args, threads::Int, blocks::Int;
                             name::Union{String,Nothing})
-    @metal threads=threads grid=blocks name=name f(mtlKernelContext(), args...)
+    @metal threads=threads groups=blocks name=name f(mtlKernelContext(), args...)
 end
 
 

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -221,7 +221,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::WrappedMtlArray{T},
     # perform the actual reduction
     if reduce_groups == 1
         # we can cover the dimensions to reduce using a single group
-        @metal threads=threads grid=groups partial_mapreduce_device(
+        @metal threads=threads groups=groups partial_mapreduce_device(
             f, op, init, Val(threads), Val(Rreduce), Val(Rother),
             Val(UInt64(length(Rother))), Val(grain), Val(shuffle), R′, A)
     else
@@ -232,7 +232,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::WrappedMtlArray{T},
             # use broadcasting to extend singleton dimensions
             partial .= R
         end
-        @metal threads=threads grid=groups partial_mapreduce_device(
+        @metal threads=threads groups=groups partial_mapreduce_device(
             f, op, init, Val(threads), Val(Rreduce), Val(Rother),
             Val(UInt64(length(Rother))), Val(grain), Val(shuffle), partial, A)
 

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -32,7 +32,7 @@ end
     @test all(vecA == Int.([5, 5, 0, 0, 0, 0, 0, 0]))
     vecA .= 0
 
-    @metal grid=(3) threads=(2) tester(bufferA)
+    @metal groups=(3) threads=(2) tester(bufferA)
     synchronize()
     @test all(vecA == Int.([5, 5, 5, 5, 5, 5, 0, 0]))
     vecA .= 0
@@ -45,7 +45,7 @@ end
     vecA .= 0
 
     @test_throws InexactError @metal threads=(-2) tester(bufferA)
-    @test_throws InexactError @metal grid=(-2) tester(bufferA)
+    @test_throws InexactError @metal groups=(-2) tester(bufferA)
     @test_throws ArgumentError @metal threads=(1025) tester(bufferA)
     @test_throws ArgumentError @metal threads=(1000,2) tester(bufferA)
 end


### PR DESCRIPTION
Prior to this PR,  Metal.jl was using the term `grid` in a way that is inconsistent with Apple's terminology.  

Things to consider adding to this PR
- [x] the Readme should have an example that uses the `groups` keyword?

