### PR TITLE
fix `rand(::AbstractRange{Int64})`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Metal"
 uuid = "dde4c033-4e86-420c-a63e-0dd931031962"
-version = "1.9.0"
+version = "1.9.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/device/random.jl
+++ b/src/device/random.jl
@@ -181,3 +181,6 @@ end
 @device_override @inline function Random.randexp(rng::Philox2x32, ::Type{T}) where {T <: AbstractFloat}
     @invoke Random.randexp(rng::AbstractRNG, T::Type{<:AbstractFloat})
 end
+
+@device_override Random.Sampler(::Type{<:AbstractRNG}, r::AbstractUnitRange{T},
+                                ::Random.Repetition) where {T<:Union{Int64, UInt64}} = Random.SamplerRangeFast(r)

--- a/test/device/random.jl
+++ b/test/device/random.jl
@@ -125,3 +125,24 @@ end
         @test Array(a) == Array(b)
     end
 end
+
+@testset "rand(::AbstractRange{$T}), seed $seed" for T in (Int32, Int64, UInt32, UInt64), seed in (nothing, #=missing,=# 1234)
+    function kernel(A::AbstractArray{T}, seed) where {T}
+        apply_seed(seed)
+        tid = thread_position_in_grid().x
+        A[tid] = rand(T(10):T(20))
+        return
+    end
+
+    a = Metal.zeros(T, n)
+    b = Metal.zeros(T, n)
+
+    @metal threads=n kernel(a, seed)
+    @metal threads=n kernel(b, seed)
+
+    if seed === nothing || seed === missing
+        @test Array(a) != Array(b)
+    else
+        @test Array(a) == Array(b)
+    end
+end


### PR DESCRIPTION
Previously, the default method would widen to `Int128` causing
compilation failures

ref JuliaGPU/OpenCL.jl#402
