### PR TITLE
Clean up test imports

### DIFF
--- a/test/device/intrinsics/atomics.jl
+++ b/test/device/intrinsics/atomics.jl
@@ -1,5 +1,3 @@
-using Random
-
 @testset "atomics" begin
 
 n = 128 # NOTE: also hard-coded in MtlThreadGroupArray constructors

--- a/test/device/intrinsics/math.jl
+++ b/test/device/intrinsics/math.jl
@@ -1,5 +1,4 @@
 using Metal: metal_support
-using Random
 using SpecialFunctions
 
 ############################################################################################

--- a/test/device/intrinsics/simd.jl
+++ b/test/device/intrinsics/simd.jl
@@ -1,5 +1,3 @@
-using Random
-
 @testset "simd intrinsics" begin
 
 @testset "$f($typ)" for typ in [Float32, Float16, Int32, UInt32, Int16, UInt16, Int8, UInt8], (f,res_idx) in [(simd_shuffle_down, 1), (simd_shuffle_up, 32)]

--- a/test/device/intrinsics/synchronization.jl
+++ b/test/device/intrinsics/synchronization.jl
@@ -1,4 +1,3 @@
-using Random
 @testset "synchronization" begin
     # host/device synchronization
     let

--- a/test/mps/linalg.jl
+++ b/test/mps/linalg.jl
@@ -1,5 +1,3 @@
-using LinearAlgebra
-
 if MPS.is_supported(device())
 
 @testset "mixed-precision matrix matrix multiplication" begin

--- a/test/mps/ndarray.jl
+++ b/test/mps/ndarray.jl
@@ -1,7 +1,6 @@
 #
 # matrix descriptor
 #
-using Metal
 using .MPS: MPSNDArrayDescriptor, MPSDataType, lengthOfDimension, descriptor, resourceSize
 @static if Metal.macos_version() >= v"15"
     using .MPS: userBuffer

--- a/test/mpsgraphs/core.jl
+++ b/test/mpsgraphs/core.jl
@@ -1,4 +1,3 @@
-
 if MPS.is_supported(device())
 
 using .MPS: MPSShape

--- a/test/mpsgraphs/linalg.jl
+++ b/test/mpsgraphs/linalg.jl
@@ -1,6 +1,3 @@
-using LinearAlgebra
-
-
 if MPS.is_supported(device())
 
 @testset "mixed-precision matrix matrix multiplication" begin

--- a/test/mpsgraphs/random.jl
+++ b/test/mpsgraphs/random.jl
@@ -1,5 +1,3 @@
-using BFloat16s
-
 if MPS.is_supported(device())
 
 using .MPSGraphs: MPSGraphRandomOpDescriptor, MPSGraphRandomDistributionNormal, MPSGraphRandomDistributionTruncatedNormal, MPSGraphRandomDistributionUniform

--- a/test/mpsgraphs/random.jl
+++ b/test/mpsgraphs/random.jl
@@ -18,7 +18,7 @@ using .MPSGraphs: MPSGraphRandomOpDescriptor, MPSGraphRandomDistributionNormal, 
                       (MPSGraphRandomDistributionUniform, Float16),
                       (MPSGraphRandomDistributionUniform, BFloat16),
                       ]
-        @test MPSGraphRandomOpDescriptor(MPSGraphRandomDistributionNormal, Float32) isa MPSGraphRandomOpDescriptor
+        @test MPSGraphRandomOpDescriptor(dist, T) isa MPSGraphRandomOpDescriptor
     end
 end
 

--- a/test/mtl/metal.jl
+++ b/test/mtl/metal.jl
@@ -491,6 +491,6 @@ end
 
 # TODO: continue adding tests
 
-end
+end # @autoreleasepool begin
 
-end
+end # @testset "MTL" begin

--- a/test/mtl/size.jl
+++ b/test/mtl/size.jl
@@ -1,4 +1,3 @@
-
 @testset "size" begin
     dim1 = rand(UInt64)
     dim2 = rand(UInt64)

--- a/test/profiling.jl
+++ b/test/profiling.jl
@@ -30,8 +30,8 @@ cd(tmpdir) do
     @test isdir("julia_1.trace")
 end
 
-end
-end
-end
+end # cd(tmpdir) do
+end # mktempdir() do tmpdir
+end # if run_tests
 
 end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -1,4 +1,4 @@
-using Distributed, Test, Metal, Adapt, ObjectiveC, ObjectiveC.Foundation
+using Distributed, Test, Metal, Adapt, ObjectiveC, ObjectiveC.Foundation, BFloat16s
 
 # GPUArrays has a testsuite that isn't part of the main package.
 # Include it directly.

--- a/test/version.jl
+++ b/test/version.jl
@@ -1,4 +1,4 @@
-@testset "Version" begin
+@testset "version" begin
 
 @test Metal.darwin_version() isa VersionNumber
 @test Metal.macos_version() isa VersionNumber
@@ -8,4 +8,4 @@
 @test Metal.air_support() isa VersionNumber
 @test Metal.metal_support() isa VersionNumber
 
-end # testset "Version"
+end # testset "version"


### PR DESCRIPTION
Also fixes a bug oversight in the tests for `MPSGraphRandomOpDescriptor`.

I left the specific imports (eg. `using .MPS: something`) in their respective files.

I moved the `BFloat16s` import to setup.jl since it would eventually get moved there with #446 regardless. I left the `SpecialFunctions` in the math intrinsics test file because it's the only set of tests that require it, but I can move it to setup.jl if people think that would be best.