### PR TITLE
Bump `BFloat16s` compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -33,7 +33,7 @@ SpecialFunctionsExt = "SpecialFunctions"
 
 [compat]
 Adapt = "4"
-BFloat16s = "0.5"
+BFloat16s = "0.5, 0.6"
 CEnum = "0.4, 0.5"
 CodecBzip2 = "0.8.5"
 ExprTools = "0.1"


### PR DESCRIPTION
BFloat16s.jl v0.5.1 will continue to be used until https://github.com/JuliaLLVM/LLVM.jl/pull/526 is merged and registered