### PR TITLE
Remove support for `MtlArray`s backed by managed storage.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,10 +37,10 @@ steps:
               soft_fail: true
 
   # special tests
-  - group: ":floppy_disk: Storage Modes"
+  - group: ":floppy_disk: Shared (unified) Storage"
     depends_on: "julia"
     steps:
-      - label: "{{matrix.storage}} array storage"
+      - label: "shared array storage"
         plugins:
           - JuliaCI/julia#v1:
               version: "1.11"
@@ -57,13 +57,8 @@ steps:
             build.message !~ /\[skip tests\]/ &&
             build.message !~ /\[skip storage\]/
         timeout_in_minutes: 60
-        matrix:
-          setup:
-            storage:
-              - "shared"
-              - "managed"
         commands: |
-          echo -e "[Metal]\ndefault_storage = \"{{matrix.storage}}\"" >LocalPreferences.toml
+          echo -e "[Metal]\ndefault_storage = \"shared\"" >LocalPreferences.toml
 
   # special tests
   - group: ":eyes: Special"

--- a/lib/mtl/storage_type.jl
+++ b/lib/mtl/storage_type.jl
@@ -5,7 +5,7 @@ export ReadUsage, WriteUsage, ReadWriteUsage
 # SharedStorage  -> Buffer in Host memory, accessed by the GPU. Requires no sync
 # ManagedStorage -> Mirrored memory buffers in host and GPU. Requires syncing
 # PrivateStorage -> Memory in Device, not accessible by Host.
-# Memoryless -> iOS stuff. ignore it
+# Memoryless -> render pipeline stuff. ignore it (for now)
 
 abstract type StorageMode end
 
@@ -16,7 +16,7 @@ Used to indicate that the resource is stored using `MTLStorageModeShared` in mem
 
 For more information on Metal storage modes, refer to the official Metal documentation.
 
-See also [`Metal.PrivateStorage`](@ref) and [`Metal.ManagedStorage`](@ref).
+See also [`Metal.PrivateStorage`](@ref).
 """
 struct SharedStorage  <: StorageMode end
 
@@ -26,6 +26,9 @@ struct SharedStorage  <: StorageMode end
 Used to indicate that the resource is stored using `MTLStorageModeManaged` in memory.
 
 For more information on Metal storage modes, refer to the official Metal documentation.
+
+!!! warning
+    `ManagedStorage` is no longer supported with `MtlArray`s. Instead, use `SharedStorage` or use the Metal api directly from `Metal.MTL`.
 
 See also [`Metal.SharedStorage`](@ref) and [`Metal.PrivateStorage`](@ref).
 """
@@ -38,7 +41,7 @@ Used to indicate that the resource is stored using `MTLStorageModePrivate` in me
 
 For more information on Metal storage modes, refer to the official Metal documentation.
 
