### PR TITLE
Add autoreleasepools to MPS interface methods.

### DIFF
--- a/lib/mps/MPS.jl
+++ b/lib/mps/MPS.jl
@@ -13,22 +13,16 @@ is_supported(dev::MTLDevice) = ccall(:MPSSupportsMTLDevice, Bool, (id{MTLDevice}
 
 include("size.jl")
 
-# MPS kernel base clases
+# high-level wrappers
 include("command_buf.jl")
 include("kernel.jl")
 include("images.jl")
-
-# high-level wrappers
 include("matrix.jl")
 include("vector.jl")
+include("decomposition.jl")
+include("copy.jl")
 
 # integrations
 include("linalg.jl")
-
-# decompositions
-include("decomposition.jl")
-
-# matrix copy
-include("copy.jl")
 
 end

--- a/lib/mps/command_buf.jl
+++ b/lib/mps/command_buf.jl
@@ -5,7 +5,7 @@
 #
 
 # XXX: Not actually inheritance but MPSCommandBuffer conforms to MTLCommandBuffer protocol
-@objcwrapper immutable=false MPSCommandBuffer <: MTLCommandBuffer
+@objcwrapper MPSCommandBuffer <: MTLCommandBuffer
 
 @objcproperties MPSCommandBuffer begin
     # Identifying the Command Buffer
@@ -17,21 +17,17 @@ end
 
 function MPSCommandBuffer(commandBuffer::MTLCommandBuffer)
     cmdbuf = @objc [MPSCommandBuffer commandBufferWithCommandBuffer:commandBuffer::id{MTLCommandBuffer}]::id{MPSCommandBuffer}
-    obj = MPSCommandBuffer(cmdbuf)
-    finalizer(release, obj)
-    return obj
+    MPSCommandBuffer(cmdbuf)
 end
 
 function MPSCommandBuffer(commandQueue::MTLCommandQueue)
     cmdbuf = @objc [MPSCommandBuffer commandBufferFromCommandQueue:commandQueue::id{MTLCommandQueue}]::id{MPSCommandBuffer}
-    obj = MPSCommandBuffer(cmdbuf)
-    finalizer(release, obj)
-    return obj
+    MPSCommandBuffer(cmdbuf)
 end
 
-function MPSCommandBuffer(f::Base.Callable, queueOrBuf::Q) where Q <: Union{MTLCommandBuffer, MTLCommandQueue}
+function MPSCommandBuffer(f::Base.Callable, queueOrBuf)
     cmdbuf = MPSCommandBuffer(queueOrBuf)
-    cmdbuf = commitAndContinue!(f, cmdbuf)
+    commitAndContinue!(f, cmdbuf)
     return cmdbuf
 end
 
@@ -45,9 +41,8 @@ function MPS.commit!(f::Base.Callable, cmdbuf::MPSCommandBuffer)
     return cmdbuf
 end
 
-function commitAndContinue!(cmdbuf::MPSCommandBuffer)
+commitAndContinue!(cmdbuf::MPSCommandBuffer) =
     @objc [cmdbuf::id{MPSCommandBuffer} commitAndContinue]::Nothing
-end
 
 function commitAndContinue!(f::Base.Callable, cmdbuf::MPSCommandBuffer)
     enqueue!(cmdbuf)

--- a/lib/mps/copy.jl
+++ b/lib/mps/copy.jl
@@ -1,3 +1,7 @@
+## descriptor
+
+export MPSMatrixCopyDescriptor
+
 struct MPSMatrixCopyOffsets
     sourceRowOffset::Cuint
     sourceColumnOffset::Cuint
@@ -5,20 +9,17 @@ struct MPSMatrixCopyOffsets
     destinationColumnOffset::Cuint
 end
 
-export MPSMatrixCopyDescriptor
-
 @objcwrapper MPSMatrixCopyDescriptor <: NSObject
-
 
 function MPSMatrixCopyDescriptor(sourceMatrix, destinationMatrix, offsets = MPSMatrixCopyOffsets(Cuint(0), Cuint(0), Cuint(0), Cuint(0)))
     desc = @objc [MPSMatrixCopyDescriptor descriptorWithSourceMatrix:sourceMatrix::id{MPSMatrix}
                                           destinationMatrix:destinationMatrix::id{MPSMatrix}
                                           offsets:offsets::MPSMatrixCopyOffsets]::id{MPSMatrixCopyDescriptor}
-    obj = MPSMatrixCopyDescriptor(desc)
-    # XXX: who releases this object?
-    return obj
+    MPSMatrixCopyDescriptor(desc)
 end
 
+
+## kernel
 
 export MPSMatrixCopy
 

--- a/lib/mps/decomposition.jl
+++ b/lib/mps/decomposition.jl
@@ -1,4 +1,3 @@
-
 @cenum MPSMatrixDecompositionStatus::Cint begin
     MPSMatrixDecompositionStatusSuccess =  0
     MPSMatrixDecompositionStatusFailure = -1
@@ -6,6 +5,8 @@
     MPSMatrixDecompositionStatusNonPositiveDefinite = -3
 end
 
+
+## lu
 
 export MPSMatrixDecompositionLU
 
@@ -29,6 +30,8 @@ function encode!(cmdbuf::MTLCommandBuffer, kernel::MPSMatrixDecompositionLU, sou
                                                 status:status::id{MTLBuffer}]::Nothing
 end
 
+
+## cholesky
 
 export MPSMatrixDecompositionCholesky
 

--- a/lib/mps/linalg.jl
+++ b/lib/mps/linalg.jl
@@ -31,7 +31,9 @@ const MPS_VALID_MATMUL_TYPES =
      (Float16, Float16),
      (Float32, Float32)]
 
-function LinearAlgebra.generic_matmatmul!(C::MtlMatrix, tA, tB, A::MtlMatrix, B::MtlMatrix, _add::MulAddMul)
+@autoreleasepool function LinearAlgebra.generic_matmatmul!(C::MtlMatrix, tA, tB,
+                                                           A::MtlMatrix, B::MtlMatrix,
+                                                           _add::MulAddMul)
     mA, nA = LinearAlgebra.lapack_size(tA, A)
     mB, nB = LinearAlgebra.lapack_size(tB, B)
 
@@ -67,18 +69,23 @@ end
 
 if VERSION < v"1.10.0-DEV.1365"
 # catch other functions that are called by LinearAlgebra's mul!
-LinearAlgebra.gemm_wrapper!(C::MtlMatrix, tA::AbstractChar, tB::AbstractChar, A::MtlMatrix, B::MtlMatrix, _add::MulAddMul) =
+LinearAlgebra.gemm_wrapper!(C::MtlMatrix, tA::AbstractChar, tB::AbstractChar, A::MtlMatrix,
+                            B::MtlMatrix, _add::MulAddMul) =
     LinearAlgebra.generic_matmatmul!(C, tA, tB, A, B, _add)
-LinearAlgebra.gemm_wrapper!(C::MtlMatrix{T}, tA::AbstractChar, tB::AbstractChar, A::MtlMatrix{T}, B::MtlMatrix{T}, _add::MulAddMul) where {T<:LinearAlgebra.BlasFloat} =
+LinearAlgebra.gemm_wrapper!(C::MtlMatrix{T}, tA::AbstractChar, tB::AbstractChar,
+                            A::MtlMatrix{T}, B::MtlMatrix{T},
+                            _add::MulAddMul) where {T<:LinearAlgebra.BlasFloat} =
     LinearAlgebra.generic_matmatmul!(C, tA, tB, A, B, _add)
-function LinearAlgebra.syrk_wrapper!(C::MtlMatrix, tA::AbstractChar, A::MtlMatrix, _add::MulAddMul = MulAddMul())
+function LinearAlgebra.syrk_wrapper!(C::MtlMatrix, tA::AbstractChar, A::MtlMatrix,
+                                     _add::MulAddMul = MulAddMul())
     if tA == 'T'
         LinearAlgebra.generic_matmatmul!(C, 'T', 'N', A, A, _add)
     else # tA == 'N'
         LinearAlgebra.generic_matmatmul!(C, 'N', 'T', A, A, _add)
     end
 end
-function LinearAlgebra.herk_wrapper!(C::MtlMatrix, tA::AbstractChar, A::MtlMatrix, _add::MulAddMul = MulAddMul())
+function LinearAlgebra.herk_wrapper!(C::MtlMatrix, tA::AbstractChar, A::MtlMatrix,
+                                     _add::MulAddMul = MulAddMul())
     if tA == 'C'
         LinearAlgebra.generic_matmatmul!(C, 'C', 'N', A, A, _add)
     else # tA == 'N'
@@ -92,7 +99,9 @@ const MPS_VALID_MATVECMUL_TYPES =
      (Float16, Float32),
      (Float32, Float32)]
 
