### PR TITLE
Make `lu` results have same storage mode as input

### DIFF
--- a/lib/mps/linalg.jl
+++ b/lib/mps/linalg.jl
@@ -118,7 +118,7 @@ LinearAlgebra.ipiv2perm(v::MtlVector{T}, maxi::Integer) where T =
     dev = device()
     queue = global_queue(dev)
 
-    At = MtlMatrix{T,PrivateStorage}(undef, (N, M))
+    At = similar(A, (N, M))
     mps_a = MPSMatrix(A)
     mps_at = MPSMatrix(At)
 
@@ -137,7 +137,7 @@ LinearAlgebra.ipiv2perm(v::MtlVector{T}, maxi::Integer) where T =
         encode!(cbuf, kernel, mps_at, mps_at, mps_p, status)
     end
 
-    B = MtlMatrix{T}(undef, M, N)
+    B = similar(A, M, N)
 
     commit!(cmdbuf) do cbuf
         mps_b = MPSMatrix(B)
@@ -176,7 +176,7 @@ end
     dev = device()
     queue = global_queue(dev)
 
-    At = MtlMatrix{T,PrivateStorage}(undef, (N, M))
+    At = similar(A, (N, M))
     mps_a = MPSMatrix(A)
     mps_at = MPSMatrix(At)
 

--- a/lib/mps/linalg.jl
+++ b/lib/mps/linalg.jl
@@ -118,7 +118,7 @@ LinearAlgebra.ipiv2perm(v::MtlVector{T}, maxi::Integer) where T =
     dev = device()
     queue = global_queue(dev)
 
-    At = similar(A, (N, M))
+    At = MtlMatrix{T,PrivateStorage}(undef, (N, M))
     mps_a = MPSMatrix(A)
     mps_at = MPSMatrix(At)
 
@@ -128,7 +128,7 @@ LinearAlgebra.ipiv2perm(v::MtlVector{T}, maxi::Integer) where T =
         encode!(cbuf, kernel, descriptor)
     end
 
-    P = MtlMatrix{UInt32}(undef, 1, min(N, M))
+    P = similar(A, UInt32, 1, min(N, M))
     status = MtlArray{MPSMatrixDecompositionStatus}(undef)
 
     commitAndContinue!(cmdbuf) do cbuf
@@ -176,7 +176,7 @@ end
     dev = device()
     queue = global_queue(dev)
 
-    At = similar(A, (N, M))
+    At = MtlMatrix{T,PrivateStorage}(undef, (N, M))
     mps_a = MPSMatrix(A)
     mps_at = MPSMatrix(At)
 
@@ -186,7 +186,7 @@ end
         encode!(cbuf, kernel, descriptor)
     end
 
-    P = MtlMatrix{UInt32}(undef, 1, min(N, M))
+    P = similar(A, UInt32, 1, min(N, M))
     status = MtlArray{MPSMatrixDecompositionStatus}(undef)
 
     commitAndContinue!(cmdbuf) do cbuf

--- a/test/mps/linalg.jl
+++ b/test/mps/linalg.jl
@@ -191,22 +191,29 @@ end
 end
 
 @testset "decompositions" begin
+    testreturntype(_,_) = false
+    testreturntype(luobj::LU{<:Any,<:MtlArray{<:Any,<:Any,S},<:MtlArray{<:Any,<:Any,S}},::MtlArray{<:Any,<:Any,S}) where S = true
+
     A = MtlMatrix(rand(Float32, 1024, 1024))
     lua = lu(A)
+    @test testreturntype(lua,A)
     @test lua.L * lua.U ≈ MtlMatrix(lua.P) * A
 
     A = MtlMatrix(rand(Float32, 1024, 512))
     lua = lu(A)
+    @test testreturntype(lua,A)
     @test lua.L * lua.U ≈ MtlMatrix(lua.P) * A
 
     A = MtlMatrix(rand(Float32, 512, 1024))
     lua = lu(A)
+    @test testreturntype(lua,A)
     @test lua.L * lua.U ≈ MtlMatrix(lua.P) * A
 
     a = rand(Float32, 1024, 1024)
     A = MtlMatrix(a)
     B = MtlMatrix(a)
     lua = lu!(A)
