### PR TITLE
ComplexF32 division

### DIFF
--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -48,6 +48,25 @@ end
 @device_override Base.max(x::Float32, y::Float32, z::Float32) = ccall("extern air.fmax3.f32", llvmcall, Cfloat, (Cfloat, Cfloat, Cfloat), x, y, z)
 @device_override Base.max(x::Float16, y::Float16, z::Float16) = ccall("extern air.fmax3.f16", llvmcall, Float16, (Float16, Float16, Float16), x, y, z)
 
+@device_override function Base.:(/)(a::Complex{Float32}, b::Complex{Float32})
+    are = real(a); aim = imag(a); bre = real(b); bim = imag(b)
+    if (isinf(bre) | isinf(bim))
+        if isfinite(a)
+            return complex(zero(Float32)*sign(are)*sign(bre), -zero(Float32)*sign(aim)*sign(bim))
+        end
+        return NaN32+NaN32*im
+    end
+    if abs(bre) <= abs(bim)
+        r = bre / bim
+        den = bim + r*bre
+        Complex((are*r + aim)/den, (aim*r - are)/den)
+    else
+        r = bim / bre
+        den = bre + r*bim
+        Complex((are + aim*r)/den, (aim - are*r)/den)
+    end
+end
+
 @device_override FastMath.acos_fast(x::Float32) = ccall("extern air.fast_acos.f32", llvmcall, Cfloat, (Cfloat,), x)
 @device_override Base.acos(x::Float32) = ccall("extern air.acos.f32", llvmcall, Cfloat, (Cfloat,), x)
 @device_override Base.acos(x::Float16) = ccall("extern air.acos.f16", llvmcall, Float16, (Float16,), x)

--- a/test/device/intrinsics/math.jl
+++ b/test/device/intrinsics/math.jl
@@ -425,4 +425,21 @@ end
     bufferA = MtlArray(a)
     vecA = Array(sqrt.(bufferA))
     @test vecA ≈ sqrt.(a)
+
+    # Division
+    let
+        N = 10
+
+        x = rand(ComplexF32, N)
+        y = rand(ComplexF32, N)
+
+        dx = MtlArray(x)
+        dy = MtlArray(y)
+
+
+        z = x ./ y
+        dz = dx ./ dy
+
+        @test Array(dz) ≈ z
+    end
 end

--- a/test/device/intrinsics/math.jl
+++ b/test/device/intrinsics/math.jl
@@ -441,5 +441,9 @@ end
         dz = dx ./ dy
 
         @test Array(dz) ≈ z
+
+        # Over/Underflow tests
+        as = MtlArray([Complex{Float32}(2.0e20, 2.0e20), Complex{Float32}(1.0e-25, 1.0e-25)])
+        @test all(Array(as ./ as) .≈ Complex{Float32}(1.0, 0.0))
     end
 end


### PR DESCRIPTION
Alternative to #738. This implements smith's method, which is more resilient to overflow and underflow than the naive method, but simpler than the even better implementation in Base. I also added 2 tests where #738 and the naive algorithm fail.

@oscardssmith @albertomercurio Any thoughts?