### PR TITLE
Only load BFloat16s extension on Apple systems

### DIFF
--- a/ext/BFloat16sExt.jl
+++ b/ext/BFloat16sExt.jl
@@ -4,9 +4,11 @@ using Metal: MPS.MPSDataType, MPS.MPSDataTypeBFloat16, MPS.jl_mps_to_typ, macos_
 using BFloat16s
 
 # BFloat is only supported in MPS starting in MacOS 14
-if macos_version() >= v"14"
-    Base.convert(::Type{MPSDataType}, ::Type{BFloat16}) = MPSDataTypeBFloat16
-    jl_mps_to_typ[MPSDataTypeBFloat16] = BFloat16
+@static if Sys.isapple()
+    if macos_version() >= v"14"
+        Base.convert(::Type{MPSDataType}, ::Type{BFloat16}) = MPSDataTypeBFloat16
+        jl_mps_to_typ[MPSDataTypeBFloat16] = BFloat16
+    end
 end
 
 end # module


### PR DESCRIPTION
Otherwise the extension cannot precompile on non-Apple devices.