### PR TITLE
Remove an unneeded pointer method.

### DIFF
--- a/src/memory.jl
+++ b/src/memory.jl
@@ -16,8 +16,6 @@ struct MtlPointer{T}
     end
 end
 
-Base.pointer(buf::MTLBuffer) = MtlPointer{Nothing}(buf)
-
 Base.eltype(::Type{<:MtlPointer{T}}) where {T} = T
 
 # limited arithmetic


### PR DESCRIPTION
In https://github.com/JuliaInterop/ObjectiveC.jl/pull/26, we're now relying on `pointer(obj)` to return an `id` pointer. Metal.jl had a custom `pointer` method for `MTLBuffer`, which turns out problematic.