### PR TITLE
Test 1.9 CI on macOS 13.2

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,30 +21,31 @@ steps:
           queue: "juliaecosystem"
           os: "macos"
           arch: "aarch64"
+          macos_version: "13.2"
         if: build.message !~ /\[skip tests\]/
         timeout_in_minutes: 60
 
-      # FIXME: 1.9 CI fails on the juliaecosystem machines, but works locally...
-      # - label: "Julia 1.9"
-      #   plugins:
-      #     - JuliaCI/julia#v1:
-      #         version: 1.9-nightly
-      #    - JuliaCI/julia-test#v1:
-      #        test_args: "--quickfail"
-      #     - JuliaCI/julia-coverage#v1:
-      #         codecov: true
-      #         dirs:
-      #           - src
-      #           - lib
-      #           - examples
-      #   command: |
-      #     julia --project=deps deps/build_ci.jl
-      #   agents:
-      #     queue: "juliaecosystem"
-      #     os: "macos"
-      #     arch: "aarch64"
-      #   if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
-      #   timeout_in_minutes: 60
+      - label: "Julia 1.9"
+        plugins:
+          - JuliaCI/julia#v1:
+              version: 1.9-nightly
+         - JuliaCI/julia-test#v1:
+             test_args: "--quickfail"
+          - JuliaCI/julia-coverage#v1:
+              codecov: true
+              dirs:
+                - src
+                - lib
+                - examples
+        command: |
+          julia --project=deps deps/build_ci.jl
+        agents:
+          queue: "juliaecosystem"
+          os: "macos"
+          arch: "aarch64"
+          macos_version: "13.2"
+        if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
+        timeout_in_minutes: 60
 
       # - label: "Julia nightly"
       #   plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,8 +29,8 @@ steps:
         plugins:
           - JuliaCI/julia#v1:
               version: 1.9-nightly
-         - JuliaCI/julia-test#v1:
-             test_args: "--quickfail"
+          - JuliaCI/julia-test#v1:
+              test_args: "--quickfail"
           - JuliaCI/julia-coverage#v1:
               codecov: true
               dirs:


### PR DESCRIPTION
@staticfloat helpfully upgraded one of the `juliaecosystem` workers to macOS 13.2, so let's see if that improves our CI reliability.