### PR TITLE
Disallow Float64 arrays entirely.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -95,9 +95,9 @@ version = "1.4.1"
 
 [[deps.KernelAbstractions]]
 deps = ["Adapt", "Atomix", "InteractiveUtils", "LinearAlgebra", "MacroTools", "PrecompileTools", "SparseArrays", "StaticArrays", "UUIDs", "UnsafeAtomics", "UnsafeAtomicsLLVM"]
-git-tree-sha1 = "47be64f040a7ece575c2b5f53ca6da7b548d69f4"
+git-tree-sha1 = "b48617c5d764908b5fac493cd907cf33cc11eec1"
 uuid = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
-version = "0.9.4"
+version = "0.9.6"
 
 [[deps.LLVM]]
 deps = ["CEnum", "LLVMExtra_jll", "Libdl", "Printf", "Unicode"]

--- a/src/array.jl
+++ b/src/array.jl
@@ -42,7 +42,7 @@ mutable struct MtlArray{T,N,S} <: AbstractGPUArray{T,N}
 
   function MtlArray{T,N,S}(::UndefInitializer, dims::Dims{N}) where {T,N,S}
       Base.allocatedinline(T) || error("MtlArray only supports element types that are stored inline")
-      contains_double(T) && @warn "Metal does not support Float64 values, try using Float32 instead" maxlog=1
+      contains_double(T) && error("Metal does not support Float64 values, try using Float32 instead")
       maxsize = prod(dims) * sizeof(T)
       bufsize = if Base.isbitsunion(T)
         # type tag array past the data

--- a/test/array.jl
+++ b/test/array.jl
@@ -12,10 +12,6 @@ let arr = MtlVector{Int}(undef, 0)
     @test sizeof(arr) == 0
 end
 
-@testset "mtl" begin
-    @test mtl(rand(2,2)) isa MtlArray{Float32}
-    @test adapt(MtlArray, rand(2,2)) isa MtlArray{Float64}
-end
 @testset "constructors" begin
     xs = MtlArray{Int}(undef, 2, 3)
     @test device(xs) == current_device()


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/Metal.jl/issues/205
Requires https://github.com/JuliaGPU/KernelAbstractions.jl/pull/402