### PR TITLE
Specialize broadcast to avoid integer divisions.

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -20,7 +20,25 @@ BroadcastStyle(::MtlArrayStyle{N, S1},
 Base.similar(bc::Broadcasted{MtlArrayStyle{N,S}}, ::Type{T}, dims) where {T,N,S} =
     similar(MtlArray{T,length(dims),S}, dims)
 
+# a static version of CartesianIndices that helps avoiding integer division
+# (at the expense of additional compilation)
+struct StaticCartesianIndices{N, I} end
+StaticCartesianIndices(iter::CartesianIndices{N}) where {N} =
+    StaticCartesianIndices{N, iter.indices}()
+StaticCartesianIndices(x) = StaticCartesianIndices(CartesianIndices(x))
+Base.CartesianIndices(iter::StaticCartesianIndices{N, I}) where {N, I} =
+    CartesianIndices{N, typeof(I)}(I)
+Base.@propagate_inbounds Base.getindex(I::StaticCartesianIndices, i::Integer) =
+    CartesianIndices(I)[Int(i)]
+Base.length(I::StaticCartesianIndices) = length(CartesianIndices(I))
+function Base.show(io::IO, I::StaticCartesianIndices)
+    print(io, "Static")
+    show(io, CartesianIndices(I))
+end
+
 # specialization of the broadcast implementation to avoid expensive integer divisions
+const _broadcast_shapes = Base.IdDict()
+const BROADCAST_SPECIALIZATION_THRESHOLD = 10
 @inline function Base.materialize!(::Style, dest, bc::Broadcasted) where {Style<:MtlArrayStyle}
     return _copyto!(dest, Broadcast.instantiate(Broadcasted{Style}(bc.f, bc.args, axes(dest))))
 end
@@ -33,6 +51,35 @@ end
     isempty(dest) && return dest
     bc = Broadcast.preprocess(dest, bc)
 
+    # if this is a common broadcast shape, specialize the kernel on it
+    Is = CartesianIndices(dest)
+    if !haskey(_broadcast_shapes, Is)
+        _broadcast_shapes[Is] = 1
+    else
+        _broadcast_shapes[Is] += 1
+    end
+    if _broadcast_shapes[Is] > BROADCAST_SPECIALIZATION_THRESHOLD
+        function broadcast_cartesian_static(dest, bc, Is)
+             i = thread_position_in_grid_1d()
+             stride = threads_per_grid_1d()
+             while 1 <= i <= length(dest)
+                I = @inbounds Is[i]
+                @inbounds dest[I] = bc[I]
+                i += stride
+             end
+             return
+        end
+
+        Is = StaticCartesianIndices(Is)
+        kernel = @metal launch=false broadcast_cartesian_static(dest, bc, Is)
+        elements = cld(length(dest), 4)
+        threads = min(elements, kernel.pipeline.maxTotalThreadsPerThreadgroup)
+        groups = cld(elements, threads)
+        kernel(dest, bc, Is; threads, groups)
+        return dest
+    end
+
+    # try to use the most appropriate hardware index to avoid integer division
     if ndims(dest) == 1 ||
        (isa(IndexStyle(dest), IndexLinear) && isa(IndexStyle(bc), IndexLinear))
         function broadcast_linear(dest, bc)

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -103,7 +103,7 @@ end
              while 1 <= is[1] <= size(dest, 1) && 1 <= is[2] <= size(dest, 2)
                 I = CartesianIndex(is)
                 @inbounds dest[I] = bc[I]
-                is = is .+ stride
+                is = (is[1] + stride[1], is[2] + stride[2])
              end
              return
         end
@@ -122,7 +122,7 @@ end
                    1 <= is[3] <= size(dest, 3)
                 I = CartesianIndex(is)
                 @inbounds dest[I] = bc[I]
-                is = is .+ stride
+                is = (is[1] + stride[1], is[2] + stride[2], is[3] + stride[3])
              end
              return
         end

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -129,7 +129,8 @@ end
 
         kernel = @metal launch=false broadcast_3d(dest, bc)
         w = min(size(dest, 1), kernel.pipeline.threadExecutionWidth)
-        h = min(size(dest, 2), kernel.pipeline.threadExecutionWidth)
+        h = min(size(dest, 2), kernel.pipeline.threadExecutionWidth,
+                               kernel.pipeline.maxTotalThreadsPerThreadgroup ÷ w)
         d = min(size(dest, 3), kernel.pipeline.maxTotalThreadsPerThreadgroup ÷ (w*h))
         threads = (w, h, d)
         groups = cld.(size(dest), threads)

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -19,3 +19,91 @@ BroadcastStyle(::MtlArrayStyle{N, S1},
 # allocation of output arrays
 Base.similar(bc::Broadcasted{MtlArrayStyle{N,S}}, ::Type{T}, dims) where {T,N,S} =
     similar(MtlArray{T,length(dims),S}, dims)
+
+# specialization of the broadcast implementation to avoid expensive integer divisions
+@inline function Base.materialize!(::Style, dest, bc::Broadcasted) where {Style<:MtlArrayStyle}
+    return _copyto!(dest, Broadcast.instantiate(Broadcasted{Style}(bc.f, bc.args, axes(dest))))
+end
+@inline Base.copyto!(dest::MtlArray, bc::Broadcasted{Nothing}) =
+    _copyto!(dest, bc) # Keep it for ArrayConflict
+@inline Base.copyto!(dest::AbstractArray, bc::Broadcasted{<:MtlArrayStyle}) =
+    _copyto!(dest, bc)
+@inline function _copyto!(dest::AbstractArray, bc::Broadcasted)
+    axes(dest) == axes(bc) || Broadcast.throwdm(axes(dest), axes(bc))
+    isempty(dest) && return dest
+    bc = Broadcast.preprocess(dest, bc)
+
+    if ndims(dest) == 1 ||
+       (isa(IndexStyle(dest), IndexLinear) && isa(IndexStyle(bc), IndexLinear))
+        function broadcast_linear(dest, bc)
+             i = thread_position_in_grid_1d()
+             stride = threads_per_grid_1d()
+             while 1 <= i <= length(dest)
+                 @inbounds dest[i] = bc[i]
+                 i += stride
+             end
+             return
+        end
+
+        kernel = @metal launch=false broadcast_linear(dest, bc)
+        elements = cld(length(dest), 4)
+        threads = min(elements, kernel.pipeline.maxTotalThreadsPerThreadgroup)
+        groups = cld(elements, threads)
+    elseif ndims(dest) == 2
+        function broadcast_2d(dest, bc)
+             is = Tuple(thread_position_in_grid_2d())
+             stride = threads_per_grid_2d()
+             while 1 <= is[1] <= size(dest, 1) && 1 <= is[2] <= size(dest, 2)
+                I = CartesianIndex(is)
+                @inbounds dest[I] = bc[I]
+                is = is .+ stride
+             end
+             return
+        end
+
+        kernel = @metal launch=false broadcast_2d(dest, bc)
+        w = min(size(dest, 1), kernel.pipeline.threadExecutionWidth)
+        h = min(size(dest, 2), kernel.pipeline.maxTotalThreadsPerThreadgroup ÷ w)
+        threads = (w, h)
+        groups = cld.(size(dest), threads)
+    elseif ndims(dest) == 3
+        function broadcast_3d(dest, bc)
+             is = Tuple(thread_position_in_grid_3d())
+             stride = threads_per_grid_3d()
+             while 1 <= is[1] <= size(dest, 1) &&
+                   1 <= is[2] <= size(dest, 2) &&
+                   1 <= is[3] <= size(dest, 3)
+                I = CartesianIndex(is)
+                @inbounds dest[I] = bc[I]
+                is = is .+ stride
+             end
+             return
+        end
+
+        kernel = @metal launch=false broadcast_3d(dest, bc)
+        w = min(size(dest, 1), kernel.pipeline.threadExecutionWidth)
+        h = min(size(dest, 2), kernel.pipeline.threadExecutionWidth)
+        d = min(size(dest, 3), kernel.pipeline.maxTotalThreadsPerThreadgroup ÷ (w*h))
+        threads = (w, h, d)
+        groups = cld.(size(dest), threads)
+    else
+        function broadcast_cartesian(dest, bc)
+             i = thread_position_in_grid_1d()
+             stride = threads_per_grid_1d()
+             while 1 <= i <= length(dest)
+                I = @inbounds CartesianIndices(dest)[i]
+                @inbounds dest[I] = bc[I]
+                i += stride
+             end
+             return
+        end
+
+        kernel = @metal launch=false broadcast_cartesian(dest, bc)
+        elements = cld(length(dest), 4)
+        threads = min(elements, kernel.pipeline.maxTotalThreadsPerThreadgroup)
+        groups = cld(elements, threads)
+    end
+    kernel(dest, bc; threads, groups)
+
+    return dest
+end

--- a/test/metal.jl
+++ b/test/metal.jl
@@ -456,7 +456,7 @@ end
         buf = Base.unsafe_convert(MTL.MTLBuffer, arr)
         Metal.unsafe_fill!(current_device(), Metal.MtlPointer{T}(buf, 0), T(val), 4)
 
-        @test all(arr .== val)
+        @test all(Array(arr) .== val)
     end
 end
 


### PR DESCRIPTION
By using hardware 2d/3d indices whenever possible.

Benchmark script:

```julia
using Metal
using Chairmarks

function memcopy(output_data::AbstractArray{T}, input_data::AbstractArray{T}) where T
    i = thread_position_in_grid_1d()
    if 1 <= i <= length(input_data)
        @inbounds output_data[i] = input_data[i]
    end
    return
end

function test(dims; T=Float32)
    cpu_in = rand(T, dims)
    gpu_in = MtlArray(cpu_in)
    gpu_out = similar(gpu_in)
    print(join(dims, "×"), "-element $T (", Base.format_bytes(sizeof(cpu_in)), "): ")

    # verify results
    gpu_out .= gpu_in
    @assert Array(gpu_in) == Array(gpu_out)

    # reference
    threads = 256
    groups = cld(length(cpu_in), threads)
    bench = @b Metal.@sync @metal threads=threads groups=groups memcopy(gpu_out, gpu_in)
    reference = Base.format_bytes(2*sizeof(gpu_in) / bench.time) * "/s"

    # broadcast
    bench = @b Metal.@sync (gpu_out .= gpu_in; nothing)
    speed = Base.format_bytes(2*sizeof(gpu_in) / bench.time) * "/s"

    println(speed, " / ", reference)

    return
end

function main()
    for dims in [(2^28,), (2^14, 2^14), (2^8, 2^8, 2^8),
                 (1, 2^28), (2^28,1),
                 (1, 2^14, 2^14), (2^14, 1, 2^14), (2^14, 2^14, 1),
                 (1, 1, 2^28), (1, 2^28, 1), (2^28, 1, 1)]
        test(dims)
    end
end
```

Before (on an M3 Pro with max 150GB/s bandwidth):

```
268435456-element Float32 (1024.000 MiB): 125.527 GiB/s / 126.282 GiB/s
16384×16384-element Float32 (1024.000 MiB): 31.089 GiB/s / 126.004 GiB/s
256×256×256-element Float32 (64.000 MiB): 17.313 GiB/s / 108.182 GiB/s
1×268435456-element Float32 (1024.000 MiB): 121.685 GiB/s / 125.155 GiB/s
268435456×1-element Float32 (1024.000 MiB): 121.661 GiB/s / 125.648 GiB/s
1×16384×16384-element Float32 (1024.000 MiB): 26.239 GiB/s / 125.158 GiB/s
16384×1×16384-element Float32 (1024.000 MiB): 26.102 GiB/s / 125.538 GiB/s
16384×16384×1-element Float32 (1024.000 MiB): 26.079 GiB/s / 125.631 GiB/s
1×1×268435456-element Float32 (1024.000 MiB): 72.273 GiB/s / 124.147 GiB/s
1×268435456×1-element Float32 (1024.000 MiB): 72.466 GiB/s / 125.649 GiB/s
268435456×1×1-element Float32 (1024.000 MiB): 72.353 GiB/s / 125.043 GiB/s
```

After:

```
268435456-element Float32 (1024.000 MiB): 122.613 GiB/s / 125.370 GiB/s
16384×16384-element Float32 (1024.000 MiB): 121.427 GiB/s / 125.990 GiB/s
256×256×256-element Float32 (64.000 MiB): 104.428 GiB/s / 107.949 GiB/s
1×268435456-element Float32 (1024.000 MiB): 125.704 GiB/s / 125.532 GiB/s
268435456×1-element Float32 (1024.000 MiB): 78.905 GiB/s / 125.298 GiB/s
1×16384×16384-element Float32 (1024.000 MiB): 123.495 GiB/s / 126.113 GiB/s
16384×1×16384-element Float32 (1024.000 MiB): 118.807 GiB/s / 125.526 GiB/s
16384×16384×1-element Float32 (1024.000 MiB): 120.582 GiB/s / 125.738 GiB/s
1×1×268435456-element Float32 (1024.000 MiB): 122.905 GiB/s / 125.729 GiB/s
1×268435456×1-element Float32 (1024.000 MiB): 80.628 GiB/s / 125.679 GiB/s
268435456×1×1-element Float32 (1024.000 MiB): 78.646 GiB/s / 125.736 GiB/s
```

Fixes #41 