### PR TITLE
Initial MTLTexture support

### DIFF
--- a/lib/mps/MPS.jl
+++ b/lib/mps/MPS.jl
@@ -11,8 +11,11 @@ const MtlFloat = Union{Float32, Float16}
 
 is_supported(dev::MTLDevice) = ccall(:MPSSupportsMTLDevice, Bool, (id{MTLDevice},), dev)
 
+include("size.jl")
+
 # MPS kernel base clases
 include("kernel.jl")
+include("images.jl")
 
 # high-level wrappers
 include("matrix.jl")

--- a/lib/mps/images.jl
+++ b/lib/mps/images.jl
@@ -22,7 +22,20 @@ end
     @autoproperty edgeMode::MPSImageEdgeMode
 end
 
-@objcwrapper immutable=false MPSBinarImageyKernel <: MPSKernel
+function encode!(cmdbuf::MTLCommandBuffer, kernel::K, sourceTexture, destinationTexture) where {K<:MPSUnaryImageKernel}
+    @objc [kernel::id{K} encodeToCommandBuffer:cmdbuf::id{MTLCommandBuffer}
+                                     sourceTexture:sourceTexture::id{MTLTexture}
+                                     destinationTexture:destinationTexture::id{MTLTexture}]::Nothing
+end
+
+# Implementing MPSCopyAllocator would allow blurring (and other things) to be done in-place
+# function encode!(cmdbuf::MTLCommandBuffer, kernel::K, inPlaceTexture, copyAllocator=nothing) where {K<:MPSUnaryImageKernel}
+#     @objc [kernel::id{K} encodeToCommandBuffer:cmdbuf::id{MTLCommandBuffer}
+#                                      inPlaceTexture:inPlaceTexture::id{MTLTexture}
+#                                      fallbackCopyAllocator:copyAllocator::MPSCopyAllocator]::Bool
+# end
+
+@objcwrapper immutable=false MPSBinaryImageKernel <: MPSKernel
 
 @objcproperties MPSBinaryImageKernel begin
     @autoproperty primaryOffset::MPSOffset
@@ -30,4 +43,76 @@ end
     @autoproperty primaryEdgeMode::MPSImageEdgeMode
     @autoproperty secondaryEdgeMode::MPSImageEdgeMode
     @autoproperty clipRect::MTLRegion
