### PR TITLE
Make 1.11 CI success mandatory.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,9 +29,6 @@ steps:
               - "nightly"
           adjustments:
             - with:
-                julia: "1.11"
-              soft_fail: true
-            - with:
                 julia: "nightly"
               soft_fail: true
 


### PR DESCRIPTION
Should have been fixed by https://github.com/JuliaGPU/GPUCompiler.jl/pull/618, which is part of GPUCompiler 0.27.2
Closes https://github.com/JuliaGPU/Metal.jl/issues/370