### PR TITLE
Add bare minimum for macOS 26 Tahoe

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Metal"
 uuid = "dde4c033-4e86-420c-a63e-0dd931031962"
-version = "1.6.0"
+version = "1.6.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ Toolchain:
 - LLVM: 16.0.6
 
 Julia packages:
-- Metal.jl: 1.6.0
+- Metal.jl: 1.6.1
 - GPUArrays: 11.2.2
-- GPUCompiler: 1.5.1
-- KernelAbstractions: 0.9.34
+- GPUCompiler: 1.5.2
+- KernelAbstractions: 0.9.35
 - ObjectiveC: 3.4.1
 - LLVM: 9.4.0
 - LLVMDowngrader_jll: 0.6.0+0

--- a/lib/mtl/compile-opts.jl
+++ b/lib/mtl/compile-opts.jl
@@ -14,6 +14,7 @@ const language_versions = Dict(
     MTLLanguageVersion3_0 => v"3.0",
     MTLLanguageVersion3_1 => v"3.1",
     MTLLanguageVersion3_2 => v"3.2",
+    MTLLanguageVersion4_0 => v"4.0",
 )
 
 function Base.convert(::Type{VersionNumber}, ver::MTLLanguageVersion)

--- a/lib/mtl/libmtl.jl
+++ b/lib/mtl/libmtl.jl
@@ -853,6 +853,7 @@ end
     MTLLanguageVersion3_0 = 0x0000000000030000
     MTLLanguageVersion3_1 = 0x0000000000030001
     MTLLanguageVersion3_2 = 0x0000000000030002
+    MTLLanguageVersion4_0 = 0x0000000000040000
 end
 
 @cenum MTLLibraryType::Int64 begin


### PR DESCRIPTION
The errors this fixes only show up when testing with a version of Julia compiled on macOS 26.

I'm thinking of waiting a couple beta versions before adding the rest of the wrappers in case things change.