### PR TITLE
Small fix and typos

### DIFF
--- a/lib/mps/matrixrandom.jl
+++ b/lib/mps/matrixrandom.jl
@@ -111,7 +111,7 @@ synchronize_state(kern::MPSMatrixRandomMTGP32, cmdbuf::MTLCommandBuffer) =
 
 
 @inline function _mpsmat_rand!(randkern::MPSMatrixRandom, dest::MtlArray{T}, ::Type{T2};
-                        queue::MTLCommandQueue = global_queue(device()),
+                        queue::MTLCommandQueue = global_queue(randkern.device),
                         async::Bool=false) where {T,T2}
     byteoffset = dest.offset * sizeof(T)
     bytesize = sizeof(dest)

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -80,7 +80,7 @@ end
 
     macos = macos_version()
     metal = metal_support()
-    # we support down to macOS 10.13, which support AIR 2.5
+    # we support down to macOS 13, which supports AIR 2.5
     # so always target that version for now
     air = v"2.5"
     @assert air <= air_support()


### PR DESCRIPTION
Make the default argument for `_mpsmat_rand!` slightly more correct.

Also fix a couple unrelated typos that I caught while exploring.