### PR TITLE
Retain NSError we rethrow to avoid an UAF.

### DIFF
--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -126,6 +126,7 @@ end
             MTLComputePipelineState(dev, fun)
         catch err
             isa(err, NSError) || rethrow()
+            retain(err)
 
             # the back-end compiler likely failed
             # XXX: check more accurately? the error domain doesn't help much here


### PR DESCRIPTION
When `throw`ing in a catch block, the previously-caught `NSError` will be rendered as part of the exception stack. This is an issue, as it may have been freed already at that point. Maybe this hints to a fragile pattern we ought to somehow avoid in ObjectiveC.jl, but for now let's just tackle this very issue.

Fixes https://github.com/JuliaGPU/Metal.jl/issues/301