### PR TITLE
Unexport some high-level MPS functionality from `MPS`

### DIFF
--- a/lib/mps/images.jl
+++ b/lib/mps/images.jl
@@ -73,9 +73,7 @@ function MPSImageBox(dev, kernelWidth, kernelHeight)
 end
 
 
-## high-level blurring functionality
-
-export blur, gaussianblur, boxblur
+## high-level blurring functionality. Interface subject to change
 
 function blur(image, kernel; pixelFormat=MTL.MTLPixelFormatRGBA8Unorm)
     res = copy(image)

--- a/lib/mps/matrix.jl
+++ b/lib/mps/matrix.jl
@@ -242,7 +242,7 @@ end
 
 ## topk
 
-export MPSMatrixFindTopK, encode!, topk, topk!
+export MPSMatrixFindTopK, encode!
 
 @objcwrapper immutable=false MPSMatrixFindTopK <: MPSMatrixUnaryKernel
 
@@ -270,7 +270,7 @@ function encode!(cmdbuf::MTLCommandBuffer, kernel::MPSMatrixFindTopK, inputMatri
 end
 
 """
-    topk!(A::MtlMatrix{T}, I::MtlMatrix{Int32}, V::MtlMatrix{T}, k)
+    MPS.topk!(A::MtlMatrix{T}, I::MtlMatrix{Int32}, V::MtlMatrix{T}, k)
                                                      where {T<:MtlFloat}
 
 Compute the top `k` values and their corresponding indices column-wise in a matrix `A`.
@@ -281,6 +281,9 @@ Return the indices in `I` and the values in `V`.
 Uses `MPSMatrixFindTopK`.
 
 See also: [`topk`](@ref).
+
+!!! warn
+    This interface is experimental, and might change without warning.
 """
 function topk!(A::MtlMatrix{T}, I::MtlMatrix{UInt32}, V::MtlMatrix{T}, k) where {T<:MtlFloat}
     size(I,1) >= k         || throw(ArgumentError("Matrix 'I' must be large enough for k rows"))
@@ -311,7 +314,7 @@ end
 end
 
 """
-    topk(A::MtlMatrix{T}, k) where {T<:MtlFloat}
+    MPS.topk(A::MtlMatrix{T}, k) where {T<:MtlFloat}
 
 Compute the top `k` values and their corresponding indices column-wise in a matrix `A`.
 Return the indices in `I` and the values in `V`.
@@ -321,6 +324,9 @@ Return the indices in `I` and the values in `V`.
 Uses `MPSMatrixFindTopK`.
 
 See also: [`topk!`](@ref).
+
+!!! warn
+    This interface is experimental, and might change without warning.
 """
 function topk(A::MtlMatrix{T,S}, k) where {T<:MtlFloat,S}
     s = (k,size(A,2))


### PR DESCRIPTION
These functions were kind of just thrown in from when I was newer to contributing. The topk functions are fine but feel out of place, but the blurring functions were mostly for testing the filters, and I don't think they should be used in their current form.

I think we should unexport while we have breaking changes waiting to be released, and reintroduce in a more thought-out form in the future.