### PR TITLE
Run examples in isolated test processes

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,19 +87,8 @@ for example in find_examples(joinpath(@__DIR__, "..", "examples"))
     name = splitext(basename(example))[1]
     dir = dirname(example)
     testsuite["examples/$name"] = quote
-        cd($dir) do
-            project = Base.active_project()
-            Base.set_active_project($dir)
-            try
-                withenv("TESTING" => "true") do
-                redirect_stdout(devnull) do
-                    include($example)
-                end
-                end
-            finally
-                Base.set_active_project(project)
-            end
-        end
+        cmd = Cmd(`$(Base.julia_cmd()) --project=$dir --startup-file=no $example`; dir = $dir)
+        run(pipeline(setenv(cmd, "TESTING" => "true"); stdout = devnull))
     end
 end
 


### PR DESCRIPTION
Examples may load packages that mutate global numerical-library state, such as AppleAccelerate. When examples are included directly in the package test runner, that state can leak into unrelated tests scheduled later on the same worker.

This keeps example coverage, but runs each example in a fresh Julia process with the example project active and TESTING=true. That makes the test suite independent of example load order and avoids example-only dependencies contaminating later package tests.

One example where this matters is #713, which adds FFT tests that should not depend on whether the flops comparison example loaded AppleAccelerate earlier on the same worker. The same isolation should help any future example that pulls in process-global state.

Type stability / allocation impact: this changes only how examples are run during tests. There is no public API or package runtime impact. Example tests now pay one Julia process startup per example in exchange for hermetic test state.
