### PR TITLE
Don't transpose empty MtlArrays

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -245,6 +245,8 @@ end
                                                    A::MtlMatrix{T}) where {T}
     axes(B, 2) == axes(A, 1) && axes(B, 1) == axes(A, 2) || throw(DimensionMismatch("transpose"))
 
+    isempty(B) && return B
+
     M, N = size(A)
     dev = device()
     queue = global_queue(dev)


### PR DESCRIPTION
Fix #656

Should I backport this to 1.7? `main` has some feature removals so it should probably be 1.8 or 2.0 and I would also like to remove macOS 13 guards and support with the next release.