### PR TITLE
Rerun random tests with chance of false negative once.

### DIFF
--- a/test/random.jl
+++ b/test/random.jl
@@ -12,7 +12,8 @@ const OOPLACE_TUPLES = [[(Metal.rand, rand, T) for T in RAND_TYPES];
         rng = Metal.MPS.RNG()
 
         @testset "$f with $T" for (f, T) in INPLACE_TUPLES
-            @testset "$d" for d in (1, 3, (3, 3), (3, 3, 3), 16, (16, 16), (16, 16, 16), (1000,), (1000,1000))
+            # d == 2 and d == 3 are to hit the test cases where sizeof(A) <= 4
+            @testset "$d" for d in (2, 3, (3, 3), (3, 3, 3), 16, (16, 16), (16, 16, 16), (1000,), (1000,1000))
                 A = MtlArray{T}(undef, d)
 
                 # default_rng
@@ -224,7 +225,8 @@ const OOPLACE_TUPLES = [[(Metal.rand, rand, T) for T in RAND_TYPES];
         end
         rng = Metal.MPS.RNG()
         @testset "$f with $T" for (f, T) in mps_tuples
-            @testset "$d" for d in (1, 3, (3, 3), (3, 3, 3), 16, (16, 16), (16, 16, 16), (1000,), (1000,1000))
+            # d == 2 and d == 3 are to hit the test cases where sizeof(A) <= 4
+            @testset "$d" for d in (2, 3, (3, 3), (3, 3, 3), 16, (16, 16), (16, 16, 16), (1000,), (1000,1000))
                 A = zeros(T, d)
                 if (prod(d) * sizeof(T)) % 4 == 0
                     f(rng, A)

--- a/test/random.jl
+++ b/test/random.jl
@@ -6,6 +6,18 @@ const INPLACE_TUPLES = [[(rand!, T) for T in RAND_TYPES];
 const OOPLACE_TUPLES = [[(Metal.rand, rand, T) for T in RAND_TYPES];
                         [(Metal.randn, rand, T) for T in RANDN_TYPES]]
 
+# `f` must return a bool
+function retry_on_failure(f::Function, arr::AbstractArray{T}; n_tries=2) where T
+    i = n_tries
+    pass = false
+    while !pass && i > 0
+        i != n_tries && @info "Retrying test with array size $(size(arr)) and type $T"
+        i -= 1
+        pass = f(arr)
+    end
+    return pass
+end
+
 @testset "random" begin
     # in-place
     @testset "in-place" begin
@@ -16,17 +28,22 @@ const OOPLACE_TUPLES = [[(Metal.rand, rand, T) for T in RAND_TYPES];
                 A = MtlArray{T}(undef, d)
 
                 # default_rng
-                fill!(A, T(0))
-                f(A)
-                @test !iszero(collect(A))
+                @test retry_on_failure(A) do arr
+                    fill!(arr, T(0))
+                    f(arr)
+                    !iszero(collect(arr))
+                end
 
                 # specified MPS rng
                 if T != Float16
-                    fill!(A, T(0))
                     if Metal.can_use_mpsrandom(A)
-                        f(rng, A)
-                        @test !iszero(collect(A))
+                        @test retry_on_failure(A) do arr
+                            fill!(arr, T(0))
+                            f(rng, arr)
+                            !iszero(collect(arr))
+                        end
                     else
+                        fill!(A, T(0))
                         @test_throws "Destination buffer" f(rng, A)
                     end
                 end
@@ -225,11 +242,14 @@ const OOPLACE_TUPLES = [[(Metal.rand, rand, T) for T in RAND_TYPES];
         rng = Metal.MPS.RNG()
         @testset "$f with $T" for (f, T) in mps_tuples
             @testset "$d" for d in (1, 3, (3, 3), (3, 3, 3), 16, (16, 16), (16, 16, 16), (1000,), (1000,1000))
-                A = zeros(T, d)
                 if (prod(d) * sizeof(T)) % 4 == 0
-                    f(rng, A)
-                    @test !iszero(collect(A))
+                    A = zeros(T, d)
+                    @test retry_on_failure(A) do arr
+                        f(rng, arr)
+                        !iszero(collect(arr))
+                    end
                 else
+                    A = zeros(T, d)
                     @test_throws "Destination buffer" f(rng, A)
                 end
             end


### PR DESCRIPTION
As part of our random tests, we verify is that at least one of the values in an array is no longer 0. We test the generation of length 1 arrays of `(U)Int8`. That gives each run of those tests a 1/256 chance of generating a 0 and erroneously failing our test suite. See [the latest such failure](https://buildkite.com/julialang/metal-dot-jl/builds/1545#0193e49a-3f9b-472b-becc-13d329d18b7b).

This PR makes tests that have such a high chance of failing try again before declaring a failure so we don't have to deal with a false failure every few days.

My solution feels overengineered so I'm open to suggestions for a simpler implementation.