### PR TITLE
Fix Bool scalar broadcast assignment

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -51,10 +51,17 @@ end
     _copyto!(dest, bc) # Keep it for ArrayConflict
 @inline Base.copyto!(dest::AbstractArray, bc::Broadcasted{<:MtlArrayStyle}) =
     _copyto!(dest, bc)
+@inline _preprocess_broadcast(dest, bc) = Broadcast.preprocess(dest, bc)
+@inline function _preprocess_broadcast(dest::MtlArray{Bool},
+                                      bc::Broadcasted{Style, Axes, typeof(identity),
+                                                      <:Tuple{Integer}}) where {Style, Axes}
+    x = convert(Bool, bc.args[1])
+    return Broadcast.preprocess(dest, Broadcasted{Style}(bc.f, (x,), bc.axes))
+end
 @inline function _copyto!(dest::AbstractArray, bc::Broadcasted)
     axes(dest) == axes(bc) || Broadcast.throwdm(axes(dest), axes(bc))
     isempty(dest) && return dest
-    bc = Broadcast.preprocess(dest, bc)
+    bc = _preprocess_broadcast(dest, bc)
 
     # if this is a common broadcast shape, specialize the kernel on it
     Is = CartesianIndices(dest)

--- a/test/array.jl
+++ b/test/array.jl
@@ -600,6 +600,14 @@ end
     @test testf(x->min.(max.(x, zero(Float32)), one(Float32)), randn(Float32, 1000))
     @test testf(x->max.(min.(x, one(Float32)), zero(Float32)), randn(Float32, 1000))
 
+    let x = MtlArray{Bool}(undef, 2)
+        x .= 1
+        @test Array(x) == [true, true]
+
+        x .= Int32(0)
+        @test Array(x) == [false, false]
+    end
+
     # preserving buffer types
     let x = Metal.zeros(Float32, 1; storage=Metal.SharedStorage)
         y = x .+ 1


### PR DESCRIPTION
## Summary

- Fixes `MtlArray{Bool}` broadcast assignment from integer scalars like `a .= 1`.
- Converts the scalar identity-broadcast value to `Bool` on the host before building the GPU broadcast kernel, which avoids device-side boxing in Julia's generic `Bool(::Real)` path.
- Adds a regression test for integer scalar broadcast fills into a `Bool` `MtlArray`.

Fixes #766.

## Tests

- `julia --project=. -e 'using Metal; a = MtlArray{Bool}(undef, 1); a .= 1; @show Array(a); a .= Int32(0); @show Array(a); try; a .= 2; catch err; @show typeof(err); @show err; end'`
  - `a .= 1` produced `Bool[1]`, `a .= Int32(0)` produced `Bool[0]`, and `a .= 2` threw `InexactError(:Bool, (Bool, 2))`.
- `julia --project=test test/runtests.jl array`
  - `Overall | 470 470 | SUCCESS`
