### PR TITLE
feat: Expose `opt_level` compiler config option

### DIFF
--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -141,6 +141,7 @@ function compiler_config(dev; kwargs...)
     return config
 end
 @noinline function _compiler_config(dev; kernel=true, name=nothing, always_inline=false,
+                                         opt_level=2,
                                          macos=nothing, air=nothing, metal=nothing,
                                          kwargs...)
     # determine the versions of things to target
@@ -160,7 +161,7 @@ end
     # create GPUCompiler objects
     target = MetalCompilerTarget(; macos, air, metal, kwargs...)
     params = MetalCompilerParams()
-    CompilerConfig(target, params; kernel, name, always_inline)
+    CompilerConfig(target, params; kernel, name, always_inline, opt_level)
 end
 
 # compile to executable machine code

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -355,6 +355,7 @@ function compiler_config(dev; kwargs...)
 end
 @noinline function _compiler_config(dev; kernel=true, name=nothing, always_inline=false,
                                          debug_level=Base.JLOptions().debug_level,
+                                         opt_level=2,
                                          macos=nothing, air=nothing, metal=nothing,
                                          kwargs...)
     # determine the versions of things to target
@@ -378,7 +379,7 @@ end
     # create GPUCompiler objects
     target = MetalCompilerTarget(; macos, air, metal, kwargs...)
     params = MetalCompilerParams()
-    CompilerConfig(target, params; kernel, name, always_inline, debug_level)
+    CompilerConfig(target, params; kernel, name, always_inline, debug_level, opt_level)
 end
 
 # Persist compilation artifacts so they can be retrieved off-machine (e.g. from CI).

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -4,7 +4,7 @@ export @metal
 ## high-level @metal interface
 
 const MACRO_KWARGS = [:launch]
-const COMPILER_KWARGS = [:kernel, :name, :always_inline, :macos, :air, :metal]
+const COMPILER_KWARGS = [:kernel, :name, :always_inline, :opt_level, :macos, :air, :metal]
 const LAUNCH_KWARGS = [:groups, :threads, :queue]
 
 """

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -4,7 +4,7 @@ export @metal
 ## high-level @metal interface
 
 const MACRO_KWARGS = [:launch]
-const COMPILER_KWARGS = [:kernel, :name, :always_inline, :debug_level, :macos, :air, :metal]
+const COMPILER_KWARGS = [:kernel, :name, :always_inline, :debug_level, :opt_level, :macos, :air, :metal]
 const LAUNCH_KWARGS = [:groups, :threads, :queue, :submit]
 
 """
@@ -24,6 +24,8 @@ There are a few keyword arguments that influence the behavior of `@metal`:
   kernel object should be launched by calling it and passing arguments again.
 - `name`: the name of the kernel in the generated code. Defaults to an automatically-
   generated name.
+- `opt_level`: the optimization level used when compiling the kernel, an integer from `0`
+  to `3`. Defaults to `2`, independent of the host session's `-O` level.
 - `queue`: the command queue to use for this kernel. Defaults to the global command queue.
 - `submit`: whether to submit the current command batch immediately after encoding this
   kernel. Defaults to `false`.

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -114,6 +114,28 @@ end
         @metal name="mykernel" dummy()
     end)))
 
+    # set the optimization level
+    let
+        # forwarded to the GPUCompiler `CompilerConfig`
+        @test Metal.compiler_config(device(); opt_level=1).opt_level == 1
+        # and accepted by the `@metal` macro
+        @metal opt_level=1 dummy()
+        # and it actually changes the optimization the pipeline performs: a
+        # fixed-trip-count loop is left as-is at -O0 but cleaned up at -O2
+        function sum_kernel(x)
+            acc = zero(Float32)
+            for i in 1:8
+                acc += unsafe_load(x, i)
+            end
+            unsafe_store!(x, acc, 1)
+            return
+        end
+        tt = Tuple{Core.LLVMPtr{Float32,1}}
+        ir_O0 = sprint(io->Metal.code_llvm(io, sum_kernel, tt; opt_level=0))
+        ir_O2 = sprint(io->Metal.code_llvm(io, sum_kernel, tt; opt_level=2))
+        @test ir_O0 != ir_O2
+    end
+
     # set macOS, AIR, and Metal versions
     let
         @test occursin("""!{!"Metal", i32 3, i32 2, i32 1}""",


### PR DESCRIPTION
Pass the `opt_level` keyword argument through the compiler pipeline, allowing users to control the optimization level for Metal shader compilation via `_compiler_config` and the `@metal` macro.

----

If this feature is of interest, I'm happy to add tests, docs, etc., as needed.