### PR TITLE
Store MtlArray offset in bytes instead of elements

### DIFF
--- a/lib/mps/matrix.jl
+++ b/lib/mps/matrix.jl
@@ -59,7 +59,7 @@ as Metal stores matrices row-major instead of column-major.
 function MPSMatrix(mat::MtlMatrix{T}) where T
     n_cols, n_rows = size(mat)
     desc = MPSMatrixDescriptor(n_rows, n_cols, sizeof(T)*n_cols, T)
-    offset = mat.offset * sizeof(T)
+    offset = mat.offset
     return MPSMatrix(mat, desc, offset)
 end
 
@@ -74,7 +74,7 @@ as Metal stores matrices row-major instead of column-major.
 function MPSMatrix(vec::MtlVector{T}) where T
     n_cols, n_rows = length(vec), 1
     desc = MPSMatrixDescriptor(n_rows, n_cols, sizeof(T)*n_cols, T)
-    offset = vec.offset * sizeof(T)
+    offset = vec.offset
     return MPSMatrix(vec, desc, offset)
 end
 
@@ -90,7 +90,7 @@ function MPSMatrix(arr::MtlArray{T,3}) where T
     n_cols, n_rows, n_matrices = size(arr)
     row_bytes = sizeof(T)*n_cols
     desc = MPSMatrixDescriptor(n_rows, n_cols, n_matrices, row_bytes, row_bytes * n_rows, T)
-    offset = arr.offset * sizeof(T)
+    offset = arr.offset
     return MPSMatrix(arr, desc, offset)
 end
 

--- a/lib/mps/matrixrandom.jl
+++ b/lib/mps/matrixrandom.jl
@@ -90,7 +90,7 @@ synchronize_state(kern::MPSMatrixRandomMTGP32, cmdbuf::MTLCommandBuffer) =
 @inline function _mpsmat_rand!(randkern::MPSMatrixRandom, dest::MtlArray{T}, ::Type{T2};
                         queue::MTLCommandQueue = global_queue(randkern.device),
                         async::Bool=false) where {T,T2}
-    byteoffset = dest.offset * sizeof(T)
+    byteoffset = dest.offset
     bytesize = sizeof(dest)
 
     cmdbuf = if bytesize % 16 == 0 && dest.offset == 0

--- a/lib/mps/ndarray.jl
+++ b/lib/mps/ndarray.jl
@@ -116,7 +116,7 @@ function MPSNDArray(arr::MtlArray{T,N}) where {T,N}
     arrsize = size(arr)
     @assert arrsize[1] * sizeof(T) % 16 == 0 "First dimension of input MtlArray must have a byte size divisible by 16"
     desc = MPSNDArrayDescriptor(T, arrsize)
-    return MPSNDArray(arr.data[], UInt(arr.offset) * sizeof(T), desc)
+    return MPSNDArray(arr.data[], UInt(arr.offset), desc)
 end
 
 function Metal.MtlArray(ndarr::MPSNDArray; storage = Metal.DefaultStorageMode, async = false)

