### PR TITLE
Switch to `macos-15-intel` for x64 load tests

### DIFF
--- a/.github/workflows/Load.yml
+++ b/.github/workflows/Load.yml
@@ -26,7 +26,7 @@ jobs:
           - '1'    # latest stable 1.x release
         os:
           - 'ubuntu-latest'
-          - 'macOS-13'
+          - 'macOS-15-intel'
           - 'windows-latest'
         arch:
           - x64


### PR DESCRIPTION
Also make architecture detection in the test script a bit more robust.

This was originally to move to buildkite but then github actions `macos-15-intel` runners were [announced](https://github.com/actions/runner-images/issues/13045).