### PR TITLE
[NFC] Indentation consistency

### DIFF
--- a/lib/mps/vector.jl
+++ b/lib/mps/vector.jl
@@ -96,7 +96,7 @@ end
     matvecmul!(c::MtlVector, a::MtlMatrix, b::MtlVector, alpha=1, beta=1, transpose=false)
 
 A `MPSMatrixVectorMultiplication` kernel thay computes:
-  `c = alpha * op(a) * b + beta * c`
+    `c = alpha * op(a) * b + beta * c`
 
 This function should not typically be used. Rather, use the normal `LinearAlgebra` interface
 with any `MtlArray` and it should be accelerated using Metal Performance Shaders.

--- a/src/array.jl
+++ b/src/array.jl
@@ -597,7 +597,7 @@ end
 ## resizing
 
 """
-  resize!(a::MtlVector, n::Integer)
+    resize!(a::MtlVector, n::Integer)
 
 Resize `a` to contain `n` elements. If `n` is smaller than the current collection length,
 the first `n` elements will be retained. If `n` is larger, the new elements are not

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -126,7 +126,7 @@ end
 # Base.RefValue isn't GPU compatible, so provide a compatible alternative
 # TODO: port improvements from CUDA.jl
 struct MtlRefValue{T} <: Ref{T}
-  x::T
+    x::T
 end
 Base.getindex(r::MtlRefValue) = r.x
 Adapt.adapt_structure(to::Adaptor, r::Base.RefValue) = MtlRefValue(adapt(to, r[]))
@@ -144,7 +144,7 @@ Adapt.adapt_structure(to::Adaptor,
     Broadcast.Broadcasted{Style}((x...) -> T(x...), adapt(to, bc.args), bc.axes)
 
 """
-  mtlconvert(x, [cce])
+    mtlconvert(x, [cce])
 
 This function is called for every argument to be passed to a kernel, allowing it to be
 converted to a GPU-friendly format. By default, the function does nothing and returns the

--- a/src/device/array.jl
+++ b/src/device/array.jl
@@ -68,7 +68,7 @@ end
 ## conversions
 
 Base.unsafe_convert(::Type{Core.LLVMPtr{T,A}}, x::MtlDeviceArray{T,<:Any,A}) where {T,A} =
-  x.ptr
+    x.ptr
 
 
 ## indexing intrinsics
@@ -169,29 +169,29 @@ end
 # create a derived device array (reinterpreted or reshaped) that's still a MtlDeviceArray
 @inline function _derived_array(::Type{T}, N::Int, a::MtlDeviceArray{T,M,A},
                                 osize::Dims) where {T, M, A}
-  return MtlDeviceArray{T,N,A}(osize, a.ptr)
+    return MtlDeviceArray{T,N,A}(osize, a.ptr)
 end
 
 function Base.reinterpret(::Type{T}, a::MtlDeviceArray{S,N,A}) where {T,S,N,A}
-  err = _reinterpret_exception(T, a)
-  err === nothing || throw(err)
+    err = _reinterpret_exception(T, a)
+    err === nothing || throw(err)
 
-  if sizeof(T) == sizeof(S) # fast case
-    return MtlDeviceArray{T,N,A}(size(a), reinterpret(LLVMPtr{T,A}, a.ptr))
-  end
+    if sizeof(T) == sizeof(S) # fast case
+        return MtlDeviceArray{T,N,A}(size(a), reinterpret(LLVMPtr{T,A}, a.ptr))
+    end
 
-  isize = size(a)
-  size1 = div(isize[1]*sizeof(S), sizeof(T))
-  osize = tuple(size1, Base.tail(isize)...)
-  return MtlDeviceArray{T,N,A}(osize, reinterpret(LLVMPtr{T,A}, a.ptr))
+    isize = size(a)
+    size1 = div(isize[1]*sizeof(S), sizeof(T))
+    osize = tuple(size1, Base.tail(isize)...)
+    return MtlDeviceArray{T,N,A}(osize, reinterpret(LLVMPtr{T,A}, a.ptr))
 end
 
 function Base.reshape(a::MtlDeviceArray{T,M}, dims::NTuple{N,Int}) where {T,N,M}
-  if prod(dims) != length(a)
-      throw(DimensionMismatch("new dimensions (argument `dims`) must be consistent with array size (`size(a)`)"))
-  end
-  if N == M && dims == size(a)
-      return a
-  end
-  _derived_array(T, N, a, dims)
+    if prod(dims) != length(a)
+        throw(DimensionMismatch("new dimensions (argument `dims`) must be consistent with array size (`size(a)`)"))
+    end
+    if N == M && dims == size(a)
+        return a
+    end
+    _derived_array(T, N, a, dims)
 end

