### PR TITLE
Fix `macos_version` and `darwin_version` docstrings in docs

### DIFF
--- a/docs/src/api/essentials.md
+++ b/docs/src/api/essentials.md
@@ -2,8 +2,8 @@
 
 ## Versions and Support
 ```@docs
-Metal.macos_version
-Metal.darwin_version
+macos_version
+darwin_version
 Metal.metal_support
 Metal.metallib_support
 Metal.air_support

--- a/src/Metal.jl
+++ b/src/Metal.jl
@@ -10,7 +10,7 @@ import LLVMDowngrader_jll
 using Preferences: @load_preference, load_preference
 using ExprTools: splitdef, combinedef
 using ObjectiveC, .CoreFoundation, .Foundation, .Dispatch, .OS
-import ObjectiveC: is_macos, darwin_version, macos_version
+import ObjectiveC: is_macos
 import KernelAbstractions
 using ScopedValues
 

--- a/src/version.jl
+++ b/src/version.jl
@@ -1,3 +1,22 @@
+export macos_version, darwin_version
+
+"""
+    macos_version()::VersionNumber
+
+Returns the host macOS version.
+
+See also [`Metal.darwin_version`](@ref).
+"""
+const macos_version = ObjectiveC.macos_version
+
+"""
+    darwin_version()::VersionNumber
+
+Returns the host Darwin kernel version.
+
+See also [`Metal.macos_version`](@ref).
+"""
+const darwin_version = ObjectiveC.darwin_version
 
 ## support queries
 


### PR DESCRIPTION
[only docs]
[only tests]

Close #643