### PR TITLE
Version-related fixes to MPSNDArray

### DIFF
--- a/lib/mps/ndarray.jl
+++ b/lib/mps/ndarray.jl
@@ -45,13 +45,15 @@ export MPSNDArray
         res = @objc [ndarr::id{MPSNDArray} userBuffer]::id{MTLBuffer}
         return res == nil ? nothing : MTLBuffer(res)
     end
-    function resourceSize(ndarr::MPSNDArray)
-        return @objc [ndarr::id{MPSNDArray} resourceSize]::NSUInteger
-    end
-    function descriptor(ndarr::MPSNDArray)::MPSNDArrayDescriptor
-        res = @objc [ndarr::id{MPSNDArray} descriptor]::id{MPSNDArrayDescriptor}
-        return res == nil ? nothing : MPSNDArrayDescriptor(res)
-    end
+end
+
+function resourceSize(ndarr::MPSNDArray)
+    return @objc [ndarr::id{MPSNDArray} resourceSize]::NSUInteger
+end
+
+function descriptor(ndarr::MPSNDArray)::MPSNDArrayDescriptor
+    res = @objc [ndarr::id{MPSNDArray} descriptor]::id{MPSNDArrayDescriptor}
+    return res == nil ? nothing : MPSNDArrayDescriptor(res)
 end
 
 function Base.size(ndarr::MPSNDArray)


### PR DESCRIPTION
2 functions aren't actually limited to macOS 15. I don't understand why I thought they were. Also a few fixes for running tests on macOS 13.