### PR TITLE
Remove/fix unused exports

### DIFF
--- a/lib/mtl/buffer.jl
+++ b/lib/mtl/buffer.jl
@@ -1,4 +1,4 @@
-export MTLBuffer, device, handle
+export MTLBuffer
 
 # From docs: "MSL implements a buffer as a pointer to a built-in or user defined data type described in the
 # device, constant, or threadgroup address space.

--- a/lib/mtl/command_enc/compute.jl
+++ b/lib/mtl/command_enc/compute.jl
@@ -1,6 +1,6 @@
 export MTLComputeCommandEncoder
-export set_function!, set_buffer!, set_bytes!, dispatchThreads!, endEncoding!
-export set_buffers!, append_current_function!
+export set_function!, set_buffer!, dispatchThreadgroups!, endEncoding!
+export append_current_function!
 
 @cenum MTLDispatchType::NSUInteger begin
     MTLDispatchTypeSerial = 0

--- a/src/array.jl
+++ b/src/array.jl
@@ -1,6 +1,6 @@
 # host array
 
-export MtlArray, MtlVector, MtlMatrix, MtlVecOrMat, mtl, is_shared, is_managed, is_private
+export MtlArray, MtlVector, MtlMatrix, MtlVecOrMat, mtl, is_shared, is_managed, is_private, device
 
 function hasfieldcount(@nospecialize(dt))
     try


### PR DESCRIPTION
Follow up to #356. 

lib/mtl/buffer.jl no longer exports a `device` function, so I moved it to src/array.jl, `dispatchThreads!` was renamed to `dispatchThreadgroups!`, and the rest were removed during various refactors.