### PR TITLE
`Pi` and `e` to `Float32` and `Float16`

### DIFF
--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -9,10 +9,17 @@ using Base.Math: throw_complex_domainerror
 # - consider emitting LLVM intrinsics and lowering those in the back-end
 
 ### Constants
-@device_override Core.Float32(::typeof(π), ::RoundingMode) = reinterpret(Float32, 0x40490fdb) # 3.1415927f0 reinterpret(UInt32,Float32(reinterpret(Float64,0x400921FB60000000)))
-@device_override Core.Float16(::typeof(π), ::RoundingMode) = reinterpret(Float16, 0x4248)     # Float16(3.14)
-@device_override Core.Float32(::typeof(ℯ), ::RoundingMode) = reinterpret(Float32, 0x402df854) # 2.7182817f0 reinterpret(UInt32,Float32(reinterpret(Float64,0x4005BF0A80000000)))
-@device_override Core.Float16(::typeof(ℯ), ::RoundingMode) = reinterpret(Float16, 0x4170)     # Float16(2.719)
+# π
+@device_override Core.Float32(::typeof(π), ::RoundingMode) = reinterpret(Float32, 0x40490fdb)        # 3.1415927f0 reinterpret(UInt32,Float32(reinterpret(Float64,0x400921FB60000000)))
+@device_override Core.Float32(::typeof(π), ::RoundingMode{:Down}) = reinterpret(Float32, 0x40490fda) # 3.1415925f0 prevfloat(reinterpret(UInt32,Float32(reinterpret(Float64,0x400921FB60000000))))
+@device_override Core.Float16(::typeof(π), ::RoundingMode{:Up}) = reinterpret(Float16, 0x4249)       # Float16(3.143)
+@device_override Core.Float16(::typeof(π), ::RoundingMode) = reinterpret(Float16, 0x4248)            # Float16(3.14)
+
+# ℯ
+@device_override Core.Float32(::typeof(ℯ), ::RoundingMode{:Up}) = reinterpret(Float32, 0x402df855)   # 2.718282f0 nextfloat(reinterpret(UInt32,Float32(reinterpret(Float64,0x4005BF0A80000000))))
+@device_override Core.Float32(::typeof(ℯ), ::RoundingMode) = reinterpret(Float32, 0x402df854)        # 2.7182817f0 reinterpret(UInt32,Float32(reinterpret(Float64,0x4005BF0A80000000)))
+@device_override Core.Float16(::typeof(ℯ), ::RoundingMode) = reinterpret(Float16, 0x4170)            # Float16(2.719)
+@device_override Core.Float16(::typeof(ℯ), ::RoundingMode{:Down}) = reinterpret(Float16, 0x416f)     # Float16(2.717)
 
 ### Common Intrinsics
 @device_function clamp_fast(x::Float32, minval::Float32, maxval::Float32) = ccall("extern air.fast_clamp.f32", llvmcall, Cfloat, (Cfloat, Cfloat, Cfloat), x, minval, maxval)

--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -8,6 +8,12 @@ using Base.Math: throw_complex_domainerror
 # - add support for vector types
 # - consider emitting LLVM intrinsics and lowering those in the back-end
 
+### Constants
+@device_override Core.Float32(::typeof(π), ::RoundingMode) = reinterpret(Float32, 0x40490fdb) # 3.1415927f0 reinterpret(UInt32,Float32(reinterpret(Float64,0x400921FB60000000)))
+@device_override Core.Float16(::typeof(π), ::RoundingMode) = reinterpret(Float16, 0x4248)     # Float16(3.14)
+@device_override Core.Float32(::typeof(ℯ), ::RoundingMode) = reinterpret(Float32, 0x402df854) # 2.7182817f0 reinterpret(UInt32,Float32(reinterpret(Float64,0x4005BF0A80000000)))
+@device_override Core.Float16(::typeof(ℯ), ::RoundingMode) = reinterpret(Float16, 0x4170)     # Float16(2.719)
+
 ### Common Intrinsics
 @device_function clamp_fast(x::Float32, minval::Float32, maxval::Float32) = ccall("extern air.fast_clamp.f32", llvmcall, Cfloat, (Cfloat, Cfloat, Cfloat), x, minval, maxval)
 @device_override Base.clamp(x::Float32, minval::Float32, maxval::Float32) = ccall("extern air.clamp.f32", llvmcall, Cfloat, (Cfloat, Cfloat, Cfloat), x, minval, maxval)

--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -10,16 +10,24 @@ using Base.Math: throw_complex_domainerror
 
 ### Constants
 # π
