### PR TITLE
improve type stability of derived array

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -106,7 +106,6 @@ mutable struct MtlArray{T,N,S} <: AbstractGPUArray{T,N}
         end
         finalizer(unsafe_free!, obj)
     end
-
 end
 
 # Create MtlArray from MTLBuffer

--- a/src/array.jl
+++ b/src/array.jl
@@ -527,9 +527,9 @@ end
 
 ## derived arrays
 
-function GPUArrays.derive(::Type{T}, a::MtlArray, dims::Dims{N}, offset::Int) where {T,N}
+function GPUArrays.derive(::Type{T}, a::MtlArray{<:Any,<:Any,S}, dims::Dims{N}, offset::Int) where {T,N,S}
     offset = (a.offset * Base.elsize(a)) ÷ sizeof(T) + offset
-    MtlArray{T,N,storagemode(a)}(a.data, dims; a.maxsize, offset)
+    MtlArray{T,N,S}(a.data, dims; a.maxsize, offset)
 end
 
 


### PR DESCRIPTION
Without this PR:
```julia-repl
julia> using Metal, Test

julia> @inferred reshape(mtl([1]), (1,1))
ERROR: return type MtlMatrix{Int64, Private} does not match inferred return type MtlMatrix{Int64}
```

With:
```julia-repl
julia> using Metal, Test

julia> @inferred reshape(mtl([1]), (1,1))
1×1 MtlMatrix{Int64, Private}:
 1
```