-function LinearAlgebra.generic_matvecmul!(C::MtlVector, tA::AbstractChar, A::MtlMatrix, B::MtlVector, _add::MulAddMul)
+@autoreleasepool function LinearAlgebra.generic_matvecmul!(C::MtlVector, tA::AbstractChar,
+                                                           A::MtlMatrix, B::MtlVector,
+                                                           _add::MulAddMul)
     mA, nA = LinearAlgebra.lapack_size(tA, A)
     mB = length(B)
     mC = length(C)
@@ -128,17 +137,19 @@ end
 
 if VERSION < v"1.10.0-DEV.1365"
 # catch other functions that are called by LinearAlgebra's mul!
-function LinearAlgebra.gemv!(C::MtlVector, tA::AbstractChar, A::MtlMatrix, B::MtlVector, a::Number, b::Number)
+LinearAlgebra.gemv!(C::MtlVector, tA::AbstractChar, A::MtlMatrix, B::MtlVector,
+                    a::Number, b::Number) =
     LinearAlgebra.generic_matvecmul!(C, tA, A, B, MulAddMul(a, b))
-end
 # disambiguation
-function LinearAlgebra.gemv!(C::MtlVector{T}, tA::AbstractChar, A::MtlMatrix{T}, B::MtlVector{T}, a::Number, b::Number) where {T<:LinearAlgebra.BlasFloat}
+LinearAlgebra.gemv!(C::MtlVector{T}, tA::AbstractChar, A::MtlMatrix{T}, B::MtlVector{T},
+                    a::Number, b::Number) where {T<:LinearAlgebra.BlasFloat} =
     LinearAlgebra.generic_matvecmul!(C, tA, A, B, MulAddMul(a, b))
