### PR TITLE
simdgroup bfloat intrinsics

### DIFF
--- a/lib/mps/MPS.jl
+++ b/lib/mps/MPS.jl
@@ -17,9 +17,9 @@ using ObjectiveC, .Foundation
 
 import GPUArrays
 
-using BFloat16s
+using BFloat16s: BFloat16
 
-const MtlFloat = Union{Float32, Float16}
+const MtlFloat = Union{Float32, Float16, BFloat16}
 
 const MPSShape = NSArray#{NSNumber}
 Base.convert(::Type{MPSShape}, tuple::Union{Vector{<:Integer},NTuple{N, <:Integer}}) where N = NSArray(NSNumber.(collect(tuple)))

--- a/lib/mps/MPS.jl
+++ b/lib/mps/MPS.jl
@@ -19,7 +19,7 @@ import GPUArrays
 
 using BFloat16s: BFloat16
 
-const MtlFloat = Union{Float32, Float16, BFloat16}
+const MtlFloat = Union{Float32, Float16}
 
 const MPSShape = NSArray#{NSNumber}
 Base.convert(::Type{MPSShape}, tuple::Union{Vector{<:Integer},NTuple{N, <:Integer}}) where N = NSArray(NSNumber.(collect(tuple)))

--- a/lib/mps/datatype.jl
+++ b/lib/mps/datatype.jl
@@ -5,7 +5,7 @@ const jl_mps_to_typ = Dict{MPSDataType, DataType}()
 for type in [
         :Bool, :UInt8, :UInt16, :UInt32, :UInt64, :Int8, :Int16, :Int32, :Int64,
         :Float16, :BFloat16, :Float32, (:ComplexF16, :MPSDataTypeComplexFloat16),
-        (:ComplexF32, :MPSDataTypeComplexFloat32),
+        (:ComplexF32, :MPSDataTypeComplexFloat32), (Complex{BFloat16}, :MPSDataTypeComplexBFloat16)
     ]
     jltype, mpstype = if type isa Symbol
         type, Symbol(:MPSDataType, type)

--- a/src/Metal.jl
+++ b/src/Metal.jl
@@ -12,6 +12,7 @@ using ExprTools: splitdef, combinedef
 using ObjectiveC, .CoreFoundation, .Foundation, .Dispatch, .OS
 import ObjectiveC: is_macos
 import KernelAbstractions
+using BFloat16s: BFloat16
 using ScopedValues
 
 using Reexport: @reexport

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -296,7 +296,8 @@ function GPUCompiler.finish_ir!(@nospecialize(job::MetalCompilerJob),
     # pointer type information for typed intrinsics
     # (this is consumed by the LLVM IR downgrader)
     for (jltyp, llvmtyp) in (Int32 => :i32, Int64 => :i64,
-                             Float16 => :f16, Float32 => :f32),
+                             Float16 => :f16, Float32 => :f32,
+                             BFloat16 => :bf16),
         (as, asname) in (AS.Device => "global", AS.ThreadGroup => "local")
 
         # map of intrinsics to pointer operand indices and eltypes

