### PR TITLE
Don't redundantly return the cmdbuf from commit methods.

### DIFF
--- a/lib/mps/command_buf.jl
+++ b/lib/mps/command_buf.jl
@@ -16,13 +16,13 @@
 end
 
 function MPSCommandBuffer(commandBuffer::MTLCommandBuffer)
-    cmdbuf = @objc [MPSCommandBuffer commandBufferWithCommandBuffer:commandBuffer::id{MTLCommandBuffer}]::id{MPSCommandBuffer}
-    MPSCommandBuffer(cmdbuf)
+    handle = @objc [MPSCommandBuffer commandBufferWithCommandBuffer:commandBuffer::id{MTLCommandBuffer}]::id{MPSCommandBuffer}
+    MPSCommandBuffer(handle)
 end
 
 function MPSCommandBuffer(commandQueue::MTLCommandQueue)
-    cmdbuf = @objc [MPSCommandBuffer commandBufferFromCommandQueue:commandQueue::id{MTLCommandQueue}]::id{MPSCommandBuffer}
-    MPSCommandBuffer(cmdbuf)
+    handle = @objc [MPSCommandBuffer commandBufferFromCommandQueue:commandQueue::id{MTLCommandQueue}]::id{MPSCommandBuffer}
+    MPSCommandBuffer(handle)
 end
 
 function MPSCommandBuffer(f::Base.Callable, queueOrBuf)
@@ -38,7 +38,7 @@ function MPS.commit!(f::Base.Callable, cmdbuf::MPSCommandBuffer)
     enqueue!(cmdbuf)
     ret = f(cmdbuf)
     commit!(cmdbuf)
-    return cmdbuf
+    return ret
 end
 
 commitAndContinue!(cmdbuf::MPSCommandBuffer) =
@@ -48,5 +48,5 @@ function commitAndContinue!(f::Base.Callable, cmdbuf::MPSCommandBuffer)
     enqueue!(cmdbuf)
     ret = f(cmdbuf)
     commitAndContinue!(cmdbuf)
-    return cmdbuf
+    return ret
 end

--- a/lib/mps/linalg.jl
+++ b/lib/mps/linalg.jl
@@ -189,7 +189,7 @@ LinearAlgebra.ipiv2perm(v::MtlVector{T}, maxi::Integer) where T =
     P = MtlMatrix{UInt32}(undef, 1, min(N, M))
     status = MtlArray{MPSMatrixDecompositionStatus}(undef)
 
-    cmdbuf = commitAndContinue!(cmdbuf) do cbuf
+    commitAndContinue!(cmdbuf) do cbuf
         mps_p = MPSMatrix(P)
         kernel = MPSMatrixDecompositionLU(dev, M, N)
         encode!(cbuf, kernel, mps_at, mps_at, mps_p, status)
@@ -197,7 +197,7 @@ LinearAlgebra.ipiv2perm(v::MtlVector{T}, maxi::Integer) where T =
 
     B = MtlMatrix{T}(undef, M, N)
 
-    cmdbuf = commit!(cmdbuf) do cbuf
+    commit!(cmdbuf) do cbuf
         mps_b = MPSMatrix(B)
         kernel = MPSMatrixCopy(dev, M, N, false, true)
         descriptor = MPSMatrixCopyDescriptor(mps_at, mps_b)
@@ -247,13 +247,13 @@ end
     P = MtlMatrix{UInt32}(undef, 1, min(N, M))
     status = MtlArray{MPSMatrixDecompositionStatus}(undef)
 
-    cmdbuf = commitAndContinue!(cmdbuf) do cbuf
+    commitAndContinue!(cmdbuf) do cbuf
         mps_p = MPSMatrix(P)
         kernel = MPSMatrixDecompositionLU(dev, M, N)
         encode!(cbuf, kernel, mps_at, mps_at, mps_p, status)
     end
 
-    cmdbuf = commit!(cmdbuf) do cbuf
+    commit!(cmdbuf) do cbuf
         kernel = MPSMatrixCopy(dev, M, N, false, true)
         descriptor = MPSMatrixCopyDescriptor(mps_at, mps_a)
         encode!(cbuf, kernel, descriptor)

--- a/lib/mtl/command_buf.jl
+++ b/lib/mtl/command_buf.jl
@@ -77,9 +77,7 @@ end
 function MTLCommandBuffer(queue::MTLCommandQueue,
                           desc::MTLCommandBufferDescriptor=MTLCommandBufferDescriptor())
     handle = @objc [queue::id{MTLCommandQueue} commandBufferWithDescriptor:desc::id{MTLCommandBufferDescriptor}]::id{MTLCommandBuffer}
-    obj = MTLCommandBuffer(handle)
-    # command buffers are part of the queue, so we don't need to manage memory
-    return obj
+    MTLCommandBuffer(handle)
 end
 
 function MTLCommandBuffer(f::Base.Callable, queue::MTLCommandQueue,
@@ -117,7 +115,7 @@ function commit!(f::Base.Callable, cmdbuf::MTLCommandBuffer)
     enqueue!(cmdbuf)
     ret = f(cmdbuf)
     commit!(cmdbuf)
-    return cmdbuf
+    return ret
 end
 
 """


### PR DESCRIPTION
I get why we return the cmdbuf from do-block constructors, to reuse it after the commit, but it seems redundant to return the object from commit methods that already took it as an argument in the first place.
Instead, return the value returned by the callable.

I think this was an oversight with the original MTLCommandBuffer interface in the first place, given the `ret` variable.