-end
 end
 
-@inline checkpositivedefinite(status) = status == MPSMatrixDecompositionStatusNonPositiveDefinite || throw(PosDefException(status))
-@inline checknonsingular(status) = status != MPSMatrixDecompositionStatusSingular || throw(SingularException(status))
+@inline checkpositivedefinite(status) =
+    status == MPSMatrixDecompositionStatusNonPositiveDefinite || throw(PosDefException(status))
+@inline checknonsingular(status) =
+    status != MPSMatrixDecompositionStatusSingular || throw(SingularException(status))
 
 # GPU-compatible accessors of the LU decomposition properties
 function Base.getproperty(F::LU{T,<:MtlMatrix}, d::Symbol) where T
@@ -156,9 +167,11 @@ end
 
 # Metal's pivoting sequence needs to be iterated sequentially...
 # TODO: figure out a GPU-compatible way to get the permutation matrix
-LinearAlgebra.ipiv2perm(v::MtlVector{T}, maxi::Integer) where T = LinearAlgebra.ipiv2perm(Array(v), maxi)
+LinearAlgebra.ipiv2perm(v::MtlVector{T}, maxi::Integer) where T =
+    LinearAlgebra.ipiv2perm(Array(v), maxi)
 
-function LinearAlgebra.lu(A::MtlMatrix{T}; check::Bool = true) where {T<:MtlFloat}
+@autoreleasepool function LinearAlgebra.lu(A::MtlMatrix{T};
+                                           check::Bool=true) where {T<:MtlFloat}
     M,N = size(A)
     dev = current_device()
     queue = global_queue(dev)
@@ -214,8 +227,9 @@ function _check_lu_success(info, allowsingular)
 end
 
 # TODO: dispatch on pivot strategy
