### PR TITLE
Fix out-of-bounds threadgroup access in two-level mapreduce

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -103,8 +103,7 @@ steps:
           MTL_DEBUG_LAYER: '1'
           MTL_SHADER_VALIDATION: '1'
         commands: |
-          # blocking synchronization is easier to validate, and the nonblocking one
-          # causes miscompilations on CI's macOS 15
+          # blocking synchronization is easier to validate
           echo -e "[Metal]\nnonblocking_synchronization = false" >LocalPreferences.toml
         agents:
           queue: "juliaecosystem"

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -267,8 +267,13 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::WrappedMtlArray{T},
         # NOTE: we can't use the previously-compiled kernel, or its launch configuration,
         #       since the type of `partial` might not match the original output container
         #       (e.g. if that was a view).
+        # NOTE: size the threadgroup shared array by the hardware maximum (as the first
+        #       kernel does), not by `threads`. `partial_threads` below is recomputed from
+        #       this kernel's own `maxTotalThreadsPerThreadgroup`, which may exceed the first
+        #       kernel's; launching more threads than the shared array has slots is an
+        #       out-of-bounds access (issue #616, surfaced by macOS-15 shader validation).
         partial_kernel = @metal launch=false partial_mapreduce_device(
-                                    f, op, init, Val(threads), Val(Rreduce),
+                                    f, op, init, Val(maxthreads), Val(Rreduce),
                                     Val(Rother), Val(UInt64(length(Rother))),
                                     Val(grain), Val(shuffle), partial, A)
         partial_reduce_threads = compute_threads(partial_kernel)
@@ -283,7 +288,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::WrappedMtlArray{T},
             # use broadcasting to extend singleton dimensions
             partial .= R
         end
-        partial_kernel(f, op, init, Val(threads), Val(Rreduce),
+        partial_kernel(f, op, init, Val(maxthreads), Val(Rreduce),
                         Val(Rother), Val(UInt64(length(Rother))),
                         Val(grain), Val(shuffle), partial, A;
                         groups=partial_groups, threads=partial_threads)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -127,17 +127,6 @@ if filter_tests!(testsuite, args)
     if parse(Bool, get(ENV, "CI", "false")) || Sys.total_memory() < 12 * 2^30
         delete!(testsuite, "largebroadcast")
     end
-
-    # Under Metal Shader Validation on macOS 15, the large `Complex{Int64}`
-    # `mapreducedim!` reduction raises a spurious device-side exception
-    # (JuliaGPU/Metal.jl#785). It does not reproduce on macOS 26 (M1 or M3) or
-    # without shader validation, and the reduction result is otherwise correct --
-    # so this is a validation-layer issue, not a correctness regression. Skip the
-    # affected tests under shader validation to unblock CI; see ../mwe.jl for a
-    # standalone reproducer to investigate on a macOS 15 machine.
-    if get(ENV, "MTL_SHADER_VALIDATION", "0") != "0"
-        delete!(testsuite, "gpuarrays/reductions/mapreducedim!_large")
-    end
 end
 
 # workers to run tests on


### PR DESCRIPTION
Size the partial reduction kernel's shared array by the hardware maximum, matching the first kernel, so the recomputed launch thread count can never exceed it (#616). Surfaced as a KernelException under macOS-15 shader validation for shuffle=false types like Complex{Int64}.