+end
+
+@objcwrapper immutable=false MPSImageGaussianBlur <: MPSUnaryImageKernel
+
+function MPSImageGaussianBlur(device, sigma)
+    kernel = @objc [MPSImageGaussianBlur alloc]::id{MPSImageGaussianBlur}
+    obj = MPSImageGaussianBlur(kernel)
+    finalizer(release, obj)
+    @objc [obj::id{MPSImageGaussianBlur} initWithDevice:device::id{MTLDevice}
+                                  sigma:sigma::Float32]::id{MPSImageGaussianBlur}
+    return obj
+end
+
+
+@objcwrapper immutable=false MPSImageBox <: MPSUnaryImageKernel
+
+function MPSImageBox(device, kernelWidth, kernelHeight)
+    kernel = @objc [MPSImageBox alloc]::id{MPSImageBox}
+    obj = MPSImageBox(kernel)
+    finalizer(release, obj)
+    @objc [obj::id{MPSImageBox} initWithDevice:device::id{MTLDevice}
+                                kernelWidth:kernelWidth::Int
+                                kernelHeight:kernelHeight::Int]::id{MPSImageBox}
+    return obj
+end
+
+function blur(image, kernel; pixelFormat=MTL.MTLPixelFormatRGBA8Unorm)
+    res = copy(image)
+
+    h,w = size(image)
+
+    alignment = MTL.minimumLinearTextureAlignmentForPixelFormat(current_device(), pixelFormat)
+    preBytesPerRow = sizeof(eltype(image))*w
+
+    rowoffset = alignment - (preBytesPerRow - 1) % alignment - 1
+    bytesPerRow = preBytesPerRow + rowoffset
+    offset = (rowoffset * h) % bytesPerRow
+
+    @show Int(alignment)
+    @show Int(preBytesPerRow)
+    @show Int(rowoffset)
+    @show Int(bytesPerRow)
+    @show Int(offset)
+
+    textDesc1 = MTLTextureDescriptor(pixelFormat, w, h)
+    textDesc1.usage = MTL.MTLTextureUsageShaderRead | MTL.MTLTextureUsageShaderWrite
+    text1 = MTL.newTextureWithDescriptor(image.data.rc.obj, textDesc1, 0, bytesPerRow)
+    # text1 = MTL.newTextureWithDescriptor(image.data.rc.obj, textDesc1, offset, bytesPerRow)
+
+    textDesc2 = MTLTextureDescriptor(pixelFormat, w, h)
+    textDesc2.usage = MTL.MTLTextureUsageShaderRead | MTL.MTLTextureUsageShaderWrite
+    text2 = MTL.newTextureWithDescriptor(res.data.rc.obj, textDesc2, 0, bytesPerRow)
+    # text2 = MTL.newTextureWithDescriptor(res.data.rc.obj, textDesc2, offset, bytesPerRow)
+
+    cmdbuf = MTLCommandBuffer(global_queue(current_device()))
+    # encode!(cmdbuf, kernel, text1)
+    encode!(cmdbuf, kernel, text1, text2)
+    commit!(cmdbuf)
+
+    # return image
+    return res
+end
+
+
+function gaussianblur(image; sigma, pixelFormat=MTL.MTLPixelFormatRGBA8Unorm)
+    kernel = MPSImageGaussianBlur(current_device(), sigma)
+    return blur(image, kernel; pixelFormat)
+end
+
+function boxblur(image, kernelWidth, kernelHeight; pixelFormat=MTL.MTLPixelFormatRGBA8Unorm)
+    kernel = MPSImageBox(current_device(), kernelWidth, kernelHeight)
+    return blur(image, kernel; pixelFormat)
 end

--- a/lib/mps/images.jl
+++ b/lib/mps/images.jl
@@ -1,0 +1,33 @@
+struct MPSOffset
+    x::NSInteger
+    y::NSInteger
+    z::NSInteger
+
+    MPSOffset(x=0, y=0, z=0) = new(x, y, z)
+end
+
+@cenum MPSImageEdgeMode::NSUInteger begin
+    MPSImageEdgeModeZero           = 0
+    MPSImageEdgeModeClamp          = 1
+    MPSImageEdgeModeMirror         = 2
+    MPSImageEdgeModeMirrorWithEdge = 3
+    MPSImageEdgeModeConstant       = 4
+end
+
+@objcwrapper immutable=false MPSUnaryImageKernel <: MPSKernel
+
+@objcproperties MPSUnaryImageKernel begin
+    @autoproperty offset::MPSOffset
+    @autoproperty clipRect::MTLRegion
+    @autoproperty edgeMode::MPSImageEdgeMode
+end
+
+@objcwrapper immutable=false MPSBinarImageyKernel <: MPSKernel
+
+@objcproperties MPSBinaryImageKernel begin
+    @autoproperty primaryOffset::MPSOffset
+    @autoproperty secondaryOffset::MPSOffset
+    @autoproperty primaryEdgeMode::MPSImageEdgeMode
+    @autoproperty secondaryEdgeMode::MPSImageEdgeMode
+    @autoproperty clipRect::MTLRegion
+end

--- a/lib/mps/images.jl
+++ b/lib/mps/images.jl
@@ -89,13 +89,13 @@ function blur(image, kernel; pixelFormat=MTL.MTLPixelFormatRGBA8Unorm)
 
     textDesc1 = MTLTextureDescriptor(pixelFormat, w, h)
     textDesc1.usage = MTL.MTLTextureUsageShaderRead | MTL.MTLTextureUsageShaderWrite
