### PR TITLE
Add error message for running Metal.jl under Rosetta

### DIFF
--- a/lib/mtl/version.jl
+++ b/lib/mtl/version.jl
@@ -1,6 +1,17 @@
 # version and support queries
 
-export darwin_version, macos_version, metallib_support, air_support, metal_support
+export darwin_version, macos_version, metallib_support, air_support, metal_support, process_translated
+
+@noinline function _syscall_status(name)
+    ret = Array{Cint, 0}(undef)
+    size = Array{Csize_t, 0}(undef)
+    size[] = sizeof(ret)
+    err = @ccall sysctlbyname(name::Cstring, ret::Ptr{Cvoid}, size::Ptr{Csize_t},
+                              C_NULL::Ptr{Cvoid}, 0::Csize_t)::Cint
+    Base.systemerror("sysctlbyname", err != 0)
+
+    return ret[]
+end
 
 @noinline function _syscall_version(name)
     size = Ref{Csize_t}()
@@ -33,6 +44,9 @@ function macos_version()
     _macos_version[]
 end
 
+function process_translated()
+    return Bool(_syscall_status("sysctl.proc_translated"))
+end
 
 ## support queries
 

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -10,6 +10,11 @@ function __init__()
         return
     end
 
+    if process_translated()
+        @error("Metal.jl is not supported under Rosetta. Please consider using an ARM64 (Apple Silicon) version of Julia")
+        return
+    end
+
     # we use Python_jll, but don't actually want its environment to be active
     # (this breaks the call to pygmentize in GPUCompiler).
     # XXX: the JLL should only set PYTHONHOME when the executable is called

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -14,7 +14,11 @@ macro sync(code)
 end
 
 function versioninfo(io::IO=stdout)
-    println(io, "macOS $(macos_version()), Darwin $(darwin_version())")
+    print(io, "macOS $(macos_version()), Darwin $(darwin_version())")
+    if process_translated()
+        print(io, ", using Rosetta")
+    end
+    println(io)
     println(io)
 
     println(io, "Toolchain:")


### PR DESCRIPTION
Metal.jl does not seem to work under Rosetta (#338) so add a warning for now until we find a fix.