--- a/src/device/intrinsics/memory.jl
+++ b/src/device/intrinsics/memory.jl
@@ -68,7 +68,7 @@ Base.pointer(x::MtlLargerDeviceArray{T,<:Any,A}) where {T,A} =
 end
 
 Base.unsafe_convert(::Type{Core.LLVMPtr{T,A}}, x::MtlLargerDeviceArray{T,<:Any,A}) where {T,A} =
-  reinterpret(Core.LLVMPtr{T,A}, Base.unsafe_convert(Core.LLVMPtr{UInt32,A}, x.x))
+    reinterpret(Core.LLVMPtr{T,A}, Base.unsafe_convert(Core.LLVMPtr{UInt32,A}, x.x))
 
 Base.@propagate_inbounds Base.getindex(A::MtlLargerDeviceArray{T}, i1::Integer) where {T} =
     arrayref(A, i1)

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -128,29 +128,29 @@ macro time(ex)
         for (typ, gctime, memtime, bytes, allocs) in
             (("CPU", cpu_gc_time, 0, cpu_alloc_size, cpu_alloc_count),
              ("GPU", 0, gpu_mem_time, gpu_alloc_size, gpu_alloc_count))
-          if bytes != 0 || allocs != 0
-              allocs, ma = Base.prettyprint_getunits(allocs, length(Base._cnt_units), Int64(1000))
-              if ma == 1
-                  Printf.@printf(" (%d%s %s allocation%s: ", allocs, Base._cnt_units[ma], typ, allocs==1 ? "" : "s")
-              else
-                  Printf.@printf(" (%.2f%s %s allocations: ", allocs, Base._cnt_units[ma], typ)
-              end
-              print(Base.format_bytes(bytes))
-              if gctime > 0
-                  Printf.@printf(", %.2f%% gc time", 100*gctime/cpu_time)
-              end
-              if memtime > 0
-                  Printf.@printf(", %.2f%% memmgmt time", 100*memtime/cpu_time)
-              end
-              print(")")
-          else
-              if gctime > 0
-                  Printf.@printf(", %.2f%% %s gc time", 100*gctime/cpu_time, typ)
-              end
-              if memtime > 0
-                  Printf.@printf(", %.2f%% %s memmgmt time", 100*memtime/cpu_time, typ)
-              end
-          end
+            if bytes != 0 || allocs != 0
+                allocs, ma = Base.prettyprint_getunits(allocs, length(Base._cnt_units), Int64(1000))
+                if ma == 1
+                    Printf.@printf(" (%d%s %s allocation%s: ", allocs, Base._cnt_units[ma], typ, allocs==1 ? "" : "s")
+                else
+                    Printf.@printf(" (%.2f%s %s allocations: ", allocs, Base._cnt_units[ma], typ)
+                end
+                print(Base.format_bytes(bytes))
+                if gctime > 0
+                    Printf.@printf(", %.2f%% gc time", 100*gctime/cpu_time)
+                end
+                if memtime > 0
+                    Printf.@printf(", %.2f%% memmgmt time", 100*memtime/cpu_time)
+                end
+                print(")")
+            else
+                if gctime > 0
+                    Printf.@printf(", %.2f%% %s gc time", 100*gctime/cpu_time, typ)
+                end
+                if memtime > 0
+                    Printf.@printf(", %.2f%% %s memmgmt time", 100*memtime/cpu_time, typ)
+                end
+            end
         end
         println()
 

--- a/test/array.jl
+++ b/test/array.jl
@@ -311,39 +311,39 @@ end
 
 # https://github.com/JuliaGPU/CUDA.jl/issues/2191
 @testset "preserving storage mode" begin
-  a = mtl([1]; storage=Metal.SharedStorage)
-  @test Metal.storagemode(a) == Metal.SharedStorage
+    a = mtl([1]; storage=Metal.SharedStorage)
+    @test Metal.storagemode(a) == Metal.SharedStorage
 
-  # storage mode should be preserved
-  b = a .+ 1
-  @test Metal.storagemode(b) == Metal.SharedStorage
+    # storage mode should be preserved
+    b = a .+ 1
+    @test Metal.storagemode(b) == Metal.SharedStorage
 
