### PR TITLE
Add `resize!`

### DIFF
--- a/test/array.jl
+++ b/test/array.jl
@@ -230,4 +230,25 @@ end
   @test Metal.storagemode(e) == Shared
 end
 
+@testset "resizing" begin
+  a = MtlArray([1,2,3])
+
+  resize!(a, 3)
+  @test length(a) == 3
+  @test Array(a) == [1,2,3]
+
+  resize!(a, 5)
+  @test length(a) == 5
+  @test Array(a)[1:3] == [1,2,3]
+
+  resize!(a, 2)
+  @test length(a) == 2
+  @test Array(a)[1:2] == [1,2]
+
+  b = MtlArray{Int}(undef, 0)
+  @test length(b) == 0
+  resize!(b, 1)
+  @test length(b) == 1
+end
+
 end


### PR DESCRIPTION
Fixes #277. I'm not familiar with the internals of `Metal.jl` or `CUDA.jl` so it's very possible I am doing something wrong with the memory management.

As suggested by @maleadt in https://github.com/JuliaGPU/Metal.jl/issues/277#issuecomment-1914195535 I tried to follow the implementation of `resize!` from `CUDA.jl`.

I also added tests based on the ones for `resize!` in `CUDA.jl`.