### PR TITLE
Upgrade to ParallelTestRunner v2

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -21,4 +21,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-ParallelTestRunner = "1"
+ParallelTestRunner = "2"


### PR DESCRIPTION
`--quickfail` is broken in v1.0.3