-  # when there's a conflict, we should defer to shared memory
-  c = mtl([1]; storage=Metal.PrivateStorage)
-  d = mtl([1]; storage=Metal.SharedStorage)
-  e = c .+ d
-  @test Metal.storagemode(e) == Metal.SharedStorage
+    # when there's a conflict, we should defer to shared memory
+    c = mtl([1]; storage=Metal.PrivateStorage)
+    d = mtl([1]; storage=Metal.SharedStorage)
+    e = c .+ d
+    @test Metal.storagemode(e) == Metal.SharedStorage
 end
 
 @testset "resizing" begin
-  a = MtlArray([1,2,3])
+    a = MtlArray([1,2,3])
 
-  resize!(a, 3)
-  @test length(a) == 3
-  @test Array(a) == [1,2,3]
+    resize!(a, 3)
+    @test length(a) == 3
+    @test Array(a) == [1,2,3]
 
-  resize!(a, 5)
-  @test length(a) == 5
-  @test Array(a)[1:3] == [1,2,3]
+    resize!(a, 5)
+    @test length(a) == 5
+    @test Array(a)[1:3] == [1,2,3]
 
-  resize!(a, 2)
-  @test length(a) == 2
-  @test Array(a)[1:2] == [1,2]
+    resize!(a, 2)
+    @test length(a) == 2
+    @test Array(a)[1:2] == [1,2]
 
-  b = MtlArray{Int}(undef, 0)
-  @test length(b) == 0
-  resize!(b, 1)
-  @test length(b) == 1
+    b = MtlArray{Int}(undef, 0)
+    @test length(b) == 0
+    resize!(b, 1)
+    @test length(b) == 1
 end
 
 function _alignedvec(::Type{T}, n::Integer, alignment::Integer=16384) where {T}
@@ -448,10 +448,10 @@ end
 
     # ND
     let x = rand(Bool, 1000, 1000)
-      @test findall(x) == Array(findall(MtlArray(x)))
+        @test findall(x) == Array(findall(MtlArray(x)))
     end
     let x = rand(Float32, 1000, 1000)
-      @test findall(y->y>Float32(0.5), x) == Array(findall(y->y>Float32(0.5), MtlArray(x)))
+        @test findall(y->y>Float32(0.5), x) == Array(findall(y->y>Float32(0.5), MtlArray(x)))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,7 +44,7 @@ function extract_flag!(args, flag, default=nothing)
             if f != flag
                 val = split(f, '=')[2]
                 if default !== nothing && !(typeof(default) <: AbstractString)
-                  val = parse(typeof(default), val)
+                    val = parse(typeof(default), val)
                 end
             else
                 val = default
@@ -82,29 +82,29 @@ const tests = []
 const test_runners = Dict()
 ## files in the test folder
 for (rootpath, dirs, files) in walkdir(@__DIR__)
-  # find Julia files
-  filter!(files) do file
-    endswith(file, ".jl") && file !== "setup.jl" && file !== "runtests.jl"
-  end
-  isempty(files) && continue
-
-  # strip extension
-  files = map(files) do file
-    file[1:end-3]
-  end
-
-  # prepend subdir
-  subdir = relpath(rootpath, @__DIR__)
-  if subdir != "."
-    files = map(files) do file
-      joinpath(subdir, file)
+    # find Julia files
+    filter!(files) do file
+        endswith(file, ".jl") && file !== "setup.jl" && file !== "runtests.jl"
     end
-  end
+    isempty(files) && continue
 
-  append!(tests, files)
-  for file in files
-    test_runners[file] = ()->include("$(@__DIR__)/$file.jl")
-  end
+    # strip extension
+    files = map(files) do file
+        file[1:end-3]
+    end
+
+    # prepend subdir
+    subdir = relpath(rootpath, @__DIR__)
+    if subdir != "."
+        files = map(files) do file
+            joinpath(subdir, file)
+        end
+    end
+
+    append!(tests, files)
+    for file in files
+        test_runners[file] = ()->include("$(@__DIR__)/$file.jl")
+    end
 end
 ## GPUArrays testsuite
 for name in keys(TestSuite.tests)
@@ -134,9 +134,9 @@ if !isempty(optlike_args)
 end
 ## the remaining args filter tests
 if !isempty(ARGS)
-  filter!(tests) do test
-    any(arg->startswith(test, arg), ARGS)
-  end
+    filter!(tests) do test
+        any(arg->startswith(test, arg), ARGS)
+    end
 end
 
 # add workers


### PR DESCRIPTION
Fixes lines where indents are 2 spaces instead of 4.

This also fixes the REPL docstring highlighting for `resize!` and `mtlconvert`.

Closes #543