### PR TITLE
Adding definition for KA.functional

### DIFF
--- a/src/MetalKernels.jl
+++ b/src/MetalKernels.jl
@@ -28,6 +28,9 @@ KA.ones(::MetalBackend, ::Type{T}, dims::Tuple) where T = Metal.ones(T, dims)
 
 KA.get_backend(::MtlArray) = MetalBackend()
 KA.synchronize(::MetalBackend) = synchronize()
+
+KA.functional(::MetalBackend) = Metal.functional()
+
 KA.supports_float64(::MetalBackend) = false
 KA.supports_atomics(::MetalBackend) = false
 


### PR DESCRIPTION
This is just a very minor addition: I merely added a definition for `KernelAbstractions.functional(::MetalBackend)`.