### PR TITLE
Add CI for macOS 15

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,6 +36,19 @@ steps:
   - group: ":eyes: Special"
     depends_on: "julia"
     steps:
+      - label: "macOS 15"
+        plugins:
+          - JuliaCI/julia#v1:
+              version: "1.10"
+          - JuliaCI/julia-test#v1:
+              test_args: "--quickfail"
+        agents:
+          queue: "julia"
+          os: "macos"
+          arch: "aarch64"
+          macos_version: "15.0"
+        if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
+        timeout_in_minutes: 60
       - label: "{{matrix.storage}} array storage"
         plugins:
           - JuliaCI/julia#v1:
@@ -54,7 +67,7 @@ steps:
               - "shared"
               - "managed"
         commands: |
-          echo -e "[Metal]\ndefault_storage = \"{{matrix.storage}}\"" >LocalPreferences.toml
+          echo -e "[Metal]\ndefault_storage = \"{{matrix.storage}}\"" > LocalPreferences.toml
       - label: "API validation"
         plugins:
           - JuliaCI/julia#v1:


### PR DESCRIPTION
Considering this is in the `julia` queue instead of the `juliaecosystem` queue, should the macOS 15 runner only run the output tests?

I mostly created this PR to test if anything special was needed to run tests on the `julia` queue.