### PR TITLE
Test 1.12-nightly

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,10 +30,10 @@ steps:
             julia:
               - "1.10"
               - "1.11"
-              - "nightly"
+              - "1.12-nightly"
           adjustments:
             - with:
-                julia: "nightly"
+                julia: "1.12-nightly"
               soft_fail: true
 
   # special tests


### PR DESCRIPTION
Suggested here https://github.com/JuliaGPU/Metal.jl/pull/575#issuecomment-2758363545.

I went with replacing nightly for the moment as llvmdowngrader is not yet supported for llvm 18+ so we know CI will fail for both.