### PR TITLE
Handle broadcasting when storage types are different

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -12,9 +12,14 @@ BroadcastStyle(W::Type{<:WrappedMtlArray{T,N}}) where {T,N} =
 
 # when we are dealing with different buffer styles, we cannot know
 # which one is better, so use shared memory
-BroadcastStyle(::MtlArrayStyle{N, S1},
-               ::MtlArrayStyle{N, S2}) where {N,S1,S2} =
-    MtlArrayStyle{N, SharedStorage}()
+BroadcastStyle(::MtlArrayStyle{N1, S1},
+               ::MtlArrayStyle{N2, S2}) where {N1,N2,S1,S2} =
+    MtlArrayStyle{max(N1, N2), SharedStorage}()
+
+# resolve ambiguity: different N, same memory type
+BroadcastStyle(::MtlArrayStyle{N1, S},
+               ::MtlArrayStyle{N2, S}) where {N1,N2,S} =
+    MtlArrayStyle{max(N1, N2), S}()
 
 # allocation of output arrays
 Base.similar(::Broadcasted{MtlArrayStyle{N, S}}, ::Type{T}, dims) where {T, N, S} =

--- a/test/array.jl
+++ b/test/array.jl
@@ -557,24 +557,24 @@ end
     @test testf(x->min.(x, one(Float32)), randn(Float32, 1000))
     @test testf(x->min.(max.(x, zero(Float32)), one(Float32)), randn(Float32, 1000))
     @test testf(x->max.(min.(x, one(Float32)), zero(Float32)), randn(Float32, 1000))
-end
 
-@testset "preserving buffer types" begin
+    # preserving buffer types
     let x = Metal.zeros(Float32, 1; storage=Metal.SharedStorage)
         y = x .+ 1
-        @test !is_private(y) && is_shared(y) && !is_managed(y)
+        @test is_shared(y)
     end
 
-    # when storages are different, choose private
+    # when storages are different, choose shared
     let x = Metal.zeros(Float32, 1; storage=Metal.SharedStorage), y = Metal.zeros(Float32, 1; storage=Metal.PrivateStorage)
         z = x .+ y
-        @test !is_private(z) && is_shared(z) && !is_managed(z)
+        @test is_shared(z)
     end
 
     let x = Metal.zeros(Float32, 2, 2; storage=Metal.SharedStorage), y = Metal.zeros(Float32, 2; storage=Metal.PrivateStorage)
         z = x .+ y
-        @test !is_private(z) && is_shared(z) && !is_managed(z)
+        @test is_shared(z)
     end
 end
+
 
 end

--- a/test/array.jl
+++ b/test/array.jl
@@ -559,4 +559,22 @@ end
     @test testf(x->max.(min.(x, one(Float32)), zero(Float32)), randn(Float32, 1000))
 end
 
+@testset "preserving buffer types" begin
+    let x = Metal.zeros(Float32, 1; storage=Metal.SharedStorage)
+        y = x .+ 1
+        @test !is_private(y) && is_shared(y) && !is_managed(y)
+    end
+
+    # when storages are different, choose private
+    let x = Metal.zeros(Float32, 1; storage=Metal.SharedStorage), y = Metal.zeros(Float32, 1; storage=Metal.PrivateStorage)
+        z = x .+ y
+        @test !is_private(z) && is_shared(z) && !is_managed(z)
+    end
+
+    let x = Metal.zeros(Float32, 2, 2; storage=Metal.SharedStorage), y = Metal.zeros(Float32, 2; storage=Metal.PrivateStorage)
+        z = x .+ y
+        @test !is_private(z) && is_shared(z) && !is_managed(z)
+    end
+end
+
 end


### PR DESCRIPTION
Fixes a broadcasting issue when the arrays have different dimensions and storage types. 

Previously this MWE would fail:
```julia
x = Metal.zeros(10, 10, storage=Metal.SharedStorage)
y = Metal.zeros(10)
x .+ y # Error: conflicting broadcast rules defined
```