-    text1 = MTL.newTextureWithDescriptor(image.data.rc.obj, textDesc1, 0, bytesPerRow)
-    # text1 = MTL.newTextureWithDescriptor(image.data.rc.obj, textDesc1, offset, bytesPerRow)
+    text1 = MTL.MTLTexture(image.data.rc.obj, textDesc1, 0, bytesPerRow)
+    # text1 = MTL.MTLTexture(image.data.rc.obj, textDesc1, offset, bytesPerRow)
 
     textDesc2 = MTLTextureDescriptor(pixelFormat, w, h)
     textDesc2.usage = MTL.MTLTextureUsageShaderRead | MTL.MTLTextureUsageShaderWrite
-    text2 = MTL.newTextureWithDescriptor(res.data.rc.obj, textDesc2, 0, bytesPerRow)
-    # text2 = MTL.newTextureWithDescriptor(res.data.rc.obj, textDesc2, offset, bytesPerRow)
+    text2 = MTL.MTLTexture(res.data.rc.obj, textDesc2, 0, bytesPerRow)
+    # text2 = MTL.MTLTexture(res.data.rc.obj, textDesc2, offset, bytesPerRow)
 
     cmdbuf = MTLCommandBuffer(global_queue(current_device()))
     # encode!(cmdbuf, kernel, text1)

--- a/lib/mps/images.jl
+++ b/lib/mps/images.jl
@@ -72,7 +72,7 @@ end
 function blur(image, kernel; pixelFormat=MTL.MTLPixelFormatRGBA8Unorm)
     res = copy(image)
 
-    h,w = size(image)
+    w,h = size(image)
 
     alignment = MTL.minimumLinearTextureAlignmentForPixelFormat(current_device(), pixelFormat)
     preBytesPerRow = sizeof(eltype(image))*w

--- a/lib/mps/size.jl
+++ b/lib/mps/size.jl
@@ -1,0 +1,29 @@
+## size
+
+export MPSSize
+
+struct MPSSize
+    width::Float64
+    height::Float64
+    depth::Float64
+
+    MPSSize(w=1.0, h=1.0, d=1.0) = new(w, h, d)
+end
+
+# convenience constructors from tuple inputs
+MPSSize(dims::NTuple{1,<:Real}) = MPSSize(dims[1], 1.0,     1.0)
+MPSSize(dims::NTuple{2,<:Real}) = MPSSize(dims[1], dims[2], 1.0)
+MPSSize(dims::NTuple{3,<:Real}) = MPSSize(dims[1], dims[2], dims[3])
+
+
+## origin
+
+export MPSOrigin
+
+struct MPSOrigin
+    x::Float64
+    y::Float64
+    z::Float64
+
+    MPSOrigin(x=0, y=0, z=0) = new(x, y, z)
+end

--- a/lib/mtl/MTL.jl
+++ b/lib/mtl/MTL.jl
@@ -81,5 +81,6 @@ include("command_enc/compute.jl")
 include("binary_archive.jl")
 include("capture.jl")
 include("family.jl")
+include("texture.jl")
 
 end # module

--- a/lib/mtl/size.jl
+++ b/lib/mtl/size.jl
@@ -27,3 +27,14 @@ struct MTLOrigin
 
     MTLOrigin(x=0, y=0, z=0) = new(x, y, z)
 end
+
+## region
+
+export MTLRegion
+
+struct MTLRegion
+    origin::MTLOrigin # The top-left corner of the region
+    size::MTLSize # The size of the region
+
+    MTLRegion(x=0, y=0, z=0) = new(x, y, z)
+end

