### PR TITLE
Remove broken link in Docs

### DIFF
--- a/docs/src/usage/kernel.md
+++ b/docs/src/usage/kernel.md
@@ -87,4 +87,3 @@ Additional notes:
 ## Other Helpful Links
 
 [Metal Shading Language Specification](https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf)
-[An Introduction to GPU Programming course from University of Illinois](https://wiki.illinois.edu/wiki/display/ECE408/Materials+from+prior+semesters) (primarily in CUDA, but the concepts are transferable)


### PR DESCRIPTION
Unfortunately this course material seems to have been removed from the University of Illinois website, and the wayback machine version exists but no links to the actual materials work, so I propose removing it.