### PR TITLE
Add support for signposts

### DIFF
--- a/docs/src/profiling.md
+++ b/docs/src/profiling.md
@@ -46,6 +46,24 @@ julia> Metal.@profile @metal threads=length(c) vadd(a, b, c);
 [ Info: System trace saved to julia_3.trace; open the resulting trace in Instruments
 ```
 
+It is possible to augment the trace with additional information by using signposts: Similar
+to NVTX markers and ranges in CUDA.jl, signpost intervals and events can be used to add
+respectively time intervals and points of interest to the trace. This can be done by using
+the signpost functionality from ObjectiveC.jl:
+
+```julia
+using ObjectiveC, .OS
+
+@signpost_interval "My Interval" begin
+    # code to profile
+    @signpost_event "My Event"
+end
+```
+
+For more information, e.g. how to pass additional messages to the signposts, or how to
+use a custom logger, consult the ObjectiveC.jl documentation, or the docstrings of the
+`@signpost_interval` and `@signpost_event` macros.
+
 ## Frame capture
 
 For more details on specific operations, you can use Metal's frame capture feature to

--- a/src/Metal.jl
+++ b/src/Metal.jl
@@ -11,7 +11,7 @@ using Python_jll
 using ObjectFile
 using ExprTools: splitdef, combinedef
 using Artifacts
-using ObjectiveC, .CoreFoundation, .Foundation, .Dispatch
+using ObjectiveC, .CoreFoundation, .Foundation, .Dispatch, .OS
 
 if !isdefined(Base, :get_extension)
     using Requires: @require

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -55,7 +55,7 @@ end
 
 # compile to executable machine code
 function compile(@nospecialize(job::CompilerJob))
-    signpost_event(log_compiler(), "Compile", "Job=$job")
+    @signpost_event log=log_compiler() "Compile" "Job=$job"
 
     @signpost_interval log=log_compiler() "Generate LLVM IR" begin
         # TODO: on 1.9, this actually creates a context. cache those.
@@ -116,7 +116,7 @@ end
 # link into an executable kernel
 @autoreleasepool function link(@nospecialize(job::CompilerJob), compiled;
                                return_function=false)
-    signpost_event(log_compiler(), "Link", "Job=$job")
+    @signpost_event log=log_compiler() "Link" "Job=$job"
 
     @signpost_interval log=log_compiler() "Instantiate compute pipeline" begin
         dev = current_device()

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -57,7 +57,7 @@ end
 function compile(@nospecialize(job::CompilerJob))
     signpost_event(log_compiler(), "Compile", "Job=$job")
 
-    @signpost_interval "Generate LLVM IR" log=log_compiler() begin
+    @signpost_interval log=log_compiler() "Generate LLVM IR" begin
         # TODO: on 1.9, this actually creates a context. cache those.
         ir, entry = JuliaContext() do ctx
             mod, meta = GPUCompiler.compile(:llvm, job)
@@ -65,7 +65,7 @@ function compile(@nospecialize(job::CompilerJob))
         end
     end
 
-    @signpost_interval "Downgrade to AIR" log=log_compiler() begin
+    @signpost_interval log=log_compiler() "Downgrade to AIR" begin
         # generate AIR
         air = let
             input = Pipe()
@@ -92,7 +92,7 @@ function compile(@nospecialize(job::CompilerJob))
         end
     end
 
-    @signpost_interval "Create Metal library" log=log_compiler() begin
+    @signpost_interval log=log_compiler() "Create Metal library" begin
         image = try
             metallib_fun = MetalLibFunction(; name=entry, air_module=air,
                                             air_version=job.config.target.air,
@@ -118,7 +118,7 @@ end
                                return_function=false)
     signpost_event(log_compiler(), "Link", "Job=$job")
 
-    @signpost_interval "Instantiate compute pipeline" log=log_compiler() begin
+    @signpost_interval log=log_compiler() "Instantiate compute pipeline" begin
         dev = current_device()
         lib = MTLLibraryFromData(dev, compiled.image)
         fun = MTLFunction(lib, compiled.entry)

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -55,52 +55,59 @@ end
 
 # compile to executable machine code
 function compile(@nospecialize(job::CompilerJob))
-    # TODO: on 1.9, this actually creates a context. cache those.
-    ir, entry = JuliaContext() do ctx
-        mod, meta = GPUCompiler.compile(:llvm, job)
-        string(mod), LLVM.name(meta.entry)
+    signpost_event(log_compiler(), "Compile", "Job=$job")
+
+    @signpost_interval "Generate LLVM IR" log=log_compiler() begin
+        # TODO: on 1.9, this actually creates a context. cache those.
+        ir, entry = JuliaContext() do ctx
+            mod, meta = GPUCompiler.compile(:llvm, job)
+            string(mod), LLVM.name(meta.entry)
+        end
     end
 
-    # generate AIR
-    air = let
-        input = Pipe()
-        output = Pipe()
+    @signpost_interval "Downgrade to AIR" log=log_compiler() begin
+        # generate AIR
+        air = let
+            input = Pipe()
+            output = Pipe()
 
-        cmd = `$(LLVMDowngrader_jll.llvm_as()) --bitcode-version=5.0 -o -`
-        proc = run(pipeline(cmd, stdout=output, stderr=stderr, stdin=input); wait=false)
-        close(output.in)
+            cmd = `$(LLVMDowngrader_jll.llvm_as()) --bitcode-version=5.0 -o -`
+            proc = run(pipeline(cmd, stdout=output, stderr=stderr, stdin=input); wait=false)
+            close(output.in)
 
-        writer = @async begin
-            write(input, ir)
-            close(input)
+            writer = @async begin
+                write(input, ir)
+                close(input)
+            end
+            reader = @async read(output)
+
+            wait(proc)
+            if !success(proc)
+                file = tempname(cleanup=false) * ".ll"
+                write(file, ir)
+                error("""Compilation to AIR failed; see above for details.
+                        If you think this is a bug, please file an issue and attach $(file)""")
+            end
+            fetch(reader)
         end
-        reader = @async read(output)
-
-        wait(proc)
-        if !success(proc)
-            file = tempname(cleanup=false) * ".ll"
-            write(file, ir)
-            error("""Compilation to AIR failed; see above for details.
-                     If you think this is a bug, please file an issue and attach $(file)""")
-        end
-        fetch(reader)
     end
 
-    # create a Metal library
-    image = try
-        metallib_fun = MetalLibFunction(; name=entry, air_module=air,
-                                          air_version=job.config.target.air,
-                                          metal_version=job.config.target.metal)
-        metallib = MetalLib(; functions = [metallib_fun])
+    @signpost_interval "Create Metal library" log=log_compiler() begin
+        image = try
+            metallib_fun = MetalLibFunction(; name=entry, air_module=air,
+                                            air_version=job.config.target.air,
+                                            metal_version=job.config.target.metal)
+            metallib = MetalLib(; functions = [metallib_fun])
 
-        image_stream = IOBuffer()
-        write(image_stream, metallib)
-        take!(image_stream)
-    catch err
-        file = tempname(cleanup=false) * ".air"
-        write(file, air)
-        error("""Compilation to Metal library failed; see below for details.
-                 If you think this is a bug, please file an issue and attach $(file)""")
+            image_stream = IOBuffer()
+            write(image_stream, metallib)
+            take!(image_stream)
+        catch err
+            file = tempname(cleanup=false) * ".air"
+            write(file, air)
+            error("""Compilation to Metal library failed; see below for details.
+                    If you think this is a bug, please file an issue and attach $(file)""")
+        end
     end
 
     return (; image, entry)
@@ -109,20 +116,24 @@ end
 # link into an executable kernel
 @autoreleasepool function link(@nospecialize(job::CompilerJob), compiled;
                                return_function=false)
-    dev = current_device()
-    lib = MTLLibraryFromData(dev, compiled.image)
-    fun = MTLFunction(lib, compiled.entry)
-    pipeline_state = try
-        MTLComputePipelineState(dev, fun)
-    catch err
-        isa(err, NSError) || rethrow()
+    signpost_event(log_compiler(), "Link", "Job=$job")
 
-        # the back-end compiler likely failed
-        # XXX: check more accurately? the error domain doesn't help much here
-        file = tempname(cleanup=false) * ".metallib"
-        write(file, compiled.image)
-        error("""Compilation to native code failed; see below for details.
-                 If you think this is a bug, please file an issue and attach $(file)""")
+    @signpost_interval "Instantiate compute pipeline" log=log_compiler() begin
+        dev = current_device()
+        lib = MTLLibraryFromData(dev, compiled.image)
+        fun = MTLFunction(lib, compiled.entry)
+        pipeline_state = try
+            MTLComputePipelineState(dev, fun)
+        catch err
+            isa(err, NSError) || rethrow()
+
+            # the back-end compiler likely failed
+            # XXX: check more accurately? the error domain doesn't help much here
+            file = tempname(cleanup=false) * ".metallib"
+            write(file, compiled.image)
+            error("""Compilation to native code failed; see below for details.
+                    If you think this is a bug, please file an issue and attach $(file)""")
+        end
     end
 
     # most of the time, we don't need the function object,

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -55,7 +55,7 @@ function alloc(dev::Union{MTLDevice,MTLHeap}, sz::Integer, args...; storage, kwa
     @signpost_event log=log_array() "Allocate" "Size=$(Base.format_bytes(sz))"
 
     time = Base.@elapsed begin
-        buf = @autoreleasepool MTLBuffer(dev, bytesize, args...; storage, kwargs...)
+        buf = @autoreleasepool MTLBuffer(dev, sz, args...; storage, kwargs...)
     end
 
     Base.@atomic alloc_stats.alloc_count + 1

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -52,7 +52,7 @@ Note that `Private` buffers can't be directly accessed from the CPU, therefore y
 use this option if you pass a ptr to initialize the memory.
 """
 function alloc(dev::Union{MTLDevice,MTLHeap}, sz::Integer, args...; storage, kwargs...)
-    signpost_event(log_array(), "Allocate", "Size=$(Base.format_bytes(sz))")
+    @signpost_event log=log_array() "Allocate" "Size=$(Base.format_bytes(sz))"
 
     time = Base.@elapsed begin
         buf = @autoreleasepool MTLBuffer(dev, bytesize, args...; storage, kwargs...)
@@ -73,7 +73,7 @@ This does not protect against double-freeing of the same buffer!
 """
 function free(buf::MTLBuffer)
     sz::Int = buf.length
-    signpost_event(log_array(), "Free", "Size=$(Base.format_bytes(sz))")
+    @signpost_event log=log_array() "Free" "Size=$(Base.format_bytes(sz))"
 
     time = Base.@elapsed begin
         @autoreleasepool unsafe=true release(buf)

--- a/src/state.jl
+++ b/src/state.jl
@@ -1,5 +1,10 @@
 export current_device, device!, global_queue, synchronize, device_synchronize
 
+log_compiler()          = OSLog("org.juliagpu.metal", "Compiler")
+log_compiler(args...)   = log_compiler()(args...)
+log_array()             = OSLog("org.juliagpu.metal", "Array")
+log_array(args...)      = log_array()(args...)
+
 """
     current_device()::MTLDevice
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -161,6 +161,7 @@ function profiled(f)
     notification_name = "julia.metal.profile"
     folder = profile_dir()
     instruments = [
+        # relevant instruments taken from `xcrun xctrace list instruments`
         "GPU",
 
         # CPU
@@ -169,6 +170,8 @@ function profiled(f)
         "Metal Application",
         "Metal GPU Counters",
         "Metal Resource Events",
+
+        "os_signpost",
     ]
     cmd = `xctrace record`
     for instrument in instruments


### PR DESCRIPTION
This offers similar functionality to NVTX.jl in CUDA land.

Example:

```julia
using Metal
using ObjectiveC, .OS

function main(N = 10_000_000)
    a = rand(Float32, N)
    da = MtlArray(a)

    Metal.@profile begin
        for i in 1:10
            @signpost_interval start="iteration $i" "sum" sum(da)
        end
    end

    Metal.unsafe_free!(da)
    return
end

isinteractive() || main()
```

<img width="1262" alt="image" src="https://github.com/JuliaGPU/Metal.jl/assets/383068/aed21606-36b7-4404-91e0-816f114cc1f4">

You can see the `sum` interval as part of the default logger, as well as some Metal.jl-internal ones I've opted to include.
