### PR TITLE
Remove unused [extras] section in Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -53,6 +53,3 @@ SHA = "0.7"
 SpecialFunctions = "2"
 StaticArrays = "1"
 julia = "1.10"
-
-[extras]
-SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"


### PR DESCRIPTION
We don't have a [target] in our manifest so I don't believe this is needed.