--- a/lib/mtl/texture.jl
+++ b/lib/mtl/texture.jl
@@ -1,0 +1,242 @@
+
+# See https://developer.apple.com/documentation/metal/mtlpixelformat?language=objc
+#  for details on each format
+@cenum MTLPixelFormat::NSUInteger begin
+    MTLPixelFormatInvalid      = 0
+
+    # Normal 8 bit formats
+    MTLPixelFormatA8Unorm      = 1
+    MTLPixelFormatR8Unorm      = 10
+    MTLPixelFormatR8Unorm_sRGB = 11
+    MTLPixelFormatR8Snorm      = 12
+    MTLPixelFormatR8Uint       = 13
+    MTLPixelFormatR8Sint       = 14
+
+    # Normal 16 bit formats
+    MTLPixelFormatR16Unorm     = 20
+    MTLPixelFormatR16Snorm     = 22
+    MTLPixelFormatR16Uint      = 23
+    MTLPixelFormatR16Sint      = 24
+    MTLPixelFormatR16Float     = 25
+
+    MTLPixelFormatRG8Unorm      = 30
+    MTLPixelFormatRG8Unorm_sRGB = 31
+    MTLPixelFormatRG8Snorm      = 32
+    MTLPixelFormatRG8Uint       = 33
+    MTLPixelFormatRG8Sint       = 34
+
+    # Packed 16 bit formats
+    MTLPixelFormatB5G6R5Unorm = 40
+    MTLPixelFormatA1BGR5Unorm = 41
+    MTLPixelFormatABGR4Unorm  = 42
+    MTLPixelFormatBGR5A1Unorm = 43
+
+    # Normal 32 bit formats
+    MTLPixelFormatR32Uint  = 53
+    MTLPixelFormatR32Sint  = 54
+    MTLPixelFormatR32Float = 55
+
+    MTLPixelFormatRG16Unorm = 60
+    MTLPixelFormatRG16Snorm = 62
+    MTLPixelFormatRG16Uint  = 63
+    MTLPixelFormatRG16Sint  = 64
+    MTLPixelFormatRG16Float = 65
+
+    MTLPixelFormatRGBA8Unorm      = 70
+    MTLPixelFormatRGBA8Unorm_sRGB = 71
+    MTLPixelFormatRGBA8Snorm      = 72
+    MTLPixelFormatRGBA8Uint       = 73
+    MTLPixelFormatRGBA8Sint       = 74
+
+    MTLPixelFormatBGRA8Unorm      = 80
+    MTLPixelFormatBGRA8Unorm_sRGB = 81
+
+    # Packed 32 bit formats
+    MTLPixelFormatRGB10A2Unorm = 90
+    MTLPixelFormatRGB10A2Uint  = 91
+
+    MTLPixelFormatRG11B10Float = 92
+    MTLPixelFormatRGB9E5Float  = 93
+
+    MTLPixelFormatBGR10A2Unorm = 94
+
+    MTLPixelFormatBGR10_XR      = 554
+    MTLPixelFormatBGR10_XR_sRGB = 555
+
+    # Normal 64 bit formats
+    MTLPixelFormatRG32Uint  = 103
+    MTLPixelFormatRG32Sint  = 104
+    MTLPixelFormatRG32Float = 105
+
+    MTLPixelFormatRGBA16Unorm = 110
+    MTLPixelFormatRGBA16Snorm = 112
+    MTLPixelFormatRGBA16Uint  = 113
+    MTLPixelFormatRGBA16Sint  = 114
+    MTLPixelFormatRGBA16Float = 115
+
+    MTLPixelFormatBGRA10_XR      = 552
+    MTLPixelFormatBGRA10_XR_sRGB = 553
+
+    # Normal 128 bit formats
+    MTLPixelFormatRGBA32Uint  = 123
+    MTLPixelFormatRGBA32Sint  = 124
+    MTLPixelFormatRGBA32Float = 125
+
+    ## Compressed formats
+
+    # S3TC/DXT
+    MTLPixelFormatBC1_RGBA               = 130
+    MTLPixelFormatBC1_RGBA_sRGB          = 131
+    MTLPixelFormatBC2_RGBA               = 132
+    MTLPixelFormatBC2_RGBA_sRGB          = 133
+    MTLPixelFormatBC3_RGBA               = 134
+    MTLPixelFormatBC3_RGBA_sRGB          = 135
+
+    # RGTC
+    MTLPixelFormatBC4_RUnorm             = 140
+    MTLPixelFormatBC4_RSnorm             = 141
+    MTLPixelFormatBC5_RGUnorm            = 142
+    MTLPixelFormatBC5_RGSnorm            = 143
+
+    # BPTC
+    MTLPixelFormatBC6H_RGBFloat          = 150
+    MTLPixelFormatBC6H_RGBUfloat         = 151
+    MTLPixelFormatBC7_RGBAUnorm          = 152
+    MTLPixelFormatBC7_RGBAUnorm_sRGB     = 153
+
+    # PVRTC
+    MTLPixelFormatPVRTC_RGB_2BPP         = 160
+    MTLPixelFormatPVRTC_RGB_2BPP_sRGB    = 161
+    MTLPixelFormatPVRTC_RGB_4BPP         = 162
+    MTLPixelFormatPVRTC_RGB_4BPP_sRGB    = 163
+    MTLPixelFormatPVRTC_RGBA_2BPP        = 164
+    MTLPixelFormatPVRTC_RGBA_2BPP_sRGB   = 165
+    MTLPixelFormatPVRTC_RGBA_4BPP        = 166
+    MTLPixelFormatPVRTC_RGBA_4BPP_sRGB   = 167
+
+    # ETC2
+    MTLPixelFormatEAC_R11Unorm           = 170
+    MTLPixelFormatEAC_R11Snorm           = 172
+    MTLPixelFormatEAC_RG11Unorm          = 174
+    MTLPixelFormatEAC_RG11Snorm          = 176
+    MTLPixelFormatEAC_RGBA8              = 178
+    MTLPixelFormatEAC_RGBA8_sRGB         = 179
+
+    MTLPixelFormatETC2_RGB8              = 180
+    MTLPixelFormatETC2_RGB8_sRGB         = 181
+    MTLPixelFormatETC2_RGB8A1            = 182
+    MTLPixelFormatETC2_RGB8A1_sRGB       = 183
+
+    # ASTC
+    MTLPixelFormatASTC_4x4_sRGB          = 186
+    MTLPixelFormatASTC_5x4_sRGB          = 187
+    MTLPixelFormatASTC_5x5_sRGB          = 188
+    MTLPixelFormatASTC_6x5_sRGB          = 189
+    MTLPixelFormatASTC_6x6_sRGB          = 190
+    MTLPixelFormatASTC_8x5_sRGB          = 192
+    MTLPixelFormatASTC_8x6_sRGB          = 193
+    MTLPixelFormatASTC_8x8_sRGB          = 194
+    MTLPixelFormatASTC_10x5_sRGB         = 195
+    MTLPixelFormatASTC_10x6_sRGB         = 196
+    MTLPixelFormatASTC_10x8_sRGB         = 197
+    MTLPixelFormatASTC_10x10_sRGB        = 198
+    MTLPixelFormatASTC_12x10_sRGB        = 199
+    MTLPixelFormatASTC_12x12_sRGB        = 200
+
+    MTLPixelFormatASTC_4x4_LDR           = 204
+    MTLPixelFormatASTC_5x4_LDR           = 205
+    MTLPixelFormatASTC_5x5_LDR           = 206
+    MTLPixelFormatASTC_6x5_LDR           = 207
+    MTLPixelFormatASTC_6x6_LDR           = 208
+    MTLPixelFormatASTC_8x5_LDR           = 210
+    MTLPixelFormatASTC_8x6_LDR           = 211
+    MTLPixelFormatASTC_8x8_LDR           = 212
+    MTLPixelFormatASTC_10x5_LDR          = 213
+    MTLPixelFormatASTC_10x6_LDR          = 214
+    MTLPixelFormatASTC_10x8_LDR          = 215
+    MTLPixelFormatASTC_10x10_LDR         = 216
+    MTLPixelFormatASTC_12x10_LDR         = 217
+    MTLPixelFormatASTC_12x12_LDR         = 218
+
+
+    # ASTC HDR (High Dynamic Range) Formats
+    MTLPixelFormatASTC_4x4_HDR   = 222
+    MTLPixelFormatASTC_5x4_HDR   = 223
+    MTLPixelFormatASTC_5x5_HDR   = 224
+    MTLPixelFormatASTC_6x5_HDR   = 225
+    MTLPixelFormatASTC_6x6_HDR   = 226
+    MTLPixelFormatASTC_8x5_HDR   = 228
+    MTLPixelFormatASTC_8x6_HDR   = 229
+    MTLPixelFormatASTC_8x8_HDR   = 230
+    MTLPixelFormatASTC_10x5_HDR  = 231
+    MTLPixelFormatASTC_10x6_HDR  = 232
+    MTLPixelFormatASTC_10x8_HDR  = 233
+    MTLPixelFormatASTC_10x10_HDR = 234
+    MTLPixelFormatASTC_12x10_HDR = 235
+    MTLPixelFormatASTC_12x12_HDR = 236
+
+    # YUV
+    MTLPixelFormatGBGR422 = 240
+    MTLPixelFormatBGRG422 = 241
+
+    # Depth
+    MTLPixelFormatDepth16Unorm = 250
+    MTLPixelFormatDepth32Float = 252
+
+    # Stencil
+    MTLPixelFormatStencil8 = 253
+
+    # Depth Stencil
+    MTLPixelFormatDepth24Unorm_Stencil8 = 255
+    MTLPixelFormatDepth32Float_Stencil8 = 260
+
+    MTLPixelFormatX32_Stencil8 = 261
+    MTLPixelFormatX24_Stencil8 = 262
+end
+## bitwise operations lose type information, so allow conversions
+Base.convert(::Type{MTLPixelFormat}, x::Integer) = MTLPixelFormat(x)
+
+@cenum MTLTextureUsage::NSUInteger begin
+    MTLTextureUsageUnknown         = 0x0000
+    MTLTextureUsageShaderRead      = 0x0001
+    MTLTextureUsageShaderWrite     = 0x0002
+    MTLTextureUsageRenderTarget    = 0x0004
+    MTLTextureUsagePixelFormatView = 0x0010
+    MTLTextureUsageShaderAtomic    = 0x0020
+end
+## bitwise operations lose type information, so allow conversions
+Base.convert(::Type{MTLTextureUsage}, x::Integer) = MTLTextureUsage(x)
+
+export MTLTextureDescriptor
+
+@objcwrapper MTLTextureDescriptor <: NSObject
+
+function MTLTextureDescriptor(pixelFormat, width, resourceOptions, usage)
+    desc = @objc [MTLTextureDescriptor textureBufferDescriptorWithPixelFormat:pixelFormat::MTLPixelFormat
+                                          width:width::NSUInteger
+                                          resourceOptions:resourceOptions::MTLResourceOptions
+                                          usage:usage::MTLTextureUsage]::id{MTLTextureDescriptor}
+    obj = MTLTextureDescriptor(desc)
+    # XXX: who releases this object?
+    return obj
+end
+
+@objcwrapper MTLTexture <: NSObject
+
+function newTextureWithDescriptor(buffer, descriptor, offset, bytesPerRow)
+    texture = @objc [buffer::id{MTLBuffer} newTextureWithDescriptor:descriptor::id{MTLTextureDescriptor}
+                                          offset:offset::NSUInteger
+                                          bytesPerRow:bytesPerRow::NSUInteger]::id{MTLTexture}
+    obj = MTLTexture(texture)
+    # XXX: who releases this object?
+    return obj
+end
+
+# function newTextureWithDescriptor(buffer, descriptor, offset, bytesPerRow)
+#     desc = @objc [buffer newTextureWithDescriptor:descriptor::id{MTLTextureDescriptor}
+#                                           offset:offset::NSUInteger
+#                                           bytesPerRow:bytesPerRow::NSUInteger]::id{MTLTexture}
+#     obj = MTLTexture(desc)
+#     # XXX: who releases this object?
+#     return obj
+# end

