### PR TITLE
Revert error message for Rosetta

### DIFF
--- a/lib/mtl/version.jl
+++ b/lib/mtl/version.jl
@@ -1,17 +1,6 @@
 # version and support queries
 
-export darwin_version, macos_version, metallib_support, air_support, metal_support, process_translated
-
-@noinline function _syscall_status(name)
-    ret = Array{Cint, 0}(undef)
-    size = Array{Csize_t, 0}(undef)
-    size[] = sizeof(ret)
-    err = @ccall sysctlbyname(name::Cstring, ret::Ptr{Cvoid}, size::Ptr{Csize_t},
-                              C_NULL::Ptr{Cvoid}, 0::Csize_t)::Cint
-    Base.systemerror("sysctlbyname", err != 0)
-
-    return ret[]
-end
+export darwin_version, macos_version, metallib_support, air_support, metal_support
 
 @noinline function _syscall_version(name)
     size = Ref{Csize_t}()
@@ -44,9 +33,6 @@ function macos_version()
     _macos_version[]
 end
 
-function process_translated()
-    return Bool(_syscall_status("sysctl.proc_translated"))
-end
 
 ## support queries
 

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -10,11 +10,6 @@ function __init__()
         return
     end
 
-    if process_translated()
-        @error("Metal.jl is not supported under Rosetta. Please consider using an ARM64 (Apple Silicon) version of Julia")
-        return
-    end
-
     # we use Python_jll, but don't actually want its environment to be active
     # (this breaks the call to pygmentize in GPUCompiler).
     # XXX: the JLL should only set PYTHONHOME when the executable is called

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -14,11 +14,7 @@ macro sync(code)
 end
 
 function versioninfo(io::IO=stdout)
-    print(io, "macOS $(macos_version()), Darwin $(darwin_version())")
-    if process_translated()
-        print(io, ", using Rosetta")
-    end
-    println(io)
+    println(io, "macOS $(macos_version()), Darwin $(darwin_version())")
     println(io)
 
     println(io, "Toolchain:")


### PR DESCRIPTION
Asking for `sysctl.proc_translated` on non Apple Silicon platforms returns ENOENT. Also the issue this is meant to warn for also occurs on non rosetta x86

reverts #339