### PR TITLE
Shorten timeout for hanging 1.13 tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,6 +31,9 @@ steps:
               - "1.10"
               - "1.11"
               - "1.12"
+
+  - group: ":soon: Pre-releases"
+    steps:
       - label: "Julia pre-release {{matrix.julia}}"
         plugins:
           - JuliaCI/julia#v1:


### PR DESCRIPTION
1.13 tests have been hanging. This reduces timeout and and makes the special tests able to start before the pre-release tests fail