--- a/lib/mtl/texture.jl
+++ b/lib/mtl/texture.jl
@@ -239,7 +239,7 @@ export MTLTexture
 
 @objcwrapper MTLTexture <: NSObject
 
-function newTextureWithDescriptor(buffer, descriptor, offset, bytesPerRow)
+function MTLTexture(buffer, descriptor, offset, bytesPerRow)
     texture = @objc [buffer::id{MTLBuffer} newTextureWithDescriptor:descriptor::id{MTLTextureDescriptor}
                                           offset:offset::NSUInteger
                                           bytesPerRow:bytesPerRow::NSUInteger]::id{MTLTexture}
@@ -248,16 +248,9 @@ function newTextureWithDescriptor(buffer, descriptor, offset, bytesPerRow)
     return obj
 end
 
-function newTextureWithDescriptor(device, descriptor)
+function MTLTexture(device, descriptor)
     texture = @objc [device::id{MTLDevice} newTextureWithDescriptor:descriptor::id{MTLTextureDescriptor}]::id{MTLTexture}
     obj = MTLTexture(texture)
-    # XXX: who releases this object?
-    return obj
-end
-
-function newTextureViewWithPixelFormat(texture, pixelFormat)
-    tview = @objc [texture::id{MTLTexture} newTextureViewWithPixelFormat:pixelFormat::MTLPixelFormat]::id{MTLTexture}
-    obj = MTLTexture(tview)
     # XXX: who releases this object?
     return obj
 end

