### PR TITLE
Fix static threadgroup memory alignment

### DIFF
--- a/src/device/intrinsics/memory.jl
+++ b/src/device/intrinsics/memory.jl
@@ -31,7 +31,7 @@ end
             linkage!(gv, LLVM.API.LLVMInternalLinkage)
             initializer!(gv, UndefValue(gv_typ))
         end
-        alignment!(gv, 16)  # source: Metal Feature Set Tables
+        alignment!(gv, Base.datatype_alignment(T))
 
         # generate IR
         IRBuilder() do builder


### PR DESCRIPTION
The alignment defined in the [Metal Feature Set Tables](https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf) is for the length of (presumably) dynamic threadgroup memory allocations. Looking at xcode-compiled static memory IR, the arrays seem to be aligned with their underlying datatype alignment.