### PR TITLE
Don't re-use the IO object when shelling out to Python.

### DIFF
--- a/src/compiler/reflection.jl
+++ b/src/compiler/reflection.jl
@@ -77,7 +77,7 @@ function code_agx(io::IO, job::MetalCompilerJob)
             # disassemble the function
             first || println(io)
             println(io, "$name:")
-            disassemble(io, file)
+            print(io, disassemble(file))
 
             first = false
         end
@@ -151,10 +151,11 @@ function extract_gpu_code(f, binary)
     return
 end
 
-function disassemble(io::IO, path)
+function disassemble(path)
+    io = IOBuffer()
     disassembler = joinpath(only(readdir(artifact"applegpu"; join=true)), "disassemble.py")
     run(pipeline(`$(python()) $disassembler $path`, stdout=io))
-    return
+    return String(take!(io))
 end
 
 code_agx(@nospecialize(func), @nospecialize(types); kwargs...) =


### PR DESCRIPTION
This used to work fine on my M1 with macOS 14.1, but after upgrading to M3/14.2 it fails. However, it fails in the same way on Linux, so I guess it's unsupported:

```julia
julia> io = IOBuffer()
IOBuffer(data=UInt8[...], readable=true, writable=true, seekable=true, append=false, size=0, maxsize=Inf, ptr=1, mark=-1)

julia> run(pipeline(`echo`, stdout=io))
Process(`echo`, ProcessExited(0))

julia> io
IOBuffer(data=UInt8[...], readable=true, writable=false, seekable=true, append=false, size=1, maxsize=Inf, ptr=2, mark=-1)

julia> println(io, "test")
ERROR: ArgumentError: ensureroom failed, IOBuffer is not writeable
```

cc @gbaraldi