-See also [`Metal.SharedStorage`](@ref) and [`Metal.ManagedStorage`](@ref).
+See also [`Metal.SharedStorage`](@ref).
 """
 struct PrivateStorage <: StorageMode end
 struct Memoryless     <: StorageMode end
@@ -46,7 +49,6 @@ struct Memoryless     <: StorageMode end
 # Remove the ".MTL" when printing
 Base.show(io::IO, ::Type{<:PrivateStorage}) = print(io, "Metal.PrivateStorage")
 Base.show(io::IO, ::Type{<:SharedStorage}) = print(io, "Metal.SharedStorage")
-Base.show(io::IO, ::Type{<:ManagedStorage}) = print(io, "Metal.ManagedStorage")
 
 """
     MTL.CPUStorage

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -44,9 +44,6 @@ function Base.unsafe_copyto!(dev::MTLDevice, dst::MtlPtr{T}, src::Ptr{T}, N::Int
         free(tmp_buf)
     elseif storage_type == MTL.MTLStorageModeShared
         unsafe_copyto!(convert(Ptr{T}, dst), src, N)
-    elseif storage_type == MTL.MTLStorageModeManaged
-        unsafe_copyto!(convert(Ptr{T}, dst), src, N)
-        MTL.DidModifyRange!(dst.buffer, 1:N)
     end
     return dst
 end
@@ -72,14 +69,6 @@ function Base.unsafe_copyto!(dev::MTLDevice, dst::Ptr{T}, src::MtlPtr{T}, N::Int
         end
         free(tmp_buf)
     elseif storage_type ==  MTL.MTLStorageModeShared
-        unsafe_copyto!(dst, convert(Ptr{T}, src), N)
-    elseif storage_type ==  MTL.MTLStorageModeManaged
-        cmdbuf = MTLCommandBuffer(queue) do cmdbuf
-            MTLBlitCommandEncoder(cmdbuf) do enc
-                append_sync!(enc, src.buffer)
-            end
-        end
-        wait_completed(cmdbuf)
         unsafe_copyto!(dst, convert(Ptr{T}, src), N)
     end
     return dst

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -35,7 +35,7 @@ const alloc_stats = AllocStats()
     alloc(device, bytesize, [ptr=nothing];
           storage=Default, hazard_tracking=Default, cache_mode=Default)
 
-Allocates a Metal buffer on `device` of`bytesize` bytes. If a CPU-pointer is passed as last
+Allocates a Metal buffer on `device` of `bytesize` bytes. If a CPU-pointer is passed as last
 argument, then the buffer is initialized with the content of the memory starting at `ptr`,
 otherwise it's zero-initialized.
 
@@ -44,9 +44,7 @@ otherwise it's zero-initialized.
 The storage kwarg controls where the buffer is stored. Possible values are:
  - PrivateStorage : Residing on the device
  - SharedStorage  : Residing on the host
- - ManagedStorage : Keeps two copies of the buffer, on device and on host. Explicit calls must be
-   given to syncronize the two
- - Memoryless : an iOS specific thing that won't work on Mac.
+ - Memoryless : A render pipeline exclusive mode. Render pipelines are not yet supported on Metal.jl.
 
 Note that `PrivateStorage` buffers can't be directly accessed from the CPU, therefore you cannot
 use this option if you pass a ptr to initialize the memory.

--- a/test/array.jl
+++ b/test/array.jl
@@ -1,4 +1,4 @@
-STORAGEMODES = [Metal.PrivateStorage, Metal.SharedStorage, Metal.ManagedStorage]
+STORAGEMODES = [Metal.PrivateStorage, Metal.SharedStorage]
 
 @testset "array" begin
 
@@ -158,7 +158,7 @@ check_storagemode(arr, smode) = Metal.storagemode(arr) == smode
     # private storage errors.
     if SM == Metal.PrivateStorage
         let arr_mtl = Metal.zeros(Float32, dim...; storage=Metal.PrivateStorage)
-            @test is_private(arr_mtl) && !is_shared(arr_mtl) && !is_managed(arr_mtl)
+            @test is_private(arr_mtl) && !is_shared(arr_mtl)
             @test_throws "Cannot access the contents of a private buffer" arr_cpu = unsafe_wrap(Array{Float32}, arr_mtl, dim)
         end
 
@@ -169,22 +169,12 @@ check_storagemode(arr, smode) = Metal.storagemode(arr) == smode
         end
     elseif SM == Metal.SharedStorage
         let arr_mtl = Metal.zeros(Float32, dim...; storage=Metal.SharedStorage)
-            @test !is_private(arr_mtl) && is_shared(arr_mtl) && !is_managed(arr_mtl)
+            @test !is_private(arr_mtl) && is_shared(arr_mtl)
             @test unsafe_wrap(Array{Float32}, arr_mtl) isa Array{Float32}
         end
 
         let b = rand(Float32, 10)
             arr_mtl = mtl(b; storage=Metal.SharedStorage)
-            @test arr_mtl[1] == b[1]
-        end
-    elseif SM == Metal.ManagedStorage
-        let arr_mtl = Metal.zeros(Float32, dim...; storage=Metal.ManagedStorage)
-            @test !is_private(arr_mtl) && !is_shared(arr_mtl) && is_managed(arr_mtl)
-            @test unsafe_wrap(Array{Float32}, arr_mtl) isa Array{Float32}
-        end
-
-        let b = rand(Float32, 10)
-            arr_mtl = mtl(b; storage=Metal.ManagedStorage)
             @test arr_mtl[1] == b[1]
         end
     end


### PR DESCRIPTION
Metal.jl only supports Apple silicon which have unified memory. Managed storage through the MtlArray interface has never been very well supported and it's a pain to maintain whenever it comes up.

The API wrappers are untouched.

If anyone objects, please speak up. I'm curious to hear about why shared storage cannot be used in lieu of managed storage.

Close #642
