### PR TITLE
Don't warn on macOS 26 and bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Metal"
 uuid = "dde4c033-4e86-420c-a63e-0dd931031962"
-version = "1.6.2"
+version = "1.6.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/README.md
+++ b/README.md
@@ -66,17 +66,17 @@ julia> Metal.versioninfo()
 macOS 15.5.0, Darwin 24.5.0
 
 Toolchain:
-- Julia: 1.11.5
+- Julia: 1.11.6
 - LLVM: 16.0.6
 
 Julia packages:
-- Metal.jl: 1.6.2
-- GPUArrays: 11.2.2
-- GPUCompiler: 1.5.2
-- KernelAbstractions: 0.9.35
-- ObjectiveC: 3.4.1
-- LLVM: 9.4.0
-- LLVMDowngrader_jll: 0.6.0+0
+- Metal.jl: 1.6.3
+- GPUArrays: 11.2.3
+- GPUCompiler: 1.6.1
+- KernelAbstractions: 0.9.37
+- ObjectiveC: 3.4.2
+- LLVM: 9.4.2
+- LLVMDowngrader_jll: 0.6.0+1
 
 1 device:
 - Apple M2 Max (64.000 KiB allocated)

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -36,8 +36,8 @@ function __init__()
     if macos_version() < v"13"
         @error "Metal.jl requires macOS 13 or later"
         return
-    elseif macos_version() >= v"16"
-        @warn "Metal.jl has not been tested on macOS 16 or later, you may run into issues."
+    elseif macos_version() >= v"27"
+        @warn "Metal.jl has not been tested on macOS 27 or later, you may run into issues."
     end
 
     if Base.JLOptions().debug_level >= 2


### PR DESCRIPTION
All tests are passing for current Metal 3 functionality, so we can probably remove this warning for macOS 26. I wouldn't update the README until it's actually released however.