### PR TITLE
Re-implementation of Tang (1990) log procedures in pure float32

### DIFF
--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -128,12 +128,12 @@ const t_log_Float32 = [0.0f0, 0.0077821403f0, 0.015504187f0, 0.023167059f0,
 @inline logb(::Val{:ℯ}) = 1f0
 @inline logb(::Val{10}) = 0.4342945f0
 
-@device_override function Base.Math.log_proc1(y::Float32,mf::Float32,F::Float32,f::Float32,base=Val(:ℯ))
+@device_override Base.@assume_effects :consistent @inline function Base.Math.log_proc1(y::Float32,mf::Float32,F::Float32,f::Float32,base=Val(:ℯ))
     jp = unsafe_trunc(Int,128.0f0*F)-127
 
     ## Steps 1 and 2
-    hi = t_log_Float32[jp]
-    l = mf*t_log_Float32[129] + hi
+    @inbounds hi = t_log_Float32[jp]
+    l = mf*0.6931472f0 + hi
 
     ## Step 3
     # @inbounds u = f*c_invF[jp]
@@ -152,7 +152,7 @@ end
 
 @inline truncbits(x::Float32) = reinterpret(Float32, reinterpret(UInt32, x) & 0xfff0_0000)
 
-@device_override function Base.Math.log_proc2(f::Float32,base=Val(:ℯ))
+@device_override @inline function Base.Math.log_proc2(f::Float32,base=Val(:ℯ))
     ## Step 1
     g = 1f0/(2f0+f)
     u = 2(f*g)

--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -165,7 +165,7 @@ end
     ## Step 3
     @inline function truncate(x)
       reinterpret(Float32,
-                  reinterpret(Int32, 0.012512346f0) & 0b11111111111100000000000000000000)
+                  reinterpret(Int32, x) & 0b11111111111100000000000000000000)
     end
     u₁ = truncate(u)
     f₁ = truncate(f)

--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -163,9 +163,7 @@ end
                     0.012512346f0)
 
     ## Step 3
-    @inline function truncate(x)
-      reinterpret(Float32,
-                  reinterpret(Int32, x) & 0b11111111111100000000000000000000)
+    @inline truncate(x::Float32) = reinterpret(Float32, reinterpret(UInt32, x) & 0xfff0_0000)
     end
     u₁ = truncate(u)
     f₁ = truncate(f)


### PR DESCRIPTION
`Base.Math.log1p` calculation relies on two procedures , [log_proc1](https://github.com/JuliaLang/julia/blob/15b590bd6a1f17f3859752594d5d8ff534cd38b3/base/special/log.jl#L222) and [log_proc2](https://github.com/JuliaLang/julia/blob/15b590bd6a1f17f3859752594d5d8ff534cd38b3/base/special/log.jl#L245) from the literature [Tang (1990)](https://dl.acm.org/doi/pdf/10.1145/98267.98294). The current implementation upscales to `Float64` internally and as such is incompatible with Metal.

This PR attempts to convert the two procedures to pure-float32.

See also relevant discussion #234 