### PR TITLE
Use an appropriate amount of threads in unified memory example

### DIFF
--- a/examples/unified_memory.jl
+++ b/examples/unified_memory.jl
@@ -37,7 +37,7 @@ arr_cpu .= pi
 Metal.@allowscalar @test arr_mtl[1] == Float32(pi)
 
 # Now launch a kernel altering the Metal array
-Metal.@sync @metal threads=1024 groups=1024 simple_kernel(arr_mtl)
+Metal.@sync @metal threads=16 groups=16 simple_kernel(arr_mtl)
 
 # These changes are reflected in the wrapped CPU array
 synchronize()


### PR DESCRIPTION
Split out https://github.com/JuliaGPU/Metal.jl/pull/580/commits/602e4f48b17ed5f0e40b0fdb657365f8440cd1f4 to merge earlier since it was also encountered in another PR: https://buildkite.com/julialang/metal-dot-jl/builds/1881#0196445f-e2c3-4961-9eb1-6819b6b2adab

I don't actually know if this will fix the issue, but this is something that should be fixed regardless