--- a/lib/mtl/texture.jl
+++ b/lib/mtl/texture.jl
@@ -1,3 +1,4 @@
+export MTLTextureDescriptor, MTLTexture
 
 # See https://developer.apple.com/documentation/metal/mtlpixelformat?language=objc
 #  for details on each format
@@ -211,8 +212,6 @@ end
 ## bitwise operations lose type information, so allow conversions
 Base.convert(::Type{MTLTextureUsage}, x::Integer) = MTLTextureUsage(x)
 
-export MTLTextureDescriptor
-
 @objcwrapper immutable=false MTLTextureDescriptor <: NSObject
 
 @objcproperties MTLTextureDescriptor begin
@@ -235,8 +234,6 @@ function MTLTextureDescriptor(pixelFormat, width, height, mipmapped=false)
 
     return obj
 end
-
-export MTLTexture
 
 @objcwrapper immutable=false MTLTexture <: NSObject
 

--- a/lib/mtl/texture.jl
+++ b/lib/mtl/texture.jl
@@ -213,7 +213,7 @@ Base.convert(::Type{MTLTextureUsage}, x::Integer) = MTLTextureUsage(x)
 
 export MTLTextureDescriptor
 
-@objcwrapper MTLTextureDescriptor <: NSObject
+@objcwrapper immutable=false MTLTextureDescriptor <: NSObject
 
 @objcproperties MTLTextureDescriptor begin
     # Configuring an MTLTextureDescriptor
