### PR TITLE
Remove reference to no longer used library in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,5 @@ that any environment depending on the corresponding JLLs will pick-up the modifi
 
 ## Acknowledgements
 
-The C library started by forking [recp/cmt](https://github.com/recp/cmt), to whom
-goes the original credit. This package builds upon the experience of several
+This package builds upon the experience of several
 Julia contributors to CUDA.jl, AMDGPU.jl and oneAPI.jl.


### PR DESCRIPTION
I don't know if removing it or mentioning that it is no longer used would be better, but it's a bit confusing in its current state to reference cmt since it is no longer used.

[Skip-tests]