+    @test testreturntype(lua,A)
     @test lua.L * lua.U ≈ MtlMatrix(lua.P) * B
 
     A = MtlMatrix{Float32}([1 2; 0 0])

--- a/test/mps/linalg.jl
+++ b/test/mps/linalg.jl
@@ -190,30 +190,28 @@ end
     end
 end
 
+using Metal: storagemode
 @testset "decompositions" begin
-    testreturntype(_,_) = false
-    testreturntype(luobj::LU{<:Any,<:MtlArray{<:Any,<:Any,S},<:MtlArray{<:Any,<:Any,S}},::MtlArray{<:Any,<:Any,S}) where S = true
-
     A = MtlMatrix(rand(Float32, 1024, 1024))
     lua = lu(A)
-    @test testreturntype(lua,A)
+    @test storagemode(lua.factors) == storagemode(lua.ipiv) == storagemode(A)
     @test lua.L * lua.U ≈ MtlMatrix(lua.P) * A
 
     A = MtlMatrix(rand(Float32, 1024, 512))
     lua = lu(A)
-    @test testreturntype(lua,A)
+    @test storagemode(lua.factors) == storagemode(lua.ipiv) == storagemode(A)
     @test lua.L * lua.U ≈ MtlMatrix(lua.P) * A
 
     A = MtlMatrix(rand(Float32, 512, 1024))
     lua = lu(A)
-    @test testreturntype(lua,A)
+    @test storagemode(lua.factors) == storagemode(lua.ipiv) == storagemode(A)
     @test lua.L * lua.U ≈ MtlMatrix(lua.P) * A
 
     a = rand(Float32, 1024, 1024)
     A = MtlMatrix(a)
     B = MtlMatrix(a)
     lua = lu!(A)
-    @test testreturntype(lua,A)
+    @test storagemode(lua.factors) == storagemode(lua.ipiv) == storagemode(A)
     @test lua.L * lua.U ≈ MtlMatrix(lua.P) * B
 
     A = MtlMatrix{Float32}([1 2; 0 0])

--- a/test/mps/linalg.jl
+++ b/test/mps/linalg.jl
@@ -194,28 +194,31 @@ using Metal: storagemode
 @testset "decompositions" begin
     A = MtlMatrix(rand(Float32, 1024, 1024))
     lua = lu(A)
-    @test storagemode(lua.factors) == storagemode(lua.ipiv) == storagemode(A)
     @test lua.L * lua.U ≈ MtlMatrix(lua.P) * A
 
     A = MtlMatrix(rand(Float32, 1024, 512))
     lua = lu(A)
-    @test storagemode(lua.factors) == storagemode(lua.ipiv) == storagemode(A)
     @test lua.L * lua.U ≈ MtlMatrix(lua.P) * A
 
     A = MtlMatrix(rand(Float32, 512, 1024))
     lua = lu(A)
-    @test storagemode(lua.factors) == storagemode(lua.ipiv) == storagemode(A)
     @test lua.L * lua.U ≈ MtlMatrix(lua.P) * A
 
     a = rand(Float32, 1024, 1024)
     A = MtlMatrix(a)
     B = MtlMatrix(a)
     lua = lu!(A)
-    @test storagemode(lua.factors) == storagemode(lua.ipiv) == storagemode(A)
     @test lua.L * lua.U ≈ MtlMatrix(lua.P) * B
 
     A = MtlMatrix{Float32}([1 2; 0 0])
     @test_throws SingularException lu(A)
+
+    altStorage = Metal.DefaultStorageMode != Metal.PrivateStorage ? Metal.PrivateStorage : Metal.SharedStorage
+    A = MtlMatrix{Float32,altStorage}(rand(Float32, 1024, 1024))
+    lua = lu(A)
+    @test storagemode(lua.factors) == storagemode(lua.ipiv) == storagemode(A)
+    lua = lu!(A)
+    @test storagemode(lua.factors) == storagemode(lua.ipiv) == storagemode(A)
 end
 
 using .MPS: MPSMatrixSoftMax, MPSMatrixLogSoftMax


### PR DESCRIPTION
Noticed while reviewing #313.