### PR TITLE
Require 1.13 tests to pass

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,6 +31,7 @@ steps:
               - "1.10"
               - "1.11"
               - "1.12"
+              - "1.13"
 
   - group: ":soon: Pre-releases"
     steps:
@@ -60,7 +61,6 @@ steps:
         matrix:
           setup:
             julia:
-              - "1.13-nightly"
               # - "nightly" # uncomment once dependencies support current llvm
 
   # special tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,36 +33,35 @@ steps:
               - "1.12"
               - "1.13"
 
-  # No point running nightly until the downgrader supports its LLVM version
-  # - group: ":soon: Pre-releases"
-  #   steps:
-  #     - label: "Julia pre-release {{matrix.julia}}"
-  #       plugins:
-  #         - JuliaCI/julia#v1:
-  #             version: "{{matrix.julia}}"
-  #         - JuliaCI/julia-test#v1:
-  #             test_args: "--quickfail --all"
-  #         - JuliaCI/julia-coverage#v1:
-  #             codecov: true
-  #             dirs:
-  #               - src
-  #               - lib
-  #       agents:
-  #         queue: "juliaecosystem"
-  #         os: "macos"
-  #         arch: "aarch64"
-  #       if: |
-  #         build.message =~ /\[only tests\]/ ||
-  #         build.message =~ /\[only pre\]/ ||
-  #         build.message !~ /\[only/ &&
-  #           build.message !~ /\[skip tests\]/ &&
-  #           build.message !~ /\[skip pre\]/
-  #       timeout_in_minutes: 30
-  #       soft_fail: true
-  #       matrix:
-  #         setup:
-  #           julia:
-  #             # - "nightly"
+  - group: ":soon: Pre-releases"
+    steps:
+      - label: "Julia pre-release {{matrix.julia}}"
+        plugins:
+          - JuliaCI/julia#v1:
+              version: "{{matrix.julia}}"
+          - JuliaCI/julia-test#v1:
+              test_args: "--quickfail --all"
+          - JuliaCI/julia-coverage#v1:
+              codecov: true
+              dirs:
+                - src
+                - lib
+        agents:
+          queue: "juliaecosystem"
+          os: "macos"
+          arch: "aarch64"
+        if: |
+          build.message =~ /\[only tests\]/ ||
+          build.message =~ /\[only pre\]/ ||
+          build.message !~ /\[only/ &&
+            build.message !~ /\[skip tests\]/ &&
+            build.message !~ /\[skip pre\]/
+        timeout_in_minutes: 30
+        soft_fail: true
+        matrix:
+          setup:
+            julia:
+              - "nightly"
 
   # special tests
   - group: ":eyes: Special"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,35 +33,36 @@ steps:
               - "1.12"
               - "1.13"
 
-  - group: ":soon: Pre-releases"
-    steps:
-      - label: "Julia pre-release {{matrix.julia}}"
-        plugins:
-          - JuliaCI/julia#v1:
-              version: "{{matrix.julia}}"
-          - JuliaCI/julia-test#v1:
-              test_args: "--quickfail --all"
-          - JuliaCI/julia-coverage#v1:
-              codecov: true
-              dirs:
-                - src
-                - lib
-        agents:
-          queue: "juliaecosystem"
-          os: "macos"
-          arch: "aarch64"
-        if: |
-          build.message =~ /\[only tests\]/ ||
-          build.message =~ /\[only pre\]/ ||
-          build.message !~ /\[only/ &&
-            build.message !~ /\[skip tests\]/ &&
-            build.message !~ /\[skip pre\]/
-        timeout_in_minutes: 30
-        soft_fail: true
-        matrix:
-          setup:
-            julia:
-              # - "nightly" # uncomment once dependencies support current llvm
+  # No point running nightly until the downgrader supports its LLVM version
+  # - group: ":soon: Pre-releases"
+  #   steps:
+  #     - label: "Julia pre-release {{matrix.julia}}"
+  #       plugins:
+  #         - JuliaCI/julia#v1:
+  #             version: "{{matrix.julia}}"
+  #         - JuliaCI/julia-test#v1:
+  #             test_args: "--quickfail --all"
+  #         - JuliaCI/julia-coverage#v1:
+  #             codecov: true
+  #             dirs:
+  #               - src
+  #               - lib
+  #       agents:
+  #         queue: "juliaecosystem"
+  #         os: "macos"
+  #         arch: "aarch64"
+  #       if: |
+  #         build.message =~ /\[only tests\]/ ||
+  #         build.message =~ /\[only pre\]/ ||
+  #         build.message !~ /\[only/ &&
+  #           build.message !~ /\[skip tests\]/ &&
+  #           build.message !~ /\[skip pre\]/
+  #       timeout_in_minutes: 30
+  #       soft_fail: true
+  #       matrix:
+  #         setup:
+  #           julia:
+  #             # - "nightly"
 
   # special tests
   - group: ":eyes: Special"


### PR DESCRIPTION
We missed a 1.13 regression introduced in #418 because it's allowed to fail.