### PR TITLE
Revert "Synchronize using `MTLSharedEvent`s"

### DIFF
--- a/lib/mtl/events.jl
+++ b/lib/mtl/events.jl
@@ -29,10 +29,6 @@ function MTLSharedEvent(dev::MTLDevice)
     return obj
 end
 
-function waitUntilSignaledValue(ev::MTLSharedEvent, value, timeoutMS=typemax(UInt64))
-    @objc [ev::id{MTLSharedEvent} waitUntilSignaledValue:value::UInt64
-                        timeoutMS:timeoutMS::UInt64]::Bool
-end
 
 ## shared event handle
 


### PR DESCRIPTION
Reverts JuliaGPU/Metal.jl#633

The MTLCaptureManager failures seems to be related. Not much info online about how `stopCapture` works but it seems like the capture manager's `isCapturing` property does not change to false until the command buffer status is `MTLCommandBufferStatusCompleted`, which the new synchronization via events method does not wait for.

Will reland after determining how to deal with this for capturing.