@@ -231,26 +231,29 @@ function MTLTextureDescriptor(pixelFormat, width, height, mipmapped=false)
                                           height:height::NSUInteger
                                           mipmapped:mipmapped::Bool]::id{MTLTextureDescriptor}
     obj = MTLTextureDescriptor(desc)
-    # XXX: who releases this object?
+    finalizer(release, obj)
+
     return obj
 end
 
 export MTLTexture
 
-@objcwrapper MTLTexture <: NSObject
+@objcwrapper immutable=false MTLTexture <: NSObject
 
 function MTLTexture(buffer, descriptor, offset, bytesPerRow)
     texture = @objc [buffer::id{MTLBuffer} newTextureWithDescriptor:descriptor::id{MTLTextureDescriptor}
                                           offset:offset::NSUInteger
                                           bytesPerRow:bytesPerRow::NSUInteger]::id{MTLTexture}
     obj = MTLTexture(texture)
-    # XXX: who releases this object?
+    finalizer(release, obj)
+
     return obj
 end
 
 function MTLTexture(device, descriptor)
     texture = @objc [device::id{MTLDevice} newTextureWithDescriptor:descriptor::id{MTLTextureDescriptor}]::id{MTLTexture}
     obj = MTLTexture(texture)
-    # XXX: who releases this object?
+    finalizer(release, obj)
+
     return obj
 end


### PR DESCRIPTION
Initial attempt at implementing `MTLTexture`, along with some "simple" MPS image filters that I used to test the implementation. I wrote this a few months ago but couldn't figure how to get it working on non-square images.

I'm creating this draft PR in case someone can help me figure out what's going on (or take over).

`MTLTexture` is needed to implement `MPSImage`, which is needed for all the Metal Performance Shaders convolutional neural network functionality.