### PR TITLE
Increase test timeout limit to accomodate 1.8

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -241,7 +241,7 @@ try
 
                     # catch timeouts
                     pid = remotecall_fetch(getpid, wrkr)
-                    timer = Timer(300) do _
+                    timer = Timer(360) do _
                         @warn "Test timed out: $test"
                         t1 = rmprocs(wrkr, waitfor=0)
 


### PR DESCRIPTION
Seems like the mapreduce test has a high variability in duration and in 1.8 it sometimes goes over the 300 second limit.

Add an extra minute to hopefully prevent the timeout from accidentally being reached.