### PR TITLE
Improve time-to-first-kernel

### DIFF
--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -169,8 +169,13 @@ function compile(@nospecialize(job::CompilerJob))
 
     @signpost_interval log=log_compiler() "Generate LLVM IR" begin
         # TODO: on 1.9, this actually creates a context. cache those.
+        # Run the host-side compiler pipeline in the world frozen at `__init__`
+        # so precompiled native code for it keeps applying. The user's kernel
+        # is still compiled against the user's current world: `job.world` was
+        # set from `tls_world_age()` outside this call and the GPUInterpreter
+        # uses it for all method lookups in the kernel body.
         ir, entry = JuliaContext() do ctx
-            mod, meta = GPUCompiler.compile(:llvm, job)
+            mod, meta = invoke_frozen(GPUCompiler.compile, :llvm, job)
             string(mod), LLVM.name(meta.entry)
         end
     end

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -129,7 +129,6 @@ function compiler_cache(ctx::MTLDevice)
 end
 
 # cache of compiler configurations, per device (but additionally configurable via kwargs)
-const _toolchain = Ref{Any}()
 const _compiler_configs = Dict{UInt, MetalCompilerConfig}()
 function compiler_config(dev; kwargs...)
     h = hash(dev, hash(kwargs))
@@ -169,11 +168,6 @@ function compile(@nospecialize(job::CompilerJob))
 
     @signpost_interval log=log_compiler() "Generate LLVM IR" begin
         # TODO: on 1.9, this actually creates a context. cache those.
