### PR TITLE
Single-use worker for flopscomp example test

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -135,6 +135,13 @@ function test_worker(name, init_worker_code)
         return addworker(; env=["METAL_CAPTURE_ENABLED"=>"1"], init_worker_code)
     end
 
+    if name == "examples/flopscomp"
+        # Single-use worker since loading AppleAccelerate
+        # overloads some base functionality with extra
+        # limitations (e.g. FFTs must be powers of 2)
+        return addworker(; init_worker_code)
+    end
+
     return nothing
 end
 


### PR DESCRIPTION
Alternative to removing AppleAccelerate.jl from the example as mentioned in https://github.com/JuliaGPU/Metal.jl/pull/713#issuecomment-4230239557

Superceeds #771. I prefer this approach since it uses the existing ParallelTestRunner machinery for spinning up workers and the cost of a full new worker is only paid once for the relevant testset instead of for all examples. If other examples are shown to cause problems we can add them to this filter.