### PR TITLE
Return the old value from atomic_fetch_op_explicit.

### DIFF
--- a/src/device/intrinsics/atomics.jl
+++ b/src/device/intrinsics/atomics.jl
@@ -112,7 +112,7 @@ end
         cmp = old
         new = convert(T, op(old, val))
         old = atomic_compare_exchange_weak_explicit(ptr, cmp, new)
-        isequal(old, cmp) && return new
+        isequal(old, cmp) && return old
     end
 end
 


### PR DESCRIPTION
This matches the behavior of Metal's atomic_fetch_add_explicit and friends. I'm not sure this is the best behavior, but it's already being relied on by Atomix.jl, so let's bring atomic_fetch_op_explicit into the fold to make https://github.com/JuliaConcurrent/Atomix.jl/pull/60 work.