### PR TITLE
Fix Darwin version indentification

### DIFF
--- a/lib/mtl/MTL.jl
+++ b/lib/mtl/MTL.jl
@@ -8,10 +8,13 @@ using ObjectiveC, .Foundation, .Dispatch
 
 export darwin_version, macos_version
 
+const _darwin_version = Ref{VersionNumber}()
 function darwin_version()
-    # extract the trailing `-darwinXXX` bit from the triple
-    machine = Sys.MACHINE
-    VersionNumber(machine[findfirst("darwin", machine)[end]+1:end])
+    if !isassigned(_darwin_version)
+        verstr = read(`uname -r`, String)
+        _darwin_version[] = parse(VersionNumber, verstr)
+    end
+    _darwin_version[]
 end
 
 const _macos_version = Ref{VersionNumber}()


### PR DESCRIPTION
Closes #179 

I went with `uname` instead of the suggestion in issue #179 for simplicity and the fact that either method would only ever get called once per load so speed isn't very important here. 

I'm not opposed to using the other function (and giving credit) if anyone feels strongly about it.

@tgymnich What do you think?