### PR TITLE
Add `UInt16` argument intrinsics

### DIFF
--- a/test/device/intrinsics/arguments.jl
+++ b/test/device/intrinsics/arguments.jl
@@ -56,6 +56,29 @@
     @on_device threads_per_threadgroup_2d()
     @on_device threads_per_threadgroup_3d()
 
+    # UInt16
+    @on_device dispatch_quadgroups_per_threadgroup_i16()
+    @on_device dispatch_simdgroups_per_threadgroup_i16()
+    @on_device quadgroup_index_in_threadgroup_i16()
+    @on_device quadgroups_per_threadgroup_i16()
+    @on_device simdgroup_index_in_threadgroup_i16()
+    @on_device simdgroups_per_threadgroup_i16()
+    @on_device thread_index_in_quadgroup_i16()
+    @on_device thread_index_in_simdgroup_i16()
+    @on_device thread_index_in_threadgroup_i16()
+    @on_device thread_execution_width_i16()
+    @on_device threads_per_simdgroup_i16()
+
+    @on_device dispatch_threads_per_threadgroup_i16()
+    @on_device grid_origin_i16()
+    @on_device grid_size_i16()
+    @on_device thread_position_in_grid_i16()
+    @on_device thread_position_in_threadgroup_i16()
+    @on_device threadgroup_position_in_grid_i16()
+    @on_device threadgroups_per_grid_i16()
+    @on_device threads_per_grid_i16()
+    @on_device threads_per_threadgroup_i16()
+
     global const CPU_ONLY_ERR = "This function is not intended for use on the CPU"
 
     @test_throws CPU_ONLY_ERR dispatch_quadgroups_per_threadgroup()
@@ -114,4 +137,27 @@
     @test_throws CPU_ONLY_ERR threads_per_threadgroup_1d()
     @test_throws CPU_ONLY_ERR threads_per_threadgroup_2d()
     @test_throws CPU_ONLY_ERR threads_per_threadgroup_3d()
+
+    # UInt16
+    @test_throws CPU_ONLY_ERR dispatch_quadgroups_per_threadgroup_i16()
+    @test_throws CPU_ONLY_ERR dispatch_simdgroups_per_threadgroup_i16()
+    @test_throws CPU_ONLY_ERR quadgroup_index_in_threadgroup_i16()
+    @test_throws CPU_ONLY_ERR quadgroups_per_threadgroup_i16()
+    @test_throws CPU_ONLY_ERR simdgroup_index_in_threadgroup_i16()
+    @test_throws CPU_ONLY_ERR simdgroups_per_threadgroup_i16()
+    @test_throws CPU_ONLY_ERR thread_index_in_quadgroup()
+    @test_throws CPU_ONLY_ERR thread_index_in_simdgroup_i16()
+    @test_throws CPU_ONLY_ERR thread_index_in_threadgroup_i16()
+    @test_throws CPU_ONLY_ERR thread_execution_width_i16()
+    @test_throws CPU_ONLY_ERR threads_per_simdgroup_i16()
+
+    @test_throws CPU_ONLY_ERR dispatch_threads_per_threadgroup_i16()
+    @test_throws CPU_ONLY_ERR grid_origin_i16()
+    @test_throws CPU_ONLY_ERR grid_size_i16()
+    @test_throws CPU_ONLY_ERR thread_position_in_grid_i16()
+    @test_throws CPU_ONLY_ERR thread_position_in_threadgroup_i16()
+    @test_throws CPU_ONLY_ERR threadgroup_position_in_grid_i16()
+    @test_throws CPU_ONLY_ERR threadgroups_per_grid_i16()
+    @test_throws CPU_ONLY_ERR threads_per_grid_i16()
+    @test_throws CPU_ONLY_ERR threads_per_threadgroup_i16()
 end


### PR DESCRIPTION
Implemented while debugging a proper fix for #719 but this is also a standalone contribution.

Not added to docstrings yet because similar to how there are limitations to mixing different vector sizes in the indexing intrinsics, there are also limitations to mixing intrinsic return types. See Section 5.2.3.6 of the [Metal Shading Language Specification](https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf) for details.