### PR TITLE
avoid ReshapedArray using Int128 in metal kernel

### DIFF
--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -362,13 +362,25 @@ end
 @device_function reverse_bits(x::Int8)    = ccall("extern air.reverse_bits.i8", llvmcall, Int8, (Int8,), x)
 @device_function reverse_bits(x::UInt8)   = ccall("extern air.reverse_bits.i8", llvmcall, UInt8, (UInt8,), x)
 
-@device_override function Base.MultiplicativeInverses._mul_high(a::Int64, b::Int64)
+
+function _mulhi(a::Int64, b::Int64)
     shift = sizeof(a) * 4
     mask = typemax(UInt32)
     a1, a2 = (a >> shift), a & mask
     b1, b2 = (b >> shift), b & mask
     a1b1, a1b2, a2b1 = a1*b1, a1*b2, a2*b1
-    t1 = a1b2 + Base.MultiplicativeInverses._mul_high(a2 % UInt32, b2 % UInt32)
+    t1 = a1b2 + _mulhi(a2 % UInt32, b2 % UInt32)
     t2 = a2b1 + (t1 & mask)
     a1b1 + (t1 >> shift) + (t2 >> shift)
+end
+@static if isdefined(Base.MultiplicativeInverses, :_mul_high)
+    _mulhi(a::T, b::T) where {T<:Union{Signed, Unsigned}} = Base.MultiplicativeInverses._mul_high(a, b)
+    @device_override Base.MultiplicativeInverses._mul_high(a::Int64, b::Int64) = _mulhi(a, b)
+else
+    _mulhi(a::T, b::T) where {T<:Union{Signed, Unsigned}} = ((widen(a)*b) >>> (sizeof(a)*8)) % T
+    @device_override function Base.div(a::Int64, b::Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64})
+        x = _mulhi(a, b.multiplier)
+        x += (a*b.addmul) % Int64
+        ifelse(abs(b.divisor) == 1, a*b.divisor, (signbit(x) + (x >> b.shift)) % Int64)
+    end
 end

--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -361,3 +361,14 @@ end
 @device_function reverse_bits(x::UInt16)  = ccall("extern air.reverse_bits.i16", llvmcall, UInt16, (UInt16,), x)
 @device_function reverse_bits(x::Int8)    = ccall("extern air.reverse_bits.i8", llvmcall, Int8, (Int8,), x)
 @device_function reverse_bits(x::UInt8)   = ccall("extern air.reverse_bits.i8", llvmcall, UInt8, (UInt8,), x)
+
+@device_override function Base.MultiplicativeInverses._mul_high(a::Int64, b::Int64)
+    shift = sizeof(a) * 4
+    mask = typemax(UInt32)
+    a1, a2 = (a >> shift), a & mask
+    b1, b2 = (b >> shift), b & mask
+    a1b1, a1b2, a2b1 = a1*b1, a1*b2, a2*b1
+    t1 = a1b2 + Base.MultiplicativeInverses._mul_high(a2 % UInt32, b2 % UInt32)
+    t2 = a2b1 + (t1 & mask)
+    a1b1 + (t1 >> shift) + (t2 >> shift)
+end

--- a/test/array.jl
+++ b/test/array.jl
@@ -366,4 +366,10 @@ end
     @test all(marr2 .== 2)
 end
 
+@testset "ReshapedArray" begin
+    @test Array(sum(reshape(Metal.ones(3, 10)', (5, 3, 2)); dims=1)) == fill(5, (1,3,2))
+    @test Array(sum(reshape(PermutedDimsArray(reshape(mtl(collect(Float32, 1:30)), 5, 3, 2), (3, 1, 2)), (10, 3)); dims=1)) ==
+        sum(reshape(PermutedDimsArray(reshape(Float32.(1:30), 5, 3, 2), (3, 1, 2)), (10, 3)); dims=1)
+end
+
 end


### PR DESCRIPTION
The `Base.ReshapedArray` is using `Int128` for computing the indices with `Base.MultiplicativeInverses._mul_high`. This PR adds a device override to avoid `Int128`. Without this PR, the test will error out with "unsupported use of i128 value".

fixes  #332