### PR TITLE
`adapt_storage`-related improvements

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -316,6 +316,8 @@ Adapt.adapt_storage(::Type{<:MtlArray{T}}, xs::AT) where {T, AT<:AbstractArray} 
   isbitstype(AT) ? xs : convert(MtlArray{T}, xs)
 Adapt.adapt_storage(::Type{<:MtlArray{T, N}}, xs::AT) where {T, N, AT<:AbstractArray} =
   isbitstype(AT) ? xs : convert(MtlArray{T,N}, xs)
+Adapt.adapt_storage(::Type{<:MtlArray{T, N, S}}, xs::AT) where {T, N, S, AT<:AbstractArray} =
+ isbitstype(AT) ? xs : convert(MtlArray{T,N,S}, xs)
 
 
 ## opinionated gpu array adaptor

--- a/src/array.jl
+++ b/src/array.jl
@@ -327,18 +327,11 @@ struct MtlArrayAdaptor{S} end
 Adapt.adapt_storage(::MtlArrayAdaptor{S}, xs::AbstractArray{T,N}) where {T,N,S} =
   isbits(xs) ? xs : MtlArray{T,N,S}(xs)
 
-Adapt.adapt_storage(::MtlArrayAdaptor{S}, xs::AbstractArray{T,N}) where {T<:AbstractFloat,N,S} =
+Adapt.adapt_storage(::MtlArrayAdaptor{S}, xs::AbstractArray{T,N}) where {T<:Float64,N,S} =
   isbits(xs) ? xs : MtlArray{Float32,N,S}(xs)
 
-Adapt.adapt_storage(::MtlArrayAdaptor{S}, xs::AbstractArray{T,N}) where {T<:Complex{<:AbstractFloat},N,S} =
+Adapt.adapt_storage(::MtlArrayAdaptor{S}, xs::AbstractArray{T,N}) where {T<:Complex{<:Float64},N,S} =
   isbits(xs) ? xs : MtlArray{ComplexF32,N,S}(xs)
-
-# not for Float16
-Adapt.adapt_storage(::MtlArrayAdaptor{S}, xs::AbstractArray{T,N}) where {T<:Float16,N,S} =
-  isbits(xs) ? xs : MtlArray{T,N,S}(xs)
-
-Adapt.adapt_storage(::MtlArrayAdaptor{S}, xs::AbstractArray{T,N}) where {T<:Complex{Float16},N,S} =
-  isbits(xs) ? xs : MtlArray{T,N,S}(xs)
 
 """
     mtl(A; storage=Private)

--- a/src/array.jl
+++ b/src/array.jl
@@ -30,6 +30,8 @@ function check_eltype(T)
   Base.allocatedinline(T) || error("MtlArray only supports element types that are stored inline")
   Base.isbitsunion(T) && error("MtlArray does not yet support isbits-union arrays")
   contains_eltype(T, Float64) && error("Metal does not support Float64 values, try using Float32 instead")
+  contains_eltype(T, Int128) && error("Metal does not support Int128 values, try using Int64 instead")
+  contains_eltype(T, UInt128) && error("Metal does not support UInt128 values, try using UInt64 instead")
 end
 
 """

--- a/test/array.jl
+++ b/test/array.jl
@@ -42,6 +42,12 @@ end
         @test mtl(Complex{SrcType}[1+1im]) isa MtlArray{Complex{TargType}}
     end
 
+    # test the regular adaptor
+    @test Adapt.adapt(MtlArray, [1 2;3 4]) isa MtlArray{Int, 2, Private}
+    @test Adapt.adapt(MtlArray{Float32}, [1 2;3 4]) isa MtlArray{Float32, 2, Private}
+    @test Adapt.adapt(MtlArray{Float32, 2}, [1 2;3 4]) isa MtlArray{Float32, 2, Private}
+    @test Adapt.adapt(MtlArray{Float32, 2, Shared}, [1 2;3 4]) isa MtlArray{Float32, 2, Shared}
+    @test Adapt.adapt(MtlMatrix{ComplexF32, Shared}, [1 2;3 4]) isa MtlArray{ComplexF32, 2, Shared}
     @test Adapt.adapt(MtlArray{Float16}, Float64[1]) isa MtlArray{Float16}
 
     # Test a few explicitly unsupported types


### PR DESCRIPTION
This PR does 3 things:

- Adds a check for the unsupported `Int128` and `UInt128` when constructing a `MtlArray`. (https://github.com/JuliaGPU/Metal.jl/issues/287#issuecomment-1967391570)
- Simplifies the opinionated `adapt_storage` to only convert `Float64` -> `Float32`. This also makes `BigFloat` no longer get converted to Float32. Add tests for every supported scalar type. (also https://github.com/JuliaGPU/Metal.jl/issues/287#issuecomment-1967391570)
- I forgot to add a function for the regular constructor when I parameterized the storagemode in #194, so add that and add tests

Closes #287
Closes #289

I can spin off point 3 into its own PR if the other 2 need more discussion.