--- a/src/device/intrinsics/simd.jl
+++ b/src/device/intrinsics/simd.jl
@@ -58,6 +58,15 @@ for (jltype, suffix) in ((:Float16, "f16"), (:Float32, "f32"), (:BFloat16, "bf16
     end
 
     @eval begin
+        # Build a fragment whose elements are all `val`, with matrix provenance. This is the
+        # `make_filled_simdgroup_matrix` builtin; unlike assembling an `NTuple` lane vector,
+        # its result is a real matrix value, which is the only form `simdgroup_store` accepts
+        # for `bfloat` (an assembled `<64 x bfloat>` stores zeros — see the MtlSimdgroupMatrix
+        # fill constructor).
+        @device_function simdgroup_matrix_init_filled(val::$jltype) =
+            ccall($"extern air.simdgroup_matrix_8x8_init_filled.v64$suffix.$suffix",
+                llvmcall, NTuple{64, VecElement{$jltype}}, ($jltype,), val)
+
         @device_function simdgroup_multiply(
             a::NTuple{64, VecElement{$jltype}},
             b::NTuple{64, VecElement{$jltype}},
@@ -148,10 +157,12 @@ Base.size(m::MtlSimdgroupMatrix) = size(typeof(m))
 Base.eltype(::Type{<:MtlSimdgroupMatrix{T}}) where {T} = T
 Base.eltype(m::MtlSimdgroupMatrix) = eltype(typeof(m))
 
-# Fill constructor: materialize a fragment whose elements are all `val`.
+# Fill constructor: materialize a fragment whose elements are all `val`. Uses the
+# `init_filled` intrinsic rather than assembling a lane tuple so the fragment has matrix
+# provenance (required for storing `BFloat16`; see `simdgroup_matrix_init_filled`).
 @inline function MtlSimdgroupMatrix{T,8,8}(val::T) where {T}
     return _unsafe_wrap_simdgroup_matrix(MtlSimdgroupMatrix{T,8,8},
-                                         ntuple(_ -> VecElement{T}(val), Val(64)))
+                                         simdgroup_matrix_init_filled(val))
 end
 
 @inline Base.zero(::Type{MtlSimdgroupMatrix{T,8,8}}) where {T} =

--- a/src/device/intrinsics/simd.jl
+++ b/src/device/intrinsics/simd.jl
@@ -124,7 +124,7 @@ Returns `a * b + c`.
     MtlSimdgroupMatrix{T,R,C}
 
 Typed wrapper around a SIMD-group matrix fragment. `T` is the element type
-(`Float16` or `Float32`); `R` and `C` are the matrix dimensions. Only the
+(`Float16`, `Float32`, or `BFloat16`); `R` and `C` are the matrix dimensions. Only the
 8×8 shape is supported by current Apple GPUs.
 
 The fragment data is distributed across the 32 lanes of a SIMD-group; the

--- a/src/device/intrinsics/simd.jl
+++ b/src/device/intrinsics/simd.jl
@@ -274,7 +274,7 @@ Return `data` from the thread whose SIMD lane ID is `simd_lane_id`. The `simd_la
 needs to be a valid SIMD lane ID but doesn't have to be the same for all threads in the
 SIMD-group
 
-T must be one of the following: Float32, Float16, BFloat16, Int32, UInt32, Int16, UInt16, Int8, or UInt8
+T must be one of the following: Float32, Float16, Int32, UInt32, Int16, UInt16, Int8, or UInt8
 """
 simd_shuffle
 
@@ -287,7 +287,7 @@ The value for `delta` must be the same for all threads in the SIMD-group. This f
 doesn't modify the upper `delta` lanes of `data` because it doesn't wrap values around
 the SIMD-group.
 
-T must be one of the following: Float32, Float16, BFloat16, Int32, UInt32, Int16, UInt16, Int8, or UInt8
+T must be one of the following: Float32, Float16, Int32, UInt32, Int16, UInt16, Int8, or UInt8
 """
 simd_shuffle_down
 
@@ -300,7 +300,7 @@ lane ID minus `delta`.
 The value of `delta` must be the same for all threads in a SIMD-group. This function doesn't
 modify the lower `delta` lanes of `data` because it doesn't wrap values around the SIMD-group.
 
-T must be one of the following: Float32, Float16, BFloat16, Int32, UInt32, Int16, UInt16, Int8, or UInt8
+T must be one of the following: Float32, Float16, Int32, UInt32, Int16, UInt16, Int8, or UInt8
 """
 simd_shuffle_up
 
@@ -318,7 +318,7 @@ The value of `delta` needs to be the same for all threads in a SIMD-group.
 The `modulo` parameter defines the vector width that splits the SIMD-group into separate vectors
  and must be 2, 4, 8, 16, or 32.
 
-T must be one of the following: Float32, Float16, BFloat16, Int32, UInt32, Int16, UInt16, Int8, or UInt8
+T must be one of the following: Float32, Float16, Int32, UInt32, Int16, UInt16, Int8, or UInt8
 """
 simd_shuffle_and_fill_down
 
@@ -336,7 +336,7 @@ The value of `delta` needs to be the same for all threads in a SIMD-group.
 The `modulo` parameter defines the vector width that splits the SIMD-group into separate vectors
  and must be 2, 4, 8, 16, or 32.
 
-T must be one of the following: Float32, Float16, BFloat16, Int32, UInt32, Int16, UInt16, Int8, or UInt8
+T must be one of the following: Float32, Float16, Int32, UInt32, Int16, UInt16, Int8, or UInt8
 """
 simd_shuffle_and_fill_up
 

--- a/src/device/intrinsics/simd.jl
+++ b/src/device/intrinsics/simd.jl
@@ -18,7 +18,7 @@ end
 # dims = (epr, 8), strides = (1, epr) and an unswapped origin. when targeting older AIR
 # versions, `finish_ir!` rewrites these calls to the legacy elements-per-row + transpose
 # flag signature (keep in sync with the downgrade rule in src/compiler/compilation.jl).
-for (jltype, suffix) in ((:Float16, "f16"), (:Float32, "f32"))
+for (jltype, suffix) in ((:Float16, "f16"), (:Float32, "f32"), (:BFloat16, "bf16"))
     for as in (AS.Device, AS.ThreadGroup)
         @eval begin
             @device_function simdgroup_load(
@@ -83,7 +83,7 @@ end
     simdgroup_load(data::MtlDeviceArray{T}, matrix_origin=(1, 1), Val(transpose)=Val(true))
 
 Loads data from device or threadgroup memory into an 8x8 SIMD-group matrix
-and returns it. `T` must be either `Float16` or `Float32`.
+and returns it. `T` must be either `Float16`, `Float32`, or `BFloat16`.
 
 # Arguments
 - `matrix_origin::NTuple{2, Int64}=(1, 1)`: origin in the source memory to load from.
@@ -96,7 +96,7 @@ and returns it. `T` must be either `Float16` or `Float32`.
     simdgroup_store(src, dest::MtlDeviceArray{T}, matrix_origin=(1, 1), Val(transpose)=Val(true))
 
 Stores data from an 8x8 SIMD-group matrix into device or threadgroup memory.
-`T` must be either `Float16` or `Float32`.
+`T` must be either `Float16`, `Float32`, or `BFloat16`.
 
 # Arguments
 - `matrix_origin::NTuple{2, Int64}=(1, 1)`: origin in the destination memory to store to.
@@ -192,6 +192,7 @@ end
 
 simd_shuffle_map = ((Float32, "f32"),
                     (Float16, "f16"),
+                    (BFloat16,"bf16"),
                     (Int32,   "s.i32"),
                     (UInt32,  "u.i32"),
                     (Int16,   "s.i16"),
@@ -274,7 +275,7 @@ Return `data` from the thread whose SIMD lane ID is `simd_lane_id`. The `simd_la
 needs to be a valid SIMD lane ID but doesn't have to be the same for all threads in the
 SIMD-group
 
-T must be one of the following: Float32, Float16, Int32, UInt32, Int16, UInt16, Int8, or UInt8
+T must be one of the following: Float32, Float16, BFloat16, Int32, UInt32, Int16, UInt16, Int8, or UInt8
 """
 simd_shuffle
 
@@ -287,7 +288,7 @@ The value for `delta` must be the same for all threads in the SIMD-group. This f
 doesn't modify the upper `delta` lanes of `data` because it doesn't wrap values around
 the SIMD-group.
 
-T must be one of the following: Float32, Float16, Int32, UInt32, Int16, UInt16, Int8, or UInt8
+T must be one of the following: Float32, Float16, BFloat16, Int32, UInt32, Int16, UInt16, Int8, or UInt8
 """
 simd_shuffle_down
 
@@ -300,7 +301,7 @@ lane ID minus `delta`.
 The value of `delta` must be the same for all threads in a SIMD-group. This function doesn't
 modify the lower `delta` lanes of `data` because it doesn't wrap values around the SIMD-group.
 
-T must be one of the following: Float32, Float16, Int32, UInt32, Int16, UInt16, Int8, or UInt8
+T must be one of the following: Float32, Float16, BFloat16, Int32, UInt32, Int16, UInt16, Int8, or UInt8
 """
 simd_shuffle_up
 
@@ -318,7 +319,7 @@ The value of `delta` needs to be the same for all threads in a SIMD-group.
 The `modulo` parameter defines the vector width that splits the SIMD-group into separate vectors
  and must be 2, 4, 8, 16, or 32.
 
-T must be one of the following: Float32, Float16, Int32, UInt32, Int16, UInt16, Int8, or UInt8
+T must be one of the following: Float32, Float16, BFloat16, Int32, UInt32, Int16, UInt16, Int8, or UInt8
 """
 simd_shuffle_and_fill_down
 
@@ -336,7 +337,7 @@ The value of `delta` needs to be the same for all threads in a SIMD-group.
 The `modulo` parameter defines the vector width that splits the SIMD-group into separate vectors
  and must be 2, 4, 8, 16, or 32.
 
-T must be one of the following: Float32, Float16, Int32, UInt32, Int16, UInt16, Int8, or UInt8
+T must be one of the following: Float32, Float16, BFloat16, Int32, UInt32, Int16, UInt16, Int8, or UInt8
 """
 simd_shuffle_and_fill_up
 

--- a/src/device/intrinsics/simd.jl
+++ b/src/device/intrinsics/simd.jl
@@ -192,7 +192,6 @@ end
 
 simd_shuffle_map = ((Float32, "f32"),
                     (Float16, "f16"),
-                    (BFloat16,"bf16"),
                     (Int32,   "s.i32"),
                     (UInt32,  "u.i32"),
                     (Int16,   "s.i16"),

--- a/src/device/intrinsics/simd.jl
+++ b/src/device/intrinsics/simd.jl
@@ -58,11 +58,9 @@ for (jltype, suffix) in ((:Float16, "f16"), (:Float32, "f32"), (:BFloat16, "bf16
     end
 
     @eval begin
-        # Build a fragment whose elements are all `val`, with matrix provenance. This is the
-        # `make_filled_simdgroup_matrix` builtin; unlike assembling an `NTuple` lane vector,
-        # its result is a real matrix value, which is the only form `simdgroup_store` accepts
-        # for `bfloat` (an assembled `<64 x bfloat>` stores zeros — see the MtlSimdgroupMatrix
-        # fill constructor).
+        # Build a fragment whose elements are all `val`, with matrix provenance.
+        # This is the `make_filled_simdgroup_matrix` builtin and must be used
+        # to initialize any simdgroup_matrix
         @device_function simdgroup_matrix_init_filled(val::$jltype) =
             ccall($"extern air.simdgroup_matrix_8x8_init_filled.v64$suffix.$suffix",
                 llvmcall, NTuple{64, VecElement{$jltype}}, ($jltype,), val)
@@ -157,9 +155,7 @@ Base.size(m::MtlSimdgroupMatrix) = size(typeof(m))
 Base.eltype(::Type{<:MtlSimdgroupMatrix{T}}) where {T} = T
 Base.eltype(m::MtlSimdgroupMatrix) = eltype(typeof(m))
 
-# Fill constructor: materialize a fragment whose elements are all `val`. Uses the
-# `init_filled` intrinsic rather than assembling a lane tuple so the fragment has matrix
-# provenance (required for storing `BFloat16`; see `simdgroup_matrix_init_filled`).
+# Fill constructor: materialize a fragment whose elements are all `val`.
 @inline function MtlSimdgroupMatrix{T,8,8}(val::T) where {T}
     return _unsafe_wrap_simdgroup_matrix(MtlSimdgroupMatrix{T,8,8},
                                          simdgroup_matrix_init_filled(val))

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -369,9 +369,12 @@ end
 
 ## host entry points
 
-@inline gemm_simd_eltype(::Type{<:Union{Float16, Float32}},
-                          ::Type{<:Union{Float16, Float32}},
-                          ::Type{<:Union{Float16, Float32}}) = true
+# The simd kernel stages A/B as Float32 and contracts in Float32, so the only eltype-specific
+# simdgroup ops are the load/store of `C`; `BFloat16` rides the same `bf16` simdgroup intrinsics
+# (re-typed from i16 by GPUCompiler before Julia 1.13). See `device/intrinsics/simd.jl`.
+@inline gemm_simd_eltype(::Type{<:Union{Float16, Float32, BFloat16}},
+                          ::Type{<:Union{Float16, Float32, BFloat16}},
+                          ::Type{<:Union{Float16, Float32, BFloat16}}) = true
 @inline gemm_simd_eltype(::Type, ::Type, ::Type) = false
 
 # Operand-support predicate for the simdgroup kernel, mirroring `supports_mps_matmul` /

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -90,6 +90,17 @@ end
         simdgroup_multiply_accumulate(afrag[ti], bfrag[tj], acc[idx])
     end
 
+# Whether an `R`-typed fragment assembled in registers (via `cvt`) can be written straight to
+# device memory with `simdgroup_store`. Apple's frontend only ever materializes a simdgroup
+# matrix through a matrix intrinsic (load / multiply / init_filled), never by assembling a
+# `<64 x T>` with `insertelement`. The back-end tolerates an assembled `<64 x half>`/`<64 x
+# float>` operand, but an assembled `<64 x bfloat>` stores zeros — verified on M1: Apple's own
+# `init_filled`+store of `bfloat` runs correctly, while a `cvt`-assembled fragment does not. So
+# `BFloat16` outputs route through the f32 scratch + scalar-convert epilogue, which stores the
+# f32 accumulator (matrix provenance intact) and never assembles a bfloat fragment.
+@inline simd_direct_store(::Type) = true
+@inline simd_direct_store(::Type{BFloat16}) = false
+
 # store one full (in-bounds) 8x8 fragment to C with α/β applied
 @inline function store_frag!(C::MtlDeviceArray{R}, accidx, gr, gc, alpha, beta,
                               ::Val{SIMPLE}) where {R, SIMPLE}
@@ -114,7 +125,7 @@ end
     ntuple(Val(TM * TN)) do idx
         ti = (idx - 1) % TM; tj = (idx - 1) ÷ TM
         gr = bm0 + sm0 + ti * 8; gc = bn0 + sn0 + tj * 8
-        if !EDGE || (gr + 8 <= M && gc + 8 <= N)
+        if (!EDGE || (gr + 8 <= M && gc + 8 <= N)) && simd_direct_store(R)
             store_frag!(C, acc[idx], gr, gc, alpha, beta, Val(SIMPLE))
         else
             simdgroup_store(acc[idx], scratch, (1, sc0 + 1))
@@ -390,8 +401,9 @@ function gemm_simd!(C, A, B, alpha, beta, cA::Char, cB::Char)
     BM = 8 * TM * WM; BN = 8 * TN * WN
     threads = WM * WN * 32
     groups = (cld(M, BM), cld(N, BN))
-    # aligned tiles skip the bounds-checked edge path; α=1,β=0 skips the α/β arithmetic
-    edge = !(M % BM == 0 && N % BN == 0)
+    # aligned tiles skip the bounds-checked edge path; α=1,β=0 skips the α/β arithmetic.
+    # `BFloat16` outputs always need the edge path's f32 scratch (see `simd_direct_store`).
+    edge = !(M % BM == 0 && N % BN == 0) || !simd_direct_store(eltype(C))
     simple = isone(alpha) && iszero(beta)
     @metal threads=threads groups=groups gemm_simd_kernel!(
         C, A, B, Float32(alpha), Float32(beta), Int(M), Int(N), Int(K),

--- a/test/bfloat16.jl
+++ b/test/bfloat16.jl
@@ -54,3 +54,19 @@ if BFloat16s.llvm_arithmetic
         @test occursin("air.fabs.f32", air)
     end
 end
+
+# The simdgroup-matrix AIR intrinsics are typed `bf16`. Before Julia 1.13 `BFloat16` lowers to
+# `i16`, so these calls reach AIR with `i16` operands until GPUCompiler's `promote_bf16_intrinsics!`
+# re-types them to native `bfloat`; on 1.13+ they are native to begin with. Either way the AIR must
+# carry `<64 x bfloat>` — this asserts that on every path (and so fails if the pass regresses).
+@testset "simdgroup matrix codegen" begin
+    sg_mul(c, a, b) = (simdgroup_store(simdgroup_multiply(simdgroup_load(a), simdgroup_load(b)), c); return)
+    T = MtlDeviceMatrix{BFloat16,1}
+    air = sprint(io -> Metal.code_native(io, sg_mul, Tuple{T,T,T}; kernel=true))
+    @test occursin("simdgroup_matrix_8x8_load.v64bf16", air)
+    @test occursin("simdgroup_matrix_8x8_multiply_accumulate.v64bf16", air)
+    @test occursin("simdgroup_matrix_8x8_store.v64bf16", air)
+    # native bfloat operands, not the i16 lowering
+    @test occursin("<64 x bfloat>", air)
+    @test !occursin("<64 x i16>", air)
+end

--- a/test/device/intrinsics/simd.jl
+++ b/test/device/intrinsics/simd.jl
@@ -356,7 +356,7 @@ using Metal: metal_support
 end # @testset "shuffle functions"
 
 @testset "matrix functions" begin
-    simdgroup_types = [Float16, Float32]#, BFloat16]
+    simdgroup_types = [Float16, Float32, BFloat16]
     @testset "load_store($typ)" for typ in simdgroup_types
         function kernel(a::MtlDeviceArray{T}, b::MtlDeviceArray{T},
                             origin_a=(1, 1), origin_b=(1, 1)) where {T}

--- a/test/device/intrinsics/simd.jl
+++ b/test/device/intrinsics/simd.jl
@@ -1,7 +1,7 @@
 using Metal: metal_support
 
 @testset "shuffle functions" begin
-    shuffle_test_types = [Float32, Float16, BFloat16,
+    shuffle_test_types = [Float32, Float16,
                           Int32, UInt32, Int16, UInt16,
                           Int8, UInt8]
     @testset "simd_shuffle" begin

--- a/test/device/intrinsics/simd.jl
+++ b/test/device/intrinsics/simd.jl
@@ -535,13 +535,13 @@ end # @testset "shuffle functions"
     end
 
     @testset "MtlSimdgroupMatrix type" begin
-        @testset for T in (Float16, Float32, BFloat16)
+        @testset for T in simdgroup_types
             @test eltype(MtlSimdgroupMatrix{T,8,8}) === T
             @test size(MtlSimdgroupMatrix{T,8,8}) === (8, 8)
         end
     end
 
-    @testset "MtlSimdgroupMatrix fill($T)" for T in (Float16, Float32, BFloat16)
+    @testset "MtlSimdgroupMatrix fill($T)" for T in simdgroup_types
         function kernel(out::MtlDeviceMatrix{T}, val::T) where {T}
             m = MtlSimdgroupMatrix{T,8,8}(val)
             simdgroup_store(m, out)
@@ -553,7 +553,7 @@ end # @testset "shuffle functions"
         @test all(Array(out) .== T(3.5))
     end
 
-    @testset "MtlSimdgroupMatrix zero($T)" for T in (Float16, Float32, BFloat16)
+    @testset "MtlSimdgroupMatrix zero($T)" for T in simdgroup_types
         function kernel(out::MtlDeviceMatrix{T}) where {T}
             m = zero(MtlSimdgroupMatrix{T,8,8})
             simdgroup_store(m, out)
@@ -565,7 +565,7 @@ end # @testset "shuffle functions"
         @test all(Array(out) .== zero(T))
     end
 
-    @testset "MtlSimdgroupMatrix load_store($T)" for T in (Float16, Float32, BFloat16)
+    @testset "MtlSimdgroupMatrix load_store($T)" for T in simdgroup_types
         function kernel(a::MtlDeviceMatrix{T}, b::MtlDeviceMatrix{T}) where {T}
             m = simdgroup_load(MtlSimdgroupMatrix{T,8,8}, a)
             simdgroup_store(m, b)
@@ -578,7 +578,7 @@ end # @testset "shuffle functions"
         @test Array(a) == Array(b)
     end
 
-    @testset "MtlSimdgroupMatrix load_store with origin($T)" for T in (Float16, Float32, BFloat16)
+    @testset "MtlSimdgroupMatrix load_store with origin($T)" for T in simdgroup_types
         function kernel(a::MtlDeviceMatrix{T}, b::MtlDeviceMatrix{T},
                         origin_a::NTuple{2,Int64}, origin_b::NTuple{2,Int64}) where {T}
             m = simdgroup_load(MtlSimdgroupMatrix{T,8,8}, a, origin_a)
@@ -592,7 +592,7 @@ end # @testset "shuffle functions"
         @test Array(a)[4:11, 2:9] == Array(b)[3:10, 5:12]
     end
 
-    @testset "MtlSimdgroupMatrix multiply($T)" for T in (Float16, Float32, BFloat16)
+    @testset "MtlSimdgroupMatrix multiply($T)" for T in simdgroup_types
         function kernel(a::MtlDeviceMatrix{T}, b::MtlDeviceMatrix{T}, c::MtlDeviceMatrix{T}) where {T}
             ma = simdgroup_load(MtlSimdgroupMatrix{T,8,8}, a)
             mb = simdgroup_load(MtlSimdgroupMatrix{T,8,8}, b)
@@ -607,7 +607,7 @@ end # @testset "shuffle functions"
         @test Array(a) * Array(b) ≈ Array(c) rtol=sg_rtol(T)
     end
 
-    @testset "MtlSimdgroupMatrix muladd($T)" for T in (Float16, Float32, BFloat16)
+    @testset "MtlSimdgroupMatrix muladd($T)" for T in simdgroup_types
         function kernel(a::MtlDeviceMatrix{T}, b::MtlDeviceMatrix{T},
                         c::MtlDeviceMatrix{T}, d::MtlDeviceMatrix{T}) where {T}
             ma = simdgroup_load(MtlSimdgroupMatrix{T,8,8}, a)
@@ -627,7 +627,7 @@ end # @testset "shuffle functions"
 
     # Composed K-loop GEMM: C(8×8) = A(8×K) * B(K×8) with K=32, accumulating
     # four 8×8×8 fragment MMAs.
-    @testset "MtlSimdgroupMatrix K-loop GEMM($T)" for T in (Float16, Float32, BFloat16)
+    @testset "MtlSimdgroupMatrix K-loop GEMM($T)" for T in simdgroup_types
         function kernel(A::MtlDeviceMatrix{T}, B::MtlDeviceMatrix{T}, C::MtlDeviceMatrix{T}) where {T}
             acc = zero(MtlSimdgroupMatrix{T,8,8})
             for k in 0:3
@@ -648,7 +648,7 @@ end # @testset "shuffle functions"
 
     # Threadgroup-memory variant: stage tiles through threadgroup memory, then
     # load fragments from there. Mirrors how Flash Attention stages K/V tiles.
-    @testset "MtlSimdgroupMatrix threadgroup load($T)" for T in (Float16, Float32, BFloat16)
+    @testset "MtlSimdgroupMatrix threadgroup load($T)" for T in simdgroup_types
         function kernel(a::MtlDeviceMatrix{T}, b::MtlDeviceMatrix{T}) where {T}
             pos = thread_position_in_threadgroup()
             tg = MtlThreadGroupArray(T, (8, 8))

--- a/test/device/intrinsics/simd.jl
+++ b/test/device/intrinsics/simd.jl
@@ -1,7 +1,7 @@
 using Metal: metal_support
 
 @testset "shuffle functions" begin
-    shuffle_test_types = [Float32, Float16,# BFloat16,
+    shuffle_test_types = [Float32, Float16, BFloat16,
                           Int32, UInt32, Int16, UInt16,
                           Int8, UInt8]
     @testset "simd_shuffle" begin

--- a/test/device/intrinsics/simd.jl
+++ b/test/device/intrinsics/simd.jl
@@ -356,7 +356,14 @@ using Metal: metal_support
 end # @testset "shuffle functions"
 
 @testset "matrix functions" begin
+    # BFloat16 simdgroup matrices have no native LLVM type before Julia 1.13; the `bf16` AIR
+    # intrinsics arrive with `i16` operands and are re-typed to native `bfloat` by GPUCompiler's
+    # `promote_bf16_intrinsics!`. Without that pass these kernels miscompile (load/multiply throw
+    # or store garbage), so every BFloat16 case here doubles as a regression test for it.
     simdgroup_types = [Float16, Float32, BFloat16]
+    # bf16 carries ~3 significant bits of mantissa, so matmul results need a looser tolerance.
+    sg_rtol(::Type{BFloat16}) = 0.1
+    sg_rtol(::Type{T}) where {T} = sqrt(eps(T))
     @testset "load_store($typ)" for typ in simdgroup_types
         function kernel(a::MtlDeviceArray{T}, b::MtlDeviceArray{T},
                             origin_a=(1, 1), origin_b=(1, 1)) where {T}
@@ -430,7 +437,7 @@ end # @testset "shuffle functions"
         b = MtlArray(rand(typ, 8, 8))
         c = MtlArray(zeros(typ, 8, 8))
         @metal threads=(8, 8) kernel(a, b, c)
-        @test Array(a) * Array(b) ≈ Array(c)
+        @test Array(a) * Array(b) ≈ Array(c) rtol=sg_rtol(typ)
     end
 
     @testset "mad($typ)" for typ in simdgroup_types
@@ -449,7 +456,7 @@ end # @testset "shuffle functions"
         c = MtlArray(rand(typ, 8, 8))
         d = MtlArray(zeros(typ, 8, 8))
         @metal threads=(8, 8) kernel(a, b, c, d)
-        @test Array(a) * Array(b) + Array(c) ≈ Array(d)
+        @test Array(a) * Array(b) + Array(c) ≈ Array(d) rtol=sg_rtol(typ)
     end
 
     @testset "intrinsic ABI" begin
@@ -528,13 +535,13 @@ end # @testset "shuffle functions"
     end
 
     @testset "MtlSimdgroupMatrix type" begin
-        @testset for T in (Float16, Float32)
+        @testset for T in (Float16, Float32, BFloat16)
             @test eltype(MtlSimdgroupMatrix{T,8,8}) === T
             @test size(MtlSimdgroupMatrix{T,8,8}) === (8, 8)
         end
     end
 
-    @testset "MtlSimdgroupMatrix fill($T)" for T in (Float16, Float32)
+    @testset "MtlSimdgroupMatrix fill($T)" for T in (Float16, Float32, BFloat16)
         function kernel(out::MtlDeviceMatrix{T}, val::T) where {T}
             m = MtlSimdgroupMatrix{T,8,8}(val)
             simdgroup_store(m, out)
@@ -546,7 +553,7 @@ end # @testset "shuffle functions"
         @test all(Array(out) .== T(3.5))
     end
 
-    @testset "MtlSimdgroupMatrix zero($T)" for T in (Float16, Float32)
+    @testset "MtlSimdgroupMatrix zero($T)" for T in (Float16, Float32, BFloat16)
         function kernel(out::MtlDeviceMatrix{T}) where {T}
             m = zero(MtlSimdgroupMatrix{T,8,8})
             simdgroup_store(m, out)
@@ -558,7 +565,7 @@ end # @testset "shuffle functions"
         @test all(Array(out) .== zero(T))
     end
 
-    @testset "MtlSimdgroupMatrix load_store($T)" for T in (Float16, Float32)
+    @testset "MtlSimdgroupMatrix load_store($T)" for T in (Float16, Float32, BFloat16)
         function kernel(a::MtlDeviceMatrix{T}, b::MtlDeviceMatrix{T}) where {T}
             m = simdgroup_load(MtlSimdgroupMatrix{T,8,8}, a)
             simdgroup_store(m, b)
@@ -571,7 +578,7 @@ end # @testset "shuffle functions"
         @test Array(a) == Array(b)
     end
 
-    @testset "MtlSimdgroupMatrix load_store with origin($T)" for T in (Float16, Float32)
+    @testset "MtlSimdgroupMatrix load_store with origin($T)" for T in (Float16, Float32, BFloat16)
         function kernel(a::MtlDeviceMatrix{T}, b::MtlDeviceMatrix{T},
                         origin_a::NTuple{2,Int64}, origin_b::NTuple{2,Int64}) where {T}
             m = simdgroup_load(MtlSimdgroupMatrix{T,8,8}, a, origin_a)
@@ -585,7 +592,7 @@ end # @testset "shuffle functions"
         @test Array(a)[4:11, 2:9] == Array(b)[3:10, 5:12]
     end
 
-    @testset "MtlSimdgroupMatrix multiply($T)" for T in (Float16, Float32)
+    @testset "MtlSimdgroupMatrix multiply($T)" for T in (Float16, Float32, BFloat16)
         function kernel(a::MtlDeviceMatrix{T}, b::MtlDeviceMatrix{T}, c::MtlDeviceMatrix{T}) where {T}
             ma = simdgroup_load(MtlSimdgroupMatrix{T,8,8}, a)
             mb = simdgroup_load(MtlSimdgroupMatrix{T,8,8}, b)
@@ -597,10 +604,10 @@ end # @testset "shuffle functions"
         b = MtlArray(rand(T, 8, 8))
         c = MtlArray(zeros(T, 8, 8))
         Metal.@sync @metal threads=(8, 8) kernel(a, b, c)
-        @test Array(a) * Array(b) ≈ Array(c)
+        @test Array(a) * Array(b) ≈ Array(c) rtol=sg_rtol(T)
     end
 
-    @testset "MtlSimdgroupMatrix muladd($T)" for T in (Float16, Float32)
+    @testset "MtlSimdgroupMatrix muladd($T)" for T in (Float16, Float32, BFloat16)
         function kernel(a::MtlDeviceMatrix{T}, b::MtlDeviceMatrix{T},
                         c::MtlDeviceMatrix{T}, d::MtlDeviceMatrix{T}) where {T}
             ma = simdgroup_load(MtlSimdgroupMatrix{T,8,8}, a)
@@ -615,12 +622,12 @@ end # @testset "shuffle functions"
         c = MtlArray(rand(T, 8, 8))
         d = MtlArray(zeros(T, 8, 8))
         Metal.@sync @metal threads=(8, 8) kernel(a, b, c, d)
-        @test Array(a) * Array(b) + Array(c) ≈ Array(d)
+        @test Array(a) * Array(b) + Array(c) ≈ Array(d) rtol=sg_rtol(T)
     end
 
     # Composed K-loop GEMM: C(8×8) = A(8×K) * B(K×8) with K=32, accumulating
     # four 8×8×8 fragment MMAs.
-    @testset "MtlSimdgroupMatrix K-loop GEMM($T)" for T in (Float16, Float32)
+    @testset "MtlSimdgroupMatrix K-loop GEMM($T)" for T in (Float16, Float32, BFloat16)
         function kernel(A::MtlDeviceMatrix{T}, B::MtlDeviceMatrix{T}, C::MtlDeviceMatrix{T}) where {T}
             acc = zero(MtlSimdgroupMatrix{T,8,8})
             for k in 0:3
@@ -636,12 +643,12 @@ end # @testset "shuffle functions"
         B = MtlArray(rand(T, 32, 8))
         C = MtlArray(zeros(T, 8, 8))
         Metal.@sync @metal threads=(8, 8) kernel(A, B, C)
-        @test Array(A) * Array(B) ≈ Array(C) rtol=sqrt(eps(T))
+        @test Array(A) * Array(B) ≈ Array(C) rtol=sg_rtol(T)
     end
 
     # Threadgroup-memory variant: stage tiles through threadgroup memory, then
     # load fragments from there. Mirrors how Flash Attention stages K/V tiles.
-    @testset "MtlSimdgroupMatrix threadgroup load($T)" for T in (Float16, Float32)
+    @testset "MtlSimdgroupMatrix threadgroup load($T)" for T in (Float16, Float32, BFloat16)
         function kernel(a::MtlDeviceMatrix{T}, b::MtlDeviceMatrix{T}) where {T}
             pos = thread_position_in_threadgroup()
             tg = MtlThreadGroupArray(T, (8, 8))

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -97,7 +97,7 @@ end
 @testset "native GEMM" begin
     op(M, t) = t == 'N' ? M : t == 'C' ? adjoint(M) : transpose(M)
     mk(T, sz) = T <: Integer ? rand(T(1):T(4), sz...) : rand(T, sz...)
-    tol(T) = real(T) == Float16 ? 1.0f-1 : real(T) == Float32 ? 1.0f-3 : 1e-5
+    tol(T) = real(T) in (Float16, BFloat16) ? 1.0f-1 : real(T) == Float32 ? 1.0f-3 : 1e-5
 
     # C = α·op(A)·op(B) + β·C against a CPU oracle, forcing a specific native kernel
     function nativetest(T, M, N, K, tA, tB, α, β; alg=:native)
@@ -110,9 +110,11 @@ end
         T <: Integer ? Array(dC) == ref : isapprox(Array(dC), ref; rtol=tol(T))
     end
 
-    # simd path (Float16/Float32): transpose × α/β × ragged shapes. Forced via `:simd` so
-    # the simdgroup kernel is exercised regardless of whether a tensor path is available.
-    @testset "$T $tA$tB α=$α β=$β" for T in (Float32, Float16),
+    # simd path (Float16/Float32/BFloat16): transpose × α/β × ragged shapes. Forced via `:simd`
+    # so the simdgroup kernel is exercised regardless of whether a tensor path is available.
+    # BFloat16 routes its epilogue through f32 scratch (see `simd_direct_store`), which the
+    # β≠0 / ragged cases here exercise.
+    @testset "$T $tA$tB α=$α β=$β" for T in (Float32, Float16, BFloat16),
                                         (tA, tB) in (("N","N"), ("N","T"), ("T","N"), ("T","T")),
                                         (α, β) in ((T(1), T(0)), (T(2), T(0)), (T(1), T(1)), (T(2), T(3)))
         @test nativetest(T, 64, 48, 32, only(tA), only(tB), α, β; alg=:simd)   # aligned


### PR DESCRIPTION
I can't figure out the simdgroup multiply failures.

What's officially supported:
- Metal stardard library relational ones support bfloat (Table 6.3 in the 4.1 [spec](https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf)).
- The four basic arithmetic operators
- simdgroup_matrix
- Tensor stuff
- Nothing else