--- a/lib/mps/vector.jl
+++ b/lib/mps/vector.jl
@@ -53,7 +53,7 @@ Metal vector representation used in Performance Shaders.
 """
 function MPSVector(arr::MtlVector{T}) where T
     desc = MPSVectorDescriptor(length(arr), T)
-    offset = arr.offset * sizeof(T)
+    offset = arr.offset
     return MPSVector(arr, desc, offset)
 end
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -47,7 +47,7 @@ mutable struct MtlArray{T,N,S} <: AbstractGPUArray{T,N}
     data::DataRef{<:MTLBuffer}
 
     maxsize::Int  # maximum data size in bytes; excluding any selector bytes
-    offset::Int   # offset of the data in the buffer, in number of elements
+    offset::Int   # offset of the data in the buffer, in bytes
     dims::Dims{N}
 
     function MtlArray{T,N,S}(::UndefInitializer, dims::Dims{N}) where {T,N,S}
@@ -260,7 +260,7 @@ end
 
 function Base.unsafe_convert(::Type{MtlPtr{T}}, x::MtlArray) where {T}
     buf = x.data[]
-    MtlPtr{T}(buf, x.offset * Base.elsize(x))
+    MtlPtr{T}(buf, x.offset)
 end
 
 function Base.unsafe_convert(::Type{Ptr{S}}, x::MtlArray{T}) where {S,T}
@@ -269,7 +269,7 @@ function Base.unsafe_convert(::Type{Ptr{S}}, x::MtlArray{T}) where {S,T}
     end
     synchronize()
     buf = x.data[]
-    convert(Ptr{T}, buf) + x.offset * Base.elsize(x)
+    convert(Ptr{T}, buf) + x.offset
 end
 
 
@@ -571,7 +571,7 @@ end
 ## derived arrays
 
 function GPUArrays.derive(::Type{T}, a::MtlArray{<:Any,<:Any,S}, dims::Dims{N}, offset::Int) where {T,N,S}
-    offset = (a.offset * Base.elsize(a)) ÷ sizeof(T) + offset
+    offset = a.offset + offset * sizeof(T)
     MtlArray{T,N,S}(a.data, dims; a.maxsize, offset)
 end
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -407,7 +407,9 @@ end
 function Base.unsafe_copyto!(::MTLDevice, dest::MtlArray{T,<:Any,Metal.SharedStorage}, doffs, src::Array{T}, soffs, n) where T
     # these copies are implemented using pure memcpy's, not API calls, so aren't ordered.
     synchronize()
-    GC.@preserve src dest unsafe_copyto!(pointer(unsafe_wrap(Array,dest), doffs), pointer(src, soffs), n)
+    # use the raw CPU pointer directly so this also works with non-aligned offsets
+    # (which can arise from e.g. reinterpret of a view); unsafe_wrap would refuse them
+    GC.@preserve src dest unsafe_copyto!(pointer(dest, doffs; storage=SharedStorage), pointer(src, soffs), n)
     return dest
 end
 
@@ -425,7 +427,9 @@ end
 function Base.unsafe_copyto!(::MTLDevice, dest::Array{T}, doffs, src::MtlArray{T,<:Any,Metal.SharedStorage}, soffs, n) where T
     # these copies are implemented using pure memcpy's, not API calls, so aren't ordered.
     synchronize()
-    GC.@preserve src dest unsafe_copyto!(pointer(dest, doffs), pointer(unsafe_wrap(Array,src), soffs), n)
+    # use the raw CPU pointer directly so this also works with non-aligned offsets
+    # (which can arise from e.g. reinterpret of a view); unsafe_wrap would refuse them
+    GC.@preserve src dest unsafe_copyto!(pointer(dest, doffs), pointer(src, soffs; storage=SharedStorage), n)
     return dest
 end
 
@@ -451,7 +455,9 @@ function Base.unsafe_copyto!(dev::MTLDevice, dest::MtlArray{T, <:Any, Metal.Shar
             error("Not implemented")
         end
     else
-        GC.@preserve src dest unsafe_copyto!(pointer(unsafe_wrap(Array, dest), doffs), pointer(unsafe_wrap(Array, src), soffs), n)
+        # use the raw CPU pointers directly so this also works with non-aligned offsets
+        # (which can arise from e.g. reinterpret of a view); unsafe_wrap would refuse them
+        GC.@preserve src dest unsafe_copyto!(pointer(dest, doffs; storage=SharedStorage), pointer(src, soffs; storage=SharedStorage), n)
     end
     return dest
 end

--- a/test/array.jl
+++ b/test/array.jl
@@ -495,11 +495,8 @@ end
 
 @testset "reinterpret of view with non-aligned offset" begin
     # reinterpreting a view to a larger element type where the byte offset
-    # is not a multiple of the new element size. PrivateStorage is required
-    # because the SharedStorage Array conversion goes through unsafe_wrap,
-    # which requires the buffer pointer to be aligned to the element size.
-    a = MtlArray{Int16,1,Metal.PrivateStorage}(undef, 9)
-    copyto!(a, Int16[1,2,3,4,5,6,7,8,9])
+    # is not a multiple of the new element size
+    a = MtlArray(Int16[1,2,3,4,5,6,7,8,9])
     v = view(a, 2:7)  # offset of 1 Int16 = 2 bytes
     r = reinterpret(Int32, v)  # Int32 = 4 bytes; 2 is not a multiple of 4
     @test Array(r) == reinterpret(Int32, @view Array(a)[2:7])

--- a/test/array.jl
+++ b/test/array.jl
@@ -493,6 +493,18 @@ end
         sum(reshape(PermutedDimsArray(reshape(Float32.(1:30), 5, 3, 2), (3, 1, 2)), (10, 3)); dims=1)
 end
 
+@testset "reinterpret of view with non-aligned offset" begin
+    # reinterpreting a view to a larger element type where the byte offset
+    # is not a multiple of the new element size. PrivateStorage is required
+    # because the SharedStorage Array conversion goes through unsafe_wrap,
+    # which requires the buffer pointer to be aligned to the element size.
+    a = MtlArray{Int16,1,Metal.PrivateStorage}(undef, 9)
+    copyto!(a, Int16[1,2,3,4,5,6,7,8,9])
+    v = view(a, 2:7)  # offset of 1 Int16 = 2 bytes
+    r = reinterpret(Int32, v)  # Int32 = 4 bytes; 2 is not a multiple of 4
+    @test Array(r) == reinterpret(Int32, @view Array(a)[2:7])
+end
+
 @testset "accumulate" begin
     for n in (0, 1, 2, 3, 10, 10_000, 16384, 16384+1) # small, large, odd & even, pow2 and not
         @test testf(x->accumulate(+, x), rand(Float32, n))

--- a/test/mps/matrix.jl
+++ b/test/mps/matrix.jl
@@ -86,7 +86,7 @@ using .MPS: MPSMatrix
         @test vbufmat.matrices == 1
         @test vbufmat.dataType == DT
         @test vbufmat.matrixBytes == vrowBytes * vrows
-        @test vbufmat.offset == vmat.offset * sizeof(T)
+        @test vbufmat.offset == vmat.offset
         @test vbufmat.data == vmat.data[]
     end
 

--- a/test/mps/vector.jl
+++ b/test/mps/vector.jl
@@ -69,7 +69,7 @@ using .MPS: MPSVector
     @test vbufmat.vectorBytes == vvectorBytes
     @test vbufmat.vectors == 1
     @test vbufmat.dataType == DT
-    @test vbufmat.offset == vvec.offset * sizeof(T)
+    @test vbufmat.offset == vvec.offset
     @test vbufmat.data == vvec.data[]
 end
 


### PR DESCRIPTION
The element-based offset was lossy when materializing reinterpret on views with non-aligned offsets (e.g., reinterpreting a view of Int16 as Int32). The byte offset would get truncated by integer division when converting to the new element count.

The MPS lib's MPSVector/MPSMatrix/MPSNDArray wrappers and MPS random matrix initializers, which all explicitly multiplied the element-based offset by sizeof(T), now just pass the byte offset directly. This also incidentally fixes a latent bug in MPSNDArray's exportToMtlArray! which had been passing the element-based offset to a Metal API expecting bytes.

x-ref https://github.com/JuliaGPU/CUDA.jl/issues/2980