-function LinearAlgebra.lu!(A::MtlMatrix{T};
-                           check::Bool=true, allowsingular::Bool=false) where {T<:MtlFloat}
+@autoreleasepool function LinearAlgebra.lu!(A::MtlMatrix{T};
+                                            check::Bool=true,
+                                            allowsingular::Bool=false) where {T<:MtlFloat}
     M,N = size(A)
     dev = current_device()
     queue = global_queue(dev)
@@ -255,8 +269,8 @@ function LinearAlgebra.lu!(A::MtlMatrix{T};
     return LinearAlgebra.LU(A, p, status)
 end
 
-
-function LinearAlgebra.transpose!(B::MtlMatrix{T}, A::MtlMatrix{T}) where {T}
+@autoreleasepool function LinearAlgebra.transpose!(B::MtlMatrix{T},
+                                                   A::MtlMatrix{T}) where {T}
     axes(B,2) == axes(A,1) && axes(B,1) == axes(A,2) || throw(DimensionMismatch("transpose"))
 
     M,N = size(A)

--- a/lib/mps/vector.jl
+++ b/lib/mps/vector.jl
@@ -1,3 +1,5 @@
+## descriptor
+
 export MPSVectorDescriptor
 
 @objcwrapper MPSVectorDescriptor <: NSObject
@@ -13,21 +15,20 @@ end
 function MPSVectorDescriptor(length::Integer, dataType::Union{DataType,MPSDataType})
     desc = @objc [MPSVectorDescriptor vectorDescriptorWithLength:length::NSUInteger
                                       dataType:dataType::MPSDataType]::id{MPSVectorDescriptor}
-    obj = MPSVectorDescriptor(desc)
-    # XXX: who releases this object?
-    return obj
+    MPSVectorDescriptor(desc)
 end
 
-function MPSVectorDescriptor(length::Integer, vectors, vectorBytes::Integer, dataType::Union{DataType,MPSDataType})
+function MPSVectorDescriptor(length::Integer, vectors, vectorBytes::Integer,
+                             dataType::Union{DataType,MPSDataType})
     desc = @objc [MPSVectorDescriptor vectorDescriptorWithLength:length::NSUInteger
                                       vectors:vectors::NSUInteger
                                       vectorBytes:vectorBytes::NSUInteger
                                       dataType:dataType::MPSDataType]::id{MPSVectorDescriptor}
-    obj = MPSVectorDescriptor(desc)
-    # XXX: who releases this object?
-    return obj
+    MPSVectorDescriptor(desc)
 end
 
+
+## high-level object
 
 export MPSVector
 
@@ -81,9 +82,10 @@ function MPSTemporaryVector(commandBuffer::MTLCommandBuffer, descriptor::MPSVect
     return MPSTemporaryVector(obj)
 end
 
-#
-# matrix vector multiplication
-#
+
+## matrix vector multiplication
+
+export MPSMatrixVectorMultiplication, matvecmul!
 
 @objcwrapper immutable=false MPSMatrixVectorMultiplication <: MPSMatrixBinaryKernel
 
@@ -107,12 +109,11 @@ function encode!(cmdbuf::MTLCommandBuffer, matvecmul::MPSMatrixVectorMultiplicat
                                                         resultVector:resultVector::id{MPSVector}]::Nothing
 end
 
-
 """
-    matVecMulMPS(c::MtlVector, a::MtlMatrix, b::MtlVector, alpha=1, beta=1,
-                 transpose=false)
+    matvecmul!(c::MtlVector, a::MtlMatrix, b::MtlVector, alpha=1, beta=1, transpose=false)
+
 A `MPSMatrixVectorMultiplication` kernel thay computes:
-`c = alpha * op(a) * b + beta * c`
+  `c = alpha * op(a) * b + beta * c`
 
 This function should not typically be used. Rather, use the normal `LinearAlgebra` interface
 with any `MtlArray` and it should be accelerated using Metal Performance Shaders.


### PR DESCRIPTION
The idea is to add automatic memory management to interface implementation methods, so that callers don't ever have to think about memory management. Internal methods do not need to be annotated as such, because it's expected that they will be called from a context where an autoreleasepool is active.

This required additional fixes/changes:
- matrix/... descriptors are allocated by a factory method, so do not need to be released (this was a TODO)
- MPSCommandBuffer objects similarly are created by a factory, so _should not_ be manually released

I also did some light formatting while going through this code.