### PR TITLE
Use GPU blit for large SharedStorage GPU→GPU copies (>32MB)

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -440,13 +440,12 @@ function Base.unsafe_copyto!(dev::MTLDevice, dest::MtlArray{T}, doffs, src::MtlA
     end
     return dest
 end
-const GPU_COPY_THRESH = 32 * 2^20  # 32 MiB threshold. Factored out for testing
 function Base.unsafe_copyto!(dev::MTLDevice, dest::MtlArray{T, <:Any, Metal.SharedStorage}, doffs, src::MtlArray{T, <:Any, Metal.SharedStorage}, soffs, n) where {T}
     synchronize()
     bytes = n * sizeof(T)
     # Use GPU blit for large copies (>32MiB) where it's faster than CPU memcpy.
     # For small copies, CPU memcpy avoids GPU command buffer overhead.
-    if bytes >= GPU_COPY_THRESH
+    if bytes >= 32 * 2^20 # If changed, also change in tests
         GC.@preserve src dest unsafe_copyto!(dev, pointer(dest, doffs), pointer(src, soffs), n)
         if Base.isbitsunion(T)
             error("Not implemented")

--- a/test/array.jl
+++ b/test/array.jl
@@ -92,7 +92,7 @@ end
         end
 
         # Large array, only test Float32
-        A = rand(Float32, Metal.GPU_COPY_THRESH)
+        A = rand(Float32, 32 * 2^20)
         mtlA = mtl(A; storage = S)
         res = similar(A)
         copyto!(res, mtlA)


### PR DESCRIPTION
SharedStorage GPU→GPU `copyto!` currently always uses CPU memcpy, which becomes a bottleneck for large buffers. This PR adds a size-based heuristic that uses GPU blit for copies larger than 32MB, achieving up to 3.6x speedup.

## Problem

PR #445 introduced CPU memcpy for SharedStorage copies to avoid ObjectiveC.jl overhead. This is beneficial for small copies where the overhead dominates, but causes significant performance regression for large copies where GPU blit would be much faster due to its higher memory bandwidth.

## Solution

Use a size-based threshold (32MB) to choose the optimal path:
- **≤32MB**: CPU memcpy (avoids API overhead)
- **>32MB**: GPU blit (full memory bandwidth)

### Why 32MB?

The threshold is based on amortizing the fixed overhead against the bandwidth differential:
- Fixed overhead (command buffer creation, etc.): ~235 μs
- CPU memcpy bandwidth: ~53 GB/s
- GPU blit bandwidth: ~180 GB/s

Using the crossover formula `threshold = overhead / (1/cpu_bw - 1/gpu_bw)`, the theoretical crossover is ~17MB. We use 32MB as a conservative margin to ensure no regression at the boundary.

## Benchmark Results

**GPU→GPU SharedStorage (improved by this change):**

| Size | Old (CPU memcpy) | New (heuristic) | Speedup |
|------|------------------|-----------------|---------|
| 32 MB | 0.62 ms (54 GB/s) | 0.67 ms (50 GB/s) | ~1.0x |
| 64 MB | 3.28 ms (20 GB/s) | 1.19 ms (57 GB/s) | **2.8x** |
| 128 MB | 2.72 ms (49 GB/s) | 1.25 ms (108 GB/s) | **2.2x** |
| 256 MB | 6.54 ms (41 GB/s) | 2.08 ms (129 GB/s) | **3.1x** |
| 512 MB | 9.98 ms (54 GB/s) | 3.12 ms (172 GB/s) | **3.2x** |
| 1024 MB | 21.55 ms (50 GB/s) | 5.98 ms (180 GB/s) | **3.6x** |
| 2048 MB | 39.96 ms (54 GB/s) | 11.74 ms (183 GB/s) | **3.4x** |
| 4096 MB | 79.75 ms (54 GB/s) | 23.34 ms (184 GB/s) | **3.4x** |
| 8192 MB | 159.67 ms (54 GB/s) | 46.07 ms (186 GB/s) | **3.5x** |

*Measured on M2 Max.*

## Community Benchmark Script

Copy-paste into a Julia REPL to test on your device:

```julia
using Metal

println("Device: ", Metal.device().name)
println("Testing SharedStorage GPU→GPU copyto! performance\n")

sizes_mb = [16, 32, 64, 128, 256, 512, 1024, 2048]

println("| Size (MB) | Time (ms) | Bandwidth (GB/s) |")
println("|-----------|-----------|------------------|")

for size_mb in sizes_mb
    n = size_mb * 1024^2 ÷ sizeof(Float32)

    src = MtlArray{Float32, 1, Metal.SharedStorage}(rand(Float32, n))
    dst = MtlArray{Float32, 1, Metal.SharedStorage}(undef, n)
    Metal.synchronize()

    # Warmup
    for _ in 1:3
        copyto!(dst, src)
        Metal.synchronize()
    end

    # Benchmark (10 iterations)
    times = Float64[]
    for _ in 1:10
        Metal.synchronize()
        t = @elapsed begin
            copyto!(dst, src)
            Metal.synchronize()
        end
        push!(times, t)
    end

    time_ms = minimum(times) * 1000
    bytes = n * sizeof(Float32)
    bandwidth = bytes / minimum(times) / 1e9

    println("| $size_mb | $(round(time_ms, digits=2)) | $(round(bandwidth, digits=1)) |")

    src = dst = nothing
    GC.gc(false)
end
```

**Results on M2 Max (main vs PR):**

| Size (MB) | main (GB/s) | PR (GB/s) | Speedup |
|-----------|-------------|-----------|---------|
| 16 | 30 | 40 | 1.3x |
| 32 | 41 | 46 | 1.1x |
| 64 | 54 | 82 | **1.5x** |
| 128 | 54 | 111 | **2.0x** |
| 256 | 55 | 164 | **3.0x** |
| 512 | 55 | 176 | **3.2x** |
| 1024 | 54 | 182 | **3.4x** |
| 2048 | 54 | 185 | **3.5x** |

The `main` branch plateaus at ~54 GB/s due to CPU memcpy, while the PR achieves ~180-185 GB/s via GPU blit for large copies.

The 32MB threshold can be adjusted if community testing on other devices suggests a different value.

## Key Points

1. **No regression for small copies**: ≤32MB uses same CPU memcpy path as before
2. **Significant speedup for large copies**: 2.8-3.6x faster for >32MB
3. **CPU↔GPU paths unchanged**: Only GPU→GPU SharedStorage is affected