### PR TITLE
Call the correct current_device() in reflection

### DIFF
--- a/src/compiler/reflection.jl
+++ b/src/compiler/reflection.jl
@@ -29,7 +29,7 @@ for method in (:code_typed, :code_warntype, :code_llvm, :code_native)
                          kernel::Bool=false, kwargs...)
             compiler_kwargs, kwargs = split_kwargs_runtime(kwargs, COMPILER_KWARGS)
             source = FunctionSpec(typeof(func), Base.to_tuple_type(types))
-            config = compiler_config(device(); kernel, compiler_kwargs...)
+            config = compiler_config(current_device(); kernel, compiler_kwargs...)
             job = CompilerJob(source, config)
             GPUCompiler.$method($(args...); kwargs...)
         end
@@ -66,7 +66,7 @@ Return a type `r` such that `f(args...)::r` where `args::tt`.
 """
 function return_type(@nospecialize(func), @nospecialize(tt))
     source = FunctionSpec(typeof(func), tt)
-    config = compiler_config(device())
+    config = compiler_config(current_device())
     job = CompilerJob(source, config)
     interp = GPUCompiler.get_interpreter(job)
     if VERSION >= v"1.8-"


### PR DESCRIPTION
Fixes the following error:

```julia
julia> Metal.code_llvm(stdout, () -> nothing, ())
ERROR: MethodError: no method matching device()
```