### PR TITLE
Disable nightly CI and fix invalid Metal API usage

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,11 +31,11 @@ steps:
             julia:
               - "1.10"
               - "1.11"
-              - "nightly"
-          adjustments:
-            - with:
-                julia: "nightly"
-              soft_fail: true
+          #     - "nightly"
+          # adjustments:
+          #   - with:
+          #       julia: "nightly"
+          #     soft_fail: true
 
   # special tests
   - group: ":eyes: Special"

--- a/src/array.jl
+++ b/src/array.jl
@@ -514,8 +514,10 @@ fill(v::T, dims...; storage=DefaultStorageMode) where T = fill!(MtlArray{T,lengt
 
 # optimized implementation of `fill!` for types that are directly supported by fillbuffer
 function Base.fill!(A::MtlArray{T}, val) where T <: Union{UInt8,Int8}
-    B = convert(T, val)
-    unsafe_fill!(device(A), pointer(A), B, length(A))
+    if length(A) > 0
+        B = convert(T, val)
+        unsafe_fill!(device(A), pointer(A), B, length(A))
+    end
     A
 end
 


### PR DESCRIPTION
No need to run nightly when we know it'll fail considering the current Apple silicon runner situation