### PR TITLE
Remove copy when possible from cpu rnad using GPU RNG

### DIFF
--- a/lib/mps/random.jl
+++ b/lib/mps/random.jl
@@ -73,7 +73,7 @@ end
 # CPU arrays
 function Random.rand!(rng::RNG, A::AbstractArray{T, N}) where {T <: Union{UniformTypes...}, N}
     isempty(A) && return A
-    if MTL.can_alloc_nocopy(pointer(A),sizeof(A))
+    if MTL.can_alloc_nocopy(pointer(A), sizeof(A))
         mtlA = unsafe_wrap(MtlArray{T, N}, A)
         rand!(rng, mtlA)
     else
@@ -85,7 +85,7 @@ function Random.rand!(rng::RNG, A::AbstractArray{T, N}) where {T <: Union{Unifor
 end
 function Random.randn!(rng::RNG, A::AbstractArray{T, N}) where {T <: Float32, N}
     isempty(A) && return A
-    if MTL.can_alloc_nocopy(pointer(A),sizeof(A))
+    if MTL.can_alloc_nocopy(pointer(A), sizeof(A))
         mtlA = unsafe_wrap(MtlArray{T, N}, A)
         randn!(rng, mtlA)
     else

--- a/lib/mps/random.jl
+++ b/lib/mps/random.jl
@@ -71,18 +71,29 @@ const NormalArray = MtlArray{<:Float32}
 end
 
 # CPU arrays
-# TODO: use unsafe_wrap when possible
 function Random.rand!(rng::RNG, A::AbstractArray{T, N}) where {T <: Union{UniformTypes...}, N}
     isempty(A) && return A
-    B = MtlArray{T, N, SharedStorage}(undef, size(A))
-    rand!(rng, B)
-    return copyto!(A, B)
+    if MTL.can_alloc_nocopy(pointer(A),sizeof(A))
+        mtlA = unsafe_wrap(MtlArray{T, N}, A)
+        rand!(rng, mtlA)
+    else
+        B = MtlArray{T, N, SharedStorage}(undef, size(A))
+        rand!(rng, B)
+        copyto!(A, B)
+    end
+    return A
 end
 function Random.randn!(rng::RNG, A::AbstractArray{T, N}) where {T <: Float32, N}
     isempty(A) && return A
-    B = MtlArray{T, N, SharedStorage}(undef, size(A))
-    randn!(rng, B)
-    return copyto!(A, B)
+    if MTL.can_alloc_nocopy(pointer(A),sizeof(A))
+        mtlA = unsafe_wrap(MtlArray{T, N}, A)
+        randn!(rng, mtlA)
+    else
+        B = MtlArray{T, N, SharedStorage}(undef, size(A))
+        randn!(rng, B)
+        copyto!(A, B)
+    end
+    return A
 end
 
 # Out of place


### PR DESCRIPTION
Optimization mentioned in https://github.com/JuliaGPU/Metal.jl/pull/564#discussion_r1995943912

This won't happen very often as the cpu array has to be page-aligned in memory, and `sizeof` a multiple of a page (16384 bytes), but when it does it cut memory usage in half.