-@device_override Core.Float32(::typeof(π), ::RoundingMode) = reinterpret(Float32, 0x40490fdb)        # 3.1415927f0 reinterpret(UInt32,Float32(reinterpret(Float64,0x400921FB60000000)))
-@device_override Core.Float32(::typeof(π), ::RoundingMode{:Down}) = reinterpret(Float32, 0x40490fda) # 3.1415925f0 prevfloat(reinterpret(UInt32,Float32(reinterpret(Float64,0x400921FB60000000))))
-@device_override Core.Float16(::typeof(π), ::RoundingMode{:Up}) = reinterpret(Float16, 0x4249)       # Float16(3.143)
-@device_override Core.Float16(::typeof(π), ::RoundingMode) = reinterpret(Float16, 0x4248)            # Float16(3.14)
+const M_PI_F = Float32(reinterpret(Float64, 0x400921FB60000000))
+const M_PI_H = reinterpret(Float16, 0x4248)
+@eval begin
+    @device_override Core.Float32(::typeof(π), ::RoundingMode) = $M_PI_F
+    @device_override Core.Float32(::typeof(π), ::RoundingMode{:Down}) = $(prevfloat(M_PI_F))
+    @device_override Core.Float16(::typeof(π), ::RoundingMode{:Up}) = $(nextfloat(M_PI_H))
+    @device_override Core.Float16(::typeof(π), ::RoundingMode) = $M_PI_H
+end
 
 # ℯ
-@device_override Core.Float32(::typeof(ℯ), ::RoundingMode{:Up}) = reinterpret(Float32, 0x402df855)   # 2.718282f0 nextfloat(reinterpret(UInt32,Float32(reinterpret(Float64,0x4005BF0A80000000))))
-@device_override Core.Float32(::typeof(ℯ), ::RoundingMode) = reinterpret(Float32, 0x402df854)        # 2.7182817f0 reinterpret(UInt32,Float32(reinterpret(Float64,0x4005BF0A80000000)))
-@device_override Core.Float16(::typeof(ℯ), ::RoundingMode) = reinterpret(Float16, 0x4170)            # Float16(2.719)
-@device_override Core.Float16(::typeof(ℯ), ::RoundingMode{:Down}) = reinterpret(Float16, 0x416f)     # Float16(2.717)
+const M_E_F = Float32(reinterpret(Float64, 0x4005BF0A80000000))
+const M_E_H = reinterpret(Float16, 0x4170)
+@eval begin
+    @device_override Core.Float32(::typeof(ℯ), ::RoundingMode{:Up}) = $(nextfloat(M_E_F))
+    @device_override Core.Float32(::typeof(ℯ), ::RoundingMode) = $M_E_F
+    @device_override Core.Float16(::typeof(ℯ), ::RoundingMode) = $M_E_H
+    @device_override Core.Float16(::typeof(ℯ), ::RoundingMode{:Down}) = $(prevfloat(M_E_H))
+end
 
 ### Common Intrinsics
 @device_function clamp_fast(x::Float32, minval::Float32, maxval::Float32) = ccall("extern air.fast_clamp.f32", llvmcall, Cfloat, (Cfloat, Cfloat, Cfloat), x, minval, maxval)

--- a/test/device/intrinsics/math.jl
+++ b/test/device/intrinsics/math.jl
@@ -311,6 +311,13 @@ end
         ir = sprint(io->(@device_code_llvm io=io dump_module=true @metal metal = v"3.0" nextafter_out_test()))
         @test occursin(Regex("@air\\.sign\\.f$(8*sizeof(T))"), ir)
     end
+
+    let # "issue551"
+        mtl_pi = only(Array(T.(MtlArray([π]), RoundNearest)))
+        @test mtl_pi == T(π)
+        mtl_ℯ = only(Array(T.(MtlArray([ℯ]), RoundNearest)))
+        @test mtl_ℯ == T(ℯ)
+    end
 end
 end
 

--- a/test/device/intrinsics/math.jl
+++ b/test/device/intrinsics/math.jl
@@ -323,7 +323,6 @@ end
         end
 
         res = MtlArray(zeros(Bool, 4))
-        @device_code_llvm @metal launch = false convert_test(res)
         Metal.@sync @metal convert_test(res)
         @test all(Array(res))
     end


### PR DESCRIPTION
Bypasses the conversion to `BigFloat` when converting `pi` and `e` to `Float32` and `Float16` on gpu. Values are taken from the constants in Tables 6.5 and 6.6 of the Metal shading language [specification](https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf).

Close #551