-        # Run the host-side compiler pipeline in the world frozen at `__init__`
-        # so precompiled native code for it keeps applying. The user's kernel
-        # is still compiled against the user's current world: `job.world` was
-        # set from `tls_world_age()` outside this call and the GPUInterpreter
-        # uses it for all method lookups in the kernel body.
         ir, entry = JuliaContext() do ctx
             mod, meta = invoke_frozen(GPUCompiler.compile, :llvm, job)
             string(mod), LLVM.name(meta.entry)

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -179,11 +179,12 @@ The output of this function is automatically cached, i.e. you can simply call `m
 in a hot path without degrading performance. New code will be generated automatically when
 the function changes, or when different types or keyword arguments are provided.
 """
-function mtlfunction(f::F, tt::TT=Tuple{}; name=nothing, kwargs...) where {F,TT}
+function mtlfunction(@nospecialize(f), @nospecialize(tt)=Tuple{}; name=nothing, kwargs...)
     dev = device()
     Base.@lock mtlfunction_lock begin
         # compile the function
         cache = compiler_cache(dev)
+        F = Core.Typeof(f)
         source = methodinstance(F, tt)
         config = compiler_config(dev; name, kwargs...)::MetalCompilerConfig
         pipeline = GPUCompiler.cached_compilation(cache, source, config, compile, link)
@@ -197,7 +198,7 @@ function mtlfunction(f::F, tt::TT=Tuple{}; name=nothing, kwargs...) where {F,TT}
             kernel = HostKernel{F,tt}(f, pipeline)
             _kernel_instances[h] = kernel
         end
-        return kernel::HostKernel{F,tt}
+        return kernel
     end
 end
 
@@ -246,7 +247,7 @@ const _kernel_instances = Dict{UInt, Any}()
     ex
 end
 
-@inline function encode_argument!(kernel, arg)
+@inline function encode_argument!(@nospecialize(kernel), arg)
     argtyp = typeof(arg)
 
     # replace non-isbits arguments (they should be unused, or compilation
@@ -263,8 +264,20 @@ end
     return argument_buffer
 end
 
+# Thin outer callable — specializes on HostKernel{F,TT} and args, but the body
+# is trivial (one function call) so it's fast to compile for new kernel types.
 @autoreleasepool function (kernel::HostKernel)(args...; groups=1, threads=1,
                                                queue=global_queue(device()))
+    _metal_launch(kernel, args, groups, threads, queue)
+end
+
+# Heavy body — @nospecialize, compiled once during precompilation and reused for
+# all kernel types. All generic MTL operations (command buffer, validation, etc.) live here.
+function _metal_launch(@nospecialize(kernel::HostKernel), @nospecialize(args::Tuple),
+                       groups, threads, queue)
+    pipeline = kernel.pipeline::MTLComputePipelineState
+    f = kernel.f
+
     gs = MTLSize(groups)
     ts = MTLSize(threads)
     (gs.width>0 && gs.height>0 && gs.depth>0) ||
@@ -284,48 +297,59 @@ end
 
     kernel_state = KernelState(Random.rand(UInt32))
 
-    cmdbuf = MTLCommandBuffer(queue)
-    cmdbuf.label = "MTLCommandBuffer($(nameof(kernel.f)))"
-    cce = MTLComputeCommandEncoder(cmdbuf)
-    argument_buffers = try
-        MTL.set_function!(cce, kernel.pipeline)
-        bufs = encode_arguments!(cce, kernel, kernel_state, kernel.f, args...)
-        MTL.append_current_function!(cce, gs, ts)
-        bufs
-    finally
-        close(cce)
-    end
-
-    # during precompilation, skip GPU submission (which hangs) but keep the
-    # encoding path above to cache compilation of the argument encoding pipeline
-    if ccall(:jl_generating_output, Cint, ()) != 0
-        foreach(free, argument_buffers)
-        return
-    end
-
-    # the command buffer retains resources that are explicitly encoded (i.e. direct buffer
-    # arguments, or the buffers allocated for each other argument), but that doesn't keep
-    # other resources alive for which we've encoded the GPU address ourselves. since it's
-    # possible for buffers to go out of scope while the kernel is still running, which
-    # triggers validation failures, keep track of things we need to keep alive until the
-    # kernel has actually completed.
-    #
-    # TODO: is there a way to bind additional resources to the command buffer?
-    roots = [kernel.f, args]
-    MTL.on_completed(cmdbuf) do buf
-        empty!(roots)
-        foreach(free, argument_buffers)
-
-        # Check for errors
-        # XXX: we cannot do this nicely, e.g. throwing an `error` or reporting with `@error`
-        #      because we're not allowed to switch tasks from this contexts.
-        if buf.status == MTL.MTLCommandBufferStatusError
-            Core.println("ERROR: Failed to submit command buffer: $(buf.error.localizedDescription)")
+    @autoreleasepool begin
+        cmdbuf = MTLCommandBuffer(queue)
+        cmdbuf.label = "MTLCommandBuffer($(nameof(f)))"
+        cce = MTLComputeCommandEncoder(cmdbuf)
+        argument_buffers = try
+            MTL.set_function!(cce, pipeline)
+            bufs = _metal_encode(cce, kernel, kernel_state, f, args)
+            MTL.append_current_function!(cce, gs, ts)
+            bufs
+        finally
+            close(cce)
         end
-    end
 
-    commit!(cmdbuf)
+        # during precompilation, skip GPU submission (which hangs) but keep the
+        # encoding path above to cache compilation of the argument encoding pipeline
+        if ccall(:jl_generating_output, Cint, ()) != 0
+            foreach(free, argument_buffers)
+            return
+        end
+
+        # the command buffer retains resources that are explicitly encoded (i.e. direct buffer
+        # arguments, or the buffers allocated for each other argument), but that doesn't keep
+        # other resources alive for which we've encoded the GPU address ourselves. since it's
+        # possible for buffers to go out of scope while the kernel is still running, which
+        # triggers validation failures, keep track of things we need to keep alive until the
+        # kernel has actually completed.
+        #
+        # TODO: is there a way to bind additional resources to the command buffer?
+        #
+        # collect to Vector so the callback closure type doesn't
+        # depend on the specific kernel's argument buffer tuple type
+        argument_buffer_vec = collect(argument_buffers)
+        roots = Any[f, args]
+        MTL.on_completed(cmdbuf) do buf
+            empty!(roots)
+            foreach(free, argument_buffer_vec)
+
+            # Check for errors
+            # XXX: we cannot do this nicely, e.g. throwing an `error` or reporting with `@error`
+            #      because we're not allowed to switch tasks from this contexts.
+            if buf.status == MTL.MTLCommandBufferStatusError
+                Core.println("ERROR: Failed to submit command buffer: $(buf.error.localizedDescription)")
+            end
+        end
+
+        commit!(cmdbuf)
+    end
 end
+
+# Bridge: specializes on f and args types (encode_arguments! needs concrete types
+# for ghost-type detection), but NOT on the full HostKernel type.
+@inline _metal_encode(cce, @nospecialize(kernel), kernel_state, f, args::Tuple) =
+    encode_arguments!(cce, kernel, kernel_state, f, args...)
 
 ## Intra-warp Helpers
 

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -296,6 +296,13 @@ end
         close(cce)
     end
 
+    # during precompilation, skip GPU submission (which hangs) but keep the
+    # encoding path above to cache compilation of the argument encoding pipeline
+    if ccall(:jl_generating_output, Cint, ()) != 0
+        foreach(free, argument_buffers)
+        return
+    end
+
     # the command buffer retains resources that are explicitly encoded (i.e. direct buffer
     # arguments, or the buffers allocated for each other argument), but that doesn't keep
     # other resources alive for which we've encoded the GPU address ourselves. since it's

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -208,8 +208,12 @@ const _kernel_instances = Dict{UInt, Any}()
 ## kernel launching and argument encoding
 
 @inline @generated function encode_arguments!(cce, kernel, args::Vararg{Any,N}) where {N}
-    ex = quote end
-    buffers = []
+    # Return a `Vector{MTLBuffer}` (rather than a tuple whose type varies with
+    # the number of allocated buffers) so the on_completed closure that
+    # captures the result has a stable type across kernels.
+    ex = quote
+        buffers = MTLBuffer[]
+    end
 
     # the arguments passed into this function have not been `mtlconvert`ed, because we need
     # to retain the top-level MTLBuffer and MtlPtr objects. eager conversion of nested
@@ -229,19 +233,16 @@ const _kernel_instances = Dict{UInt, Any}()
             continue
         else
             # everything else is passed by reference, in an argument buffer
-            buf = gensym("buffer")
             append!(ex.args, (quote
-                $buf = encode_argument!(kernel, mtlconvert($(argex), cce))
-                set_buffer!(cce, $buf, 0, $idx)
+                buf = encode_argument!(kernel, mtlconvert($(argex), cce))
+                set_buffer!(cce, buf, 0, $idx)
+                push!(buffers, buf)
             end).args)
-            push!(buffers, buf)
         end
         idx += 1
     end
 
-    append!(ex.args, (quote
-        return ($(buffers...),)
-    end).args)
+    push!(ex.args, :(return buffers))
 
     ex
 end
@@ -263,9 +264,10 @@ end
     return argument_buffer
 end
 
-# Thin outer callable: the @autoreleasepool stays at the same scope as the
-# baseline, and we forward into a shared `_launch` body so the bulk of the
-# launch compiles only once.
+# Thin outer callable forwards into a shared `_launch` body so the bulk of the
+# launch compiles only once across kernel/argument-type combinations. The
+# `@autoreleasepool` stays at the outer level (matching the baseline) and only
+# wraps a single function call, keeping its closure body small.
 @autoreleasepool function (kernel::HostKernel)(args...; groups=1, threads=1,
                                                queue=global_queue(device()))
     _launch(kernel, MTLSize(groups), MTLSize(threads), queue, args)

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -208,9 +208,6 @@ const _kernel_instances = Dict{UInt, Any}()
 ## kernel launching and argument encoding
 
 @inline @generated function encode_arguments!(cce, kernel, args::Vararg{Any,N}) where {N}
-    # Return a `Vector{MTLBuffer}` (rather than a tuple whose type varies with
-    # the number of allocated buffers) so the on_completed closure that
-    # captures the result has a stable type across kernels.
     ex = quote
         buffers = MTLBuffer[]
     end
@@ -264,17 +261,15 @@ end
     return argument_buffer
 end
 
-# Thin outer callable forwards into a shared `_launch` body so the bulk of the
-# launch compiles only once across kernel/argument-type combinations. The
-# `@autoreleasepool` stays at the outer level (matching the baseline) and only
 # wraps a single function call, keeping its closure body small.
 @autoreleasepool function (kernel::HostKernel)(args...; groups=1, threads=1,
                                                queue=global_queue(device()))
-    _launch(kernel, MTLSize(groups), MTLSize(threads), queue, args)
+    # function barrier to avoid capturing the `@autoreleasepool` in the generated code
+    launch(kernel, MTLSize(groups), MTLSize(threads), queue, args)
 end
 
-function _launch(@nospecialize(kernel::HostKernel), gs::MTLSize, ts::MTLSize,
-                 queue::MTLCommandQueue, @nospecialize(args::Tuple))
+function launch(@nospecialize(kernel::HostKernel), gs::MTLSize, ts::MTLSize,
+                queue::MTLCommandQueue, @nospecialize(args::Tuple))
     (gs.width>0 && gs.height>0 && gs.depth>0) ||
         throw(ArgumentError("All group dimensions should be non-zero"))
     (ts.width>0 && ts.height>0 && ts.depth>0) ||
@@ -299,7 +294,7 @@ function _launch(@nospecialize(kernel::HostKernel), gs::MTLSize, ts::MTLSize,
     cce = MTLComputeCommandEncoder(cmdbuf)
     argument_buffers = try
         MTL.set_function!(cce, pipeline)
-        bufs = _encode_arguments!(cce, kernel, kernel_state, f, args)
+        bufs = encode_arguments_nospec!(cce, kernel, kernel_state, f, args)
         MTL.append_current_function!(cce, gs, ts)
         bufs
     finally
@@ -327,10 +322,7 @@ function _launch(@nospecialize(kernel::HostKernel), gs::MTLSize, ts::MTLSize,
         end
     end
 
-    # During precompilation, don't commit: the GPU would do useless work and
-    # may hold resources past the end of the workload. The handler above has
-    # already been compiled, and will still fire (with status `Aborted`) when
-    # the autoreleasepool drains the command buffer, taking care of cleanup.
+    # HACK: don't actually commit when precompiling to prevent holding onto resources
     if ccall(:jl_generating_output, Cint, ()) != 0
         return
     end
@@ -339,11 +331,8 @@ function _launch(@nospecialize(kernel::HostKernel), gs::MTLSize, ts::MTLSize,
     return
 end
 
-# Bridge from the @nospecialize launch into the @generated encoder: still
-# specializes on f and args types (encode_arguments! needs them to detect ghost
-# types) but not on the HostKernel type parameters, so this compiles only once
-# per arg-type combination — shared across all kernels with those arg types.
-@inline _encode_arguments!(cce, @nospecialize(kernel), kernel_state, f, args::Tuple) =
+# force specialization on f and args, but not on the kernel
+@inline encode_arguments_nospec!(cce, @nospecialize(kernel), kernel_state, f, args::Tuple) =
     encode_arguments!(cce, kernel, kernel_state, f, args...)
 
 ## Intra-warp Helpers

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -246,7 +246,7 @@ const _kernel_instances = Dict{UInt, Any}()
     ex
 end
 
-@inline function encode_argument!(kernel, arg)
+@inline function encode_argument!(@nospecialize(kernel), arg)
     argtyp = typeof(arg)
 
     # replace non-isbits arguments (they should be unused, or compilation
@@ -263,10 +263,16 @@ end
     return argument_buffer
 end
 
+# Thin outer callable: the @autoreleasepool stays at the same scope as the
+# baseline, and we forward into a shared `_launch` body so the bulk of the
+# launch compiles only once.
 @autoreleasepool function (kernel::HostKernel)(args...; groups=1, threads=1,
                                                queue=global_queue(device()))
-    gs = MTLSize(groups)
-    ts = MTLSize(threads)
+    _launch(kernel, MTLSize(groups), MTLSize(threads), queue, args)
+end
+
+function _launch(@nospecialize(kernel::HostKernel), gs::MTLSize, ts::MTLSize,
+                 queue::MTLCommandQueue, @nospecialize(args::Tuple))
     (gs.width>0 && gs.height>0 && gs.depth>0) ||
         throw(ArgumentError("All group dimensions should be non-zero"))
     (ts.width>0 && ts.height>0 && ts.depth>0) ||
@@ -282,14 +288,16 @@ end
     (gs.depth * ts.depth) > typemax(UInt32) &&
         throw(ArgumentError("Total threads per grid in a dimension (threads.depth($(gs.depth)) * groups.depth($(ts.depth)) = $(gs.depth * ts.depth)) must not exceed $(typemax(UInt32))"))
 
+    f = kernel.f
+    pipeline = kernel.pipeline
     kernel_state = KernelState(Random.rand(UInt32))
 
     cmdbuf = MTLCommandBuffer(queue)
-    cmdbuf.label = "MTLCommandBuffer($(nameof(kernel.f)))"
+    cmdbuf.label = "MTLCommandBuffer($(nameof(f)))"
     cce = MTLComputeCommandEncoder(cmdbuf)
     argument_buffers = try
-        MTL.set_function!(cce, kernel.pipeline)
-        bufs = encode_arguments!(cce, kernel, kernel_state, kernel.f, args...)
+        MTL.set_function!(cce, pipeline)
+        bufs = _encode_arguments!(cce, kernel, kernel_state, f, args)
         MTL.append_current_function!(cce, gs, ts)
         bufs
     finally
@@ -304,7 +312,7 @@ end
     # kernel has actually completed.
     #
     # TODO: is there a way to bind additional resources to the command buffer?
-    roots = [kernel.f, args]
+    roots = Any[f, args]
     MTL.on_completed(cmdbuf) do buf
         empty!(roots)
         foreach(free, argument_buffers)
@@ -326,7 +334,15 @@ end
     end
 
     commit!(cmdbuf)
+    return
 end
+
+# Bridge from the @nospecialize launch into the @generated encoder: still
+# specializes on f and args types (encode_arguments! needs them to detect ghost
+# types) but not on the HostKernel type parameters, so this compiles only once
+# per arg-type combination — shared across all kernels with those arg types.
+@inline _encode_arguments!(cce, @nospecialize(kernel), kernel_state, f, args::Tuple) =
+    encode_arguments!(cce, kernel, kernel_state, f, args...)
 
 ## Intra-warp Helpers
 

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -317,6 +317,14 @@ end
         end
     end
 
+    # During precompilation, don't commit: the GPU would do useless work and
+    # may hold resources past the end of the workload. The handler above has
+    # already been compiled, and will still fire (with status `Aborted`) when
+    # the autoreleasepool drains the command buffer, taking care of cleanup.
+    if ccall(:jl_generating_output, Cint, ()) != 0
+        return
+    end
+
     commit!(cmdbuf)
 end
 

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -1,30 +1,18 @@
 # World age captured at __init__ time. Used to invoke the GPU-compiler stack
-# (typeinf_local etc.) in a frozen world so precompiled native code for that
-# infrastructure keeps applying even when later method definitions would have
-# invalidated it. This only freezes the *host-side* dispatch within the
-# compiler pipeline: the user's kernel is still inferred and compiled against
-# the user's current world, because GPUCompiler plumbs `tls_world_age()`
-# through `CompilerJob.world` into `GPUInterpreter.world`, and the abstract
-# interpreter uses that for all method lookups in user code (including overlay
-# tables and `@device_override` methods). The sentinel `typemax(UInt)` means
-# "use the current world", which `Base.invoke_in_world` clamps to — that's the
-# correct behavior during precompilation (before `__init__` runs).
-const _initialization_world = Ref{UInt}(typemax(UInt))
+# in a frozen world to avoid latency from invalidations.
+const initialization_world = Ref{UInt}(typemax(UInt))
 
 """
     invoke_frozen(f, args...; kwargs...)
 
 Invoke `f(args...; kwargs...)` in the world age captured at `__init__` time.
-Lets precompiled native code for the GPU-compiler stack be reused even when
-downstream packages add methods that would otherwise invalidate it. Method
-lookups for the user's kernel are unaffected — see [`_initialization_world`].
 """
 @inline function invoke_frozen(f, args...; kwargs...)
     if isempty(kwargs)
-        return Base.invoke_in_world(_initialization_world[], f, args...)
+        return Base.invoke_in_world(initialization_world[], f, args...)
     end
     kwargs = merge(NamedTuple(), kwargs)
-    return Base.invoke_in_world(_initialization_world[], Core.kwcall, kwargs, f, args...)
+    return Base.invoke_in_world(initialization_world[], Core.kwcall, kwargs, f, args...)
 end
 
 @static if isdefined(Base, :OncePerProcess) # VERSION >= v"1.12.0-DEV.1421"
@@ -102,10 +90,7 @@ function __init__()
         push!(Base.active_repl_backend.ast_transforms, synchronize_metal_tasks)
     end
 
-    # Capture the world age last, so the GPU-compiler stack runs in the world we
-    # finished initialization in. Methods defined by downstream packages after
-    # this point won't invalidate the precompiled GPUCompiler infrastructure.
-    _initialization_world[] = Base.get_world_counter()
+    initialization_world[] = Base.get_world_counter()
 end
 
 function synchronize_metal_tasks(ex)

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -1,3 +1,32 @@
+# World age captured at __init__ time. Used to invoke the GPU-compiler stack
+# (typeinf_local etc.) in a frozen world so precompiled native code for that
+# infrastructure keeps applying even when later method definitions would have
+# invalidated it. This only freezes the *host-side* dispatch within the
+# compiler pipeline: the user's kernel is still inferred and compiled against
+# the user's current world, because GPUCompiler plumbs `tls_world_age()`
+# through `CompilerJob.world` into `GPUInterpreter.world`, and the abstract
+# interpreter uses that for all method lookups in user code (including overlay
+# tables and `@device_override` methods). The sentinel `typemax(UInt)` means
+# "use the current world", which `Base.invoke_in_world` clamps to — that's the
+# correct behavior during precompilation (before `__init__` runs).
+const _initialization_world = Ref{UInt}(typemax(UInt))
+
+"""
+    invoke_frozen(f, args...; kwargs...)
+
+Invoke `f(args...; kwargs...)` in the world age captured at `__init__` time.
+Lets precompiled native code for the GPU-compiler stack be reused even when
+downstream packages add methods that would otherwise invalidate it. Method
+lookups for the user's kernel are unaffected — see [`_initialization_world`].
+"""
+@inline function invoke_frozen(f, args...; kwargs...)
+    if isempty(kwargs)
+        return Base.invoke_in_world(_initialization_world[], f, args...)
+    end
+    kwargs = merge(NamedTuple(), kwargs)
+    return Base.invoke_in_world(_initialization_world[], Core.kwcall, kwargs, f, args...)
+end
+
 @static if isdefined(Base, :OncePerProcess) # VERSION >= v"1.12.0-DEV.1421"
     const functional = OncePerProcess{Bool}() do
         try
@@ -72,6 +101,11 @@ function __init__()
     if isdefined(Base, :active_repl_backend) && !isnothing(Base.active_repl_backend)
         push!(Base.active_repl_backend.ast_transforms, synchronize_metal_tasks)
     end
+
+    # Capture the world age last, so the GPU-compiler stack runs in the world we
+    # finished initialization in. Methods defined by downstream packages after
+    # this point won't invalidate the precompiled GPUCompiler infrastructure.
+    _initialization_world[] = Base.get_world_counter()
 end
 
 function synchronize_metal_tasks(ex)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -3,18 +3,42 @@ using PrecompileTools: @setup_workload, @compile_workload
 @setup_workload begin
     metallib_file = joinpath(dirname(@__DIR__), "test", "dummy.metallib")
 
-    # parsing and writing metal libraries
-    metallib = parse(MetalLib, metallib_file)
-    sprint(write, metallib)
+    @compile_workload begin
+        # parsing and writing metal libraries
+        metallib = parse(MetalLib, metallib_file)
+        sprint(write, metallib)
+
+        # launch a trivial kernel to precompile the full pipeline:
+        #   mtlfunction → GPUCompiler → LLVM IR → AIR → metallib → link → launch
+        # (GPU submission is skipped during precompilation, but the entire
+        #  encoding path — encode_arguments!, command buffer setup, etc. — runs)
+        kernel() = return
+        @metal kernel()
+
+        # launch a realistic kernel with array arguments
+        a = MtlArray(Float32[1])
+        b = MtlArray(Float32[1])
+        c = MtlArray(Float32[0])
+        function precompile_vadd(a, b, c)
+            i = thread_position_in_grid().x
+            c[i] = a[i] + b[i]
+            return
+        end
+        @metal precompile_vadd(a, b, c)
+
+        # also exercise 2D arrays (common in real workloads)
+        a2 = MtlArray(Float32[1 1])
+        b2 = MtlArray(Float32[1 1])
+        c2 = MtlArray(Float32[0 0])
+        @metal precompile_vadd(a2, b2, c2)
+
+        # precompile MtlArray → Array copy-back
+        Array(c)
+        Array(c2)
+    end
 end
 
-precompile(compile, (CompilerJob,))
-precompile(Tuple{typeof(GPUCompiler.finish_ir!), GPUCompiler.CompilerJob{GPUCompiler.MetalCompilerTarget, Metal.MetalCompilerParams}, LLVM.Module, LLVM.Function})
-precompile(Tuple{typeof(GPUCompiler.finish_module!), GPUCompiler.CompilerJob{GPUCompiler.MetalCompilerTarget, Metal.MetalCompilerParams}, LLVM.Module, LLVM.Function})
-precompile(Tuple{typeof(GPUCompiler.check_ir), GPUCompiler.CompilerJob{GPUCompiler.MetalCompilerTarget, Metal.MetalCompilerParams}, LLVM.Module})
-precompile(Tuple{typeof(GPUCompiler.actual_compilation), Base.Dict{Any, Any}, Core.MethodInstance, UInt64, GPUCompiler.CompilerConfig{GPUCompiler.MetalCompilerTarget, Metal.MetalCompilerParams}, typeof(Metal.compile), typeof(Metal.link)})
-
-# Worth the hassle
-if isdefined(Base, :Compiler) && isdefined(Base.Compiler, :typeinf_local)
-    precompile(Tuple{typeof(Base.Compiler.typeinf_local), GPUCompiler.GPUInterpreter{Base.Compiler.CachedMethodTable{Base.Compiler.OverlayMethodTable}}, Base.Compiler.InferenceState, Base.Compiler.CurrentState})
-end
+# GPUCompiler macro-expansion utilities (compiled at every @metal callsite).
+# split_kwargs is called with 3 Vector{Symbol} groups (MACRO/COMPILER/LAUNCH_KWARGS).
+precompile(Tuple{typeof(GPUCompiler.split_kwargs), Tuple{Expr}, Vector{Symbol}, Vector{Symbol}, Vector{Symbol}})
+precompile(Tuple{typeof(GPUCompiler.assign_args!), Expr, Vector{Any}})

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -41,4 +41,5 @@ end
 # GPUCompiler macro-expansion utilities (compiled at every @metal callsite).
 # split_kwargs is called with 3 Vector{Symbol} groups (MACRO/COMPILER/LAUNCH_KWARGS).
 precompile(Tuple{typeof(GPUCompiler.split_kwargs), Tuple{Expr}, Vector{Symbol}, Vector{Symbol}, Vector{Symbol}})
+precompile(Tuple{typeof(GPUCompiler.split_kwargs), Tuple{}, Vector{Symbol}, Vector{Symbol}, Vector{Symbol}})
 precompile(Tuple{typeof(GPUCompiler.assign_args!), Expr, Vector{Any}})

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -8,10 +8,24 @@ using PrecompileTools: @setup_workload, @compile_workload
         metallib = parse(MetalLib, metallib_file)
         sprint(write, metallib)
 
-        # compile a trivial kernel to exercise the full compilation pipeline:
-        #   mtlfunction → GPUCompiler → LLVM IR → AIR → metallib → link
-        mtlfunction(identity, Tuple{Nothing})
+        # exercise the full kernel-launch pipeline:
+        #   mtlfunction → GPUCompiler → LLVM IR → AIR → metallib → link → launch
+        # The launch path skips GPU submission during precompilation (see _launch).
+        # Use `identity` since it's the only kernel whose type users can name (other
+        # closure types differ between this workload and user code, so wouldn't share
+        # the precompiled launcher).
+        @metal identity(nothing)
     end
+
+    # Caches populated by the workload hold ObjectiveC handles whose underlying
+    # objects only exist in the precompilation process; serializing those into
+    # the package image yields dangling pointers when the image is loaded. Drop
+    # the entries before precompilation finalizes.
+    empty!(_compiler_caches)
+    empty!(_compiler_configs)
+    empty!(_kernel_instances)
+    empty!(global_queues)
+    _toolchain[] = nothing
 end
 
 # Worth the hassle

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -27,8 +27,3 @@ using PrecompileTools: @setup_workload, @compile_workload
     empty!(global_queues)
     _toolchain[] = nothing
 end
-
-# Worth the hassle
-if isdefined(Base, :Compiler) && isdefined(Base.Compiler, :typeinf_local)
-    precompile(Tuple{typeof(Base.Compiler.typeinf_local), GPUCompiler.GPUInterpreter{Base.Compiler.CachedMethodTable{Base.Compiler.OverlayMethodTable}}, Base.Compiler.InferenceState, Base.Compiler.CurrentState})
-end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -3,16 +3,16 @@ using PrecompileTools: @setup_workload, @compile_workload
 @setup_workload begin
     metallib_file = joinpath(dirname(@__DIR__), "test", "dummy.metallib")
 
-    # parsing and writing metal libraries
-    metallib = parse(MetalLib, metallib_file)
-    sprint(write, metallib)
-end
+    @compile_workload begin
+        # parsing and writing metal libraries
+        metallib = parse(MetalLib, metallib_file)
+        sprint(write, metallib)
 
-precompile(compile, (CompilerJob,))
-precompile(Tuple{typeof(GPUCompiler.finish_ir!), GPUCompiler.CompilerJob{GPUCompiler.MetalCompilerTarget, Metal.MetalCompilerParams}, LLVM.Module, LLVM.Function})
-precompile(Tuple{typeof(GPUCompiler.finish_module!), GPUCompiler.CompilerJob{GPUCompiler.MetalCompilerTarget, Metal.MetalCompilerParams}, LLVM.Module, LLVM.Function})
-precompile(Tuple{typeof(GPUCompiler.check_ir), GPUCompiler.CompilerJob{GPUCompiler.MetalCompilerTarget, Metal.MetalCompilerParams}, LLVM.Module})
-precompile(Tuple{typeof(GPUCompiler.actual_compilation), Base.Dict{Any, Any}, Core.MethodInstance, UInt64, GPUCompiler.CompilerConfig{GPUCompiler.MetalCompilerTarget, Metal.MetalCompilerParams}, typeof(Metal.compile), typeof(Metal.link)})
+        # compile a trivial kernel to exercise the full compilation pipeline:
+        #   mtlfunction → GPUCompiler → LLVM IR → AIR → metallib → link
+        mtlfunction(identity, Tuple{Nothing})
+    end
+end
 
 # Worth the hassle
 if isdefined(Base, :Compiler) && isdefined(Base.Compiler, :typeinf_local)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -15,6 +15,12 @@ using PrecompileTools: @setup_workload, @compile_workload
         # closure types differ between this workload and user code, so wouldn't share
         # the precompiled launcher).
         @metal identity(nothing)
+
+        # exercise MtlArray creation and host↔device copy paths in both 1D and 2D
+        for h in (Float32[0], Float32[0;;])
+            a = MtlArray(h)
+            Array(a)
+        end
     end
 
     # Caches populated by the workload hold ObjectiveC handles whose underlying

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,6 +1,6 @@
 using PrecompileTools: @setup_workload, @compile_workload
 
-@setup_workload begin
+Sys.isapple() && @setup_workload begin
     metallib_file = joinpath(dirname(@__DIR__), "test", "dummy.metallib")
 
     @compile_workload begin

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -9,11 +9,6 @@ Sys.isapple() && @setup_workload begin
         sprint(write, metallib)
 
         # exercise the full kernel-launch pipeline:
-        #   mtlfunction → GPUCompiler → LLVM IR → AIR → metallib → link → launch
-        # The launch path skips GPU submission during precompilation (see _launch).
-        # Use `identity` since it's the only kernel whose type users can name (other
-        # closure types differ between this workload and user code, so wouldn't share
-        # the precompiled launcher).
         @metal identity(nothing)
 
         # exercise MtlArray creation and host↔device copy paths in both 1D and 2D
@@ -31,5 +26,4 @@ Sys.isapple() && @setup_workload begin
     empty!(_compiler_configs)
     empty!(_kernel_instances)
     empty!(global_queues)
-    _toolchain[] = nothing
 end


### PR DESCRIPTION
... by adding a proper precompilation workload and removing some overzealous specialization.
Needs to be properly validated to ensure the `@nospecialize` on crucial functions like `mtlfunction` doesn't regress launch overhead.

Before:

```
❯ hyperfine --warmup=1 'julia --project -e "using Metal; @metal identity(nothing)"'
Benchmark 1: julia --project -e "using Metal; @metal identity(nothing)"
  Time (mean ± σ):      2.695 s ±  0.135 s    [User: 3.360 s, System: 0.401 s]
  Range (min … max):    2.588 s …  3.063 s    10 runs

❯ hyperfine --warmup=1 'julia --project examples/vadd.jl'
Benchmark 1: julia --project examples/vadd.jl
  Time (mean ± σ):      3.827 s ±  0.237 s    [User: 4.471 s, System: 0.380 s]
  Range (min … max):    3.573 s …  4.260 s    10 runs
```

After:

```
❯ hyperfine --warmup=1 'julia --project -e "using Metal; @metal identity(nothing)"'
Benchmark 1: julia --project -e "using Metal; @metal identity(nothing)"
  Time (mean ± σ):      1.555 s ±  0.026 s    [User: 2.232 s, System: 0.405 s]
  Range (min … max):    1.516 s …  1.599 s    10 runs

❯ hyperfine --warmup=1 'julia --project examples/vadd.jl'
Benchmark 1: julia --project examples/vadd.jl
  Time (mean ± σ):      2.065 s ±  0.056 s    [User: 2.741 s, System: 0.293 s]
  Range (min … max):    2.007 s …  2.168 s    10 runs
```