### PR TITLE
Define complex sqrt

### DIFF
--- a/test/device/intrinsics.jl
+++ b/test/device/intrinsics.jl
@@ -161,6 +161,15 @@ end
 
 ############################################################################################
 
+@testset "complex" begin
+    a = rand(ComplexF32,4)
+    bufferA = MtlArray(a)
+    vecA = Array(sqrt.(bufferA))
+    @test vecA ≈ sqrt.(a)
+end
+
+############################################################################################
+
 @testset "synchronization" begin
     # host/device synchronization
     let


### PR DESCRIPTION
Fixes #364.

@maleadt this was the most minimal implementation I could come up with.

I override two functions:
1. `Base.Math.exponent(::Base.IEEEFloat)` in order to avoid exception throws.
2. `Base.ssqs(x::T, y::T) where T<:Real` to avoid a `Union` type in type inference by changing [this line](https://github.com/JuliaLang/julia/blob/a14cc38512b6daab6b8417ebb8a64fc794ff89cc/base/complex.jl#L523) to `k = m==0 ? 0 : exponent(m)`.

I wonder if 2. should be fixed in Base. The Base version effectively sets `k` to `zero(m)` rather than `0` if `iszero(m)`, however `k` is supposed to be `Int` anyway. The way that I changed it, it would probably mean that Base wouldn't need to have so many type asserts for `k` (there is one in `Base.ssqs` and one in `Base.sqrt(z::Complex)`).