### PR TITLE
Enabling previously disabled test and mark broken

### DIFF
--- a/test/mtl/metal.jl
+++ b/test/mtl/metal.jl
@@ -146,9 +146,7 @@ let ev = MTLEvent(dev)
 end
 
 let ev = MTLSharedEvent(dev)
-    # XXX: this returns nothing, which seems like a Metal bug,
-    #      especially because it does return a device under validation.
-    #@test ev.device == dev
+    @test ev.device == dev
     @test ev.label === nothing
     ev.label = "MyEvent"
     @test ev.label == "MyEvent"

--- a/test/mtl/metal.jl
+++ b/test/mtl/metal.jl
@@ -146,7 +146,7 @@ let ev = MTLEvent(dev)
 end
 
 let ev = MTLSharedEvent(dev)
-    @test ev.device ==  dev
+    @test ev.device == dev broken=(!haskey(ENV, "MTL_SHADER_VALIDATION") && Metal.is_m1(dev))
     @test ev.label === nothing
     ev.label = "MyEvent"
     @test ev.label == "MyEvent"

--- a/test/mtl/metal.jl
+++ b/test/mtl/metal.jl
@@ -146,9 +146,9 @@ let ev = MTLEvent(dev)
 end
 
 let ev = MTLSharedEvent(dev)
-    # XXX: this returns nothing, which seems like a Metal bug,
-    #      especially because it does return a device under validation.
-    @test ev.device == dev broken=!haskey(ENV, "MTL_SHADER_VALIDATION")
+    # This returns nothing, which aligns with the description from the Metal SDK headers.
+    #     Interestingly, under validation, a device is returned.
+    @test ev.device === nothing broken=haskey(ENV, "MTL_SHADER_VALIDATION")
     @test ev.label === nothing
     ev.label = "MyEvent"
     @test ev.label == "MyEvent"

--- a/test/mtl/metal.jl
+++ b/test/mtl/metal.jl
@@ -148,7 +148,7 @@ end
 let ev = MTLSharedEvent(dev)
     # This returns nothing, which aligns with the description from the Metal SDK headers.
     #     Interestingly, under validation, a device is returned.
-    @test ev.device === nothing broken=haskey(ENV, "MTL_SHADER_VALIDATION")
+    @test ev.device === nothing broken=shader_validation
     @test ev.label === nothing
     ev.label = "MyEvent"
     @test ev.label == "MyEvent"

--- a/test/mtl/metal.jl
+++ b/test/mtl/metal.jl
@@ -146,7 +146,9 @@ let ev = MTLEvent(dev)
 end
 
 let ev = MTLSharedEvent(dev)
-    @test ev.device == dev broken=(!haskey(ENV, "MTL_SHADER_VALIDATION") && Metal.is_m1(dev))
+    # XXX: this returns nothing, which seems like a Metal bug,
+    #      especially because it does return a device under validation.
+    @test ev.device == dev broken=!haskey(ENV, "MTL_SHADER_VALIDATION")
     @test ev.label === nothing
     ev.label = "MyEvent"
     @test ev.label == "MyEvent"

--- a/test/mtl/metal.jl
+++ b/test/mtl/metal.jl
@@ -146,7 +146,7 @@ let ev = MTLEvent(dev)
 end
 
 let ev = MTLSharedEvent(dev)
-    @test ev.device == dev
+    @test ev.device ==  dev
     @test ev.label === nothing
     ev.label = "MyEvent"
     @test ev.label == "MyEvent"


### PR DESCRIPTION
Edit: I found the following in the Metal headers:
```objective-c
/*!
 @property device
 @abstract The device this event can be used with. Will be nil when the event is shared across devices (i.e. MTLSharedEvent).
 */
@property (nullable, readonly) id <MTLDevice> device;
```

Seems to me like `ev.device` is supposed to be `nothing` in this test, and then I don't know why it returns a device under validation or if it that's the actual bug.

I've updated the PR to reflect the new information from the headers.