### PR TITLE
[DEBUG] Investigate #796 benchmark regression [only benchmarks]

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -158,20 +158,20 @@ steps:
     command: |
       echo "--- :git: Setting up pre-#796 worktree"
       git fetch -q origin 356e7d28ea5c2005aa3bd51ab3a3389cc28ad135
-      git worktree add /tmp/metal-before 356e7d28ea5c2005aa3bd51ab3a3389cc28ad135
+      git worktree add worktree-before 356e7d28ea5c2005aa3bd51ab3a3389cc28ad135
 
       echo "--- :julia: Instantiating projects"
-      julia --project=/tmp/env-before -e 'using Pkg; Pkg.develop(path="/tmp/metal-before"); Pkg.add("BenchmarkTools"); Pkg.status()'
-      julia --project=/tmp/env-after -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.add("BenchmarkTools"); Pkg.status()'
+      julia --project=envs/before -e 'using Pkg; Pkg.develop(path="worktree-before"); Pkg.add("BenchmarkTools"); Pkg.status()'
+      julia --project=envs/after -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.add("BenchmarkTools"); Pkg.status()'
 
       echo "+++ :racehorse: BEFORE 796, -g1"
-      julia --project=/tmp/env-before perf/mwe796.jl
+      julia --project=envs/before perf/mwe796.jl
       echo "+++ :racehorse: AFTER 796, -g1"
-      julia --project=/tmp/env-after perf/mwe796.jl
+      julia --project=envs/after perf/mwe796.jl
       echo "+++ :racehorse: AFTER 796, -g0"
-      julia -g0 --project=/tmp/env-after perf/mwe796.jl
+      julia -g0 --project=envs/after perf/mwe796.jl
       echo "+++ :racehorse: AFTER 796, -g2"
-      julia -g2 --project=/tmp/env-after perf/mwe796.jl
+      julia -g2 --project=envs/after perf/mwe796.jl
     agents:
       queue: "juliaecosystem"
       os: "macos"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -158,28 +158,23 @@ steps:
     command: |
       echo "--- :git: Setting up worktrees"
       git fetch -q origin 356e7d28ea5c2005aa3bd51ab3a3389cc28ad135
-      git fetch -q origin 65ef0f7c8685ce77dafaa7b6d0bcd453d63137ee
-      git fetch -q origin f6e8b075e701ce3736fa255863beabf801551dd4
-      git fetch -q origin a5ba318bdfa521010f15a3b6d79aaee4e2d64d20
+      git fetch -q origin ab6b7a3d104cb4d7dbd87d00a2e66594656feaf6
       git worktree add worktree-before 356e7d28ea5c2005aa3bd51ab3a3389cc28ad135
-      git worktree add worktree-v2 65ef0f7c8685ce77dafaa7b6d0bcd453d63137ee
-      git worktree add worktree-vA f6e8b075e701ce3736fa255863beabf801551dd4
-      git worktree add worktree-vB a5ba318bdfa521010f15a3b6d79aaee4e2d64d20
+      git worktree add worktree-fix ab6b7a3d104cb4d7dbd87d00a2e66594656feaf6
 
       echo "--- :julia: Instantiating projects"
       julia --project=envs/before -e 'using Pkg; Pkg.develop(path="worktree-before"); Pkg.add("BenchmarkTools"); Pkg.status()'
-      julia --project=envs/v2 -e 'using Pkg; Pkg.develop(path="worktree-v2"); Pkg.add("BenchmarkTools"); Pkg.status()'
-      julia --project=envs/vA -e 'using Pkg; Pkg.develop(path="worktree-vA"); Pkg.add("BenchmarkTools"); Pkg.status()'
-      julia --project=envs/vB -e 'using Pkg; Pkg.develop(path="worktree-vB"); Pkg.add("BenchmarkTools"); Pkg.status()'
+      julia --project=envs/after -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.add("BenchmarkTools"); Pkg.status()'
+      julia --project=envs/fix -e 'using Pkg; Pkg.develop(path="worktree-fix"); Pkg.add("BenchmarkTools"); Pkg.status()'
 
       echo "+++ :racehorse: BEFORE 796, -g1"
       julia --project=envs/before perf/mwe796.jl
-      echo "+++ :racehorse: V2 position only at -g2, -g1"
-      julia --project=envs/v2 perf/mwe796.jl
-      echo "+++ :racehorse: vA deduced-name only at -g2, -g1"
-      julia --project=envs/vA perf/mwe796.jl
-      echo "+++ :racehorse: vB record nothing at -g1, -g1"
-      julia --project=envs/vB perf/mwe796.jl
+      echo "+++ :racehorse: AFTER 796, -g1"
+      julia --project=envs/after perf/mwe796.jl
+      echo "+++ :racehorse: FIX tb/fix_796_regression, -g1"
+      julia --project=envs/fix perf/mwe796.jl
+      echo "+++ :racehorse: FIX tb/fix_796_regression, -g2"
+      julia -g2 --project=envs/fix perf/mwe796.jl
     agents:
       queue: "juliaecosystem"
       os: "macos"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -156,16 +156,22 @@ steps:
       - JuliaCI/julia#v1:
           version: "1.12"
     command: |
-      julia --project=perf -e '
-        using Pkg
+      echo "--- :git: Setting up pre-#796 worktree"
+      git fetch -q origin 356e7d28ea5c2005aa3bd51ab3a3389cc28ad135
+      git worktree add /tmp/metal-before 356e7d28ea5c2005aa3bd51ab3a3389cc28ad135
 
-        println("--- :julia: Instantiating project")
-        Pkg.develop([PackageSpec(path=pwd())])
+      echo "--- :julia: Instantiating projects"
+      julia --project=/tmp/env-before -e 'using Pkg; Pkg.develop(path="/tmp/metal-before"); Pkg.add("BenchmarkTools"); Pkg.status()'
+      julia --project=/tmp/env-after -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.add("BenchmarkTools"); Pkg.status()'
 
-        println("+++ :julia: Benchmarking")
-        include("perf/runbenchmarks.jl")'
-    artifact_paths:
-      - "benchmarkresults.json"
+      echo "+++ :racehorse: BEFORE 796, -g1"
+      julia --project=/tmp/env-before perf/mwe796.jl
+      echo "+++ :racehorse: AFTER 796, -g1"
+      julia --project=/tmp/env-after perf/mwe796.jl
+      echo "+++ :racehorse: AFTER 796, -g0"
+      julia -g0 --project=/tmp/env-after perf/mwe796.jl
+      echo "+++ :racehorse: AFTER 796, -g2"
+      julia -g2 --project=/tmp/env-after perf/mwe796.jl
     agents:
       queue: "juliaecosystem"
       os: "macos"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -158,28 +158,28 @@ steps:
     command: |
       echo "--- :git: Setting up worktrees"
       git fetch -q origin 356e7d28ea5c2005aa3bd51ab3a3389cc28ad135
-      git fetch -q origin 80b02d0387cce30fd0a8cf1af0dc569dfb171ecb
       git fetch -q origin 65ef0f7c8685ce77dafaa7b6d0bcd453d63137ee
+      git fetch -q origin f6e8b075e701ce3736fa255863beabf801551dd4
+      git fetch -q origin a5ba318bdfa521010f15a3b6d79aaee4e2d64d20
       git worktree add worktree-before 356e7d28ea5c2005aa3bd51ab3a3389cc28ad135
-      git worktree add worktree-v1 80b02d0387cce30fd0a8cf1af0dc569dfb171ecb
       git worktree add worktree-v2 65ef0f7c8685ce77dafaa7b6d0bcd453d63137ee
+      git worktree add worktree-vA f6e8b075e701ce3736fa255863beabf801551dd4
+      git worktree add worktree-vB a5ba318bdfa521010f15a3b6d79aaee4e2d64d20
 
       echo "--- :julia: Instantiating projects"
       julia --project=envs/before -e 'using Pkg; Pkg.develop(path="worktree-before"); Pkg.add("BenchmarkTools"); Pkg.status()'
-      julia --project=envs/after -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.add("BenchmarkTools"); Pkg.status()'
-      julia --project=envs/v1 -e 'using Pkg; Pkg.develop(path="worktree-v1"); Pkg.add("BenchmarkTools"); Pkg.status()'
       julia --project=envs/v2 -e 'using Pkg; Pkg.develop(path="worktree-v2"); Pkg.add("BenchmarkTools"); Pkg.status()'
+      julia --project=envs/vA -e 'using Pkg; Pkg.develop(path="worktree-vA"); Pkg.add("BenchmarkTools"); Pkg.status()'
+      julia --project=envs/vB -e 'using Pkg; Pkg.develop(path="worktree-vB"); Pkg.add("BenchmarkTools"); Pkg.status()'
 
       echo "+++ :racehorse: BEFORE 796, -g1"
       julia --project=envs/before perf/mwe796.jl
-      echo "+++ :racehorse: AFTER 796, -g1"
-      julia --project=envs/after perf/mwe796.jl
-      echo "+++ :racehorse: V1 slim site code, -g1"
-      julia --project=envs/v1 perf/mwe796.jl
       echo "+++ :racehorse: V2 position only at -g2, -g1"
       julia --project=envs/v2 perf/mwe796.jl
-      echo "+++ :racehorse: V2 position only at -g2, -g2"
-      julia -g2 --project=envs/v2 perf/mwe796.jl
+      echo "+++ :racehorse: vA deduced-name only at -g2, -g1"
+      julia --project=envs/vA perf/mwe796.jl
+      echo "+++ :racehorse: vB record nothing at -g1, -g1"
+      julia --project=envs/vB perf/mwe796.jl
     agents:
       queue: "juliaecosystem"
       os: "macos"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -156,22 +156,30 @@ steps:
       - JuliaCI/julia#v1:
           version: "1.12"
     command: |
-      echo "--- :git: Setting up pre-#796 worktree"
+      echo "--- :git: Setting up worktrees"
       git fetch -q origin 356e7d28ea5c2005aa3bd51ab3a3389cc28ad135
+      git fetch -q origin 80b02d0387cce30fd0a8cf1af0dc569dfb171ecb
+      git fetch -q origin 65ef0f7c8685ce77dafaa7b6d0bcd453d63137ee
       git worktree add worktree-before 356e7d28ea5c2005aa3bd51ab3a3389cc28ad135
+      git worktree add worktree-v1 80b02d0387cce30fd0a8cf1af0dc569dfb171ecb
+      git worktree add worktree-v2 65ef0f7c8685ce77dafaa7b6d0bcd453d63137ee
 
       echo "--- :julia: Instantiating projects"
       julia --project=envs/before -e 'using Pkg; Pkg.develop(path="worktree-before"); Pkg.add("BenchmarkTools"); Pkg.status()'
       julia --project=envs/after -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.add("BenchmarkTools"); Pkg.status()'
+      julia --project=envs/v1 -e 'using Pkg; Pkg.develop(path="worktree-v1"); Pkg.add("BenchmarkTools"); Pkg.status()'
+      julia --project=envs/v2 -e 'using Pkg; Pkg.develop(path="worktree-v2"); Pkg.add("BenchmarkTools"); Pkg.status()'
 
       echo "+++ :racehorse: BEFORE 796, -g1"
       julia --project=envs/before perf/mwe796.jl
       echo "+++ :racehorse: AFTER 796, -g1"
       julia --project=envs/after perf/mwe796.jl
-      echo "+++ :racehorse: AFTER 796, -g0"
-      julia -g0 --project=envs/after perf/mwe796.jl
-      echo "+++ :racehorse: AFTER 796, -g2"
-      julia -g2 --project=envs/after perf/mwe796.jl
+      echo "+++ :racehorse: V1 slim site code, -g1"
+      julia --project=envs/v1 perf/mwe796.jl
+      echo "+++ :racehorse: V2 position only at -g2, -g1"
+      julia --project=envs/v2 perf/mwe796.jl
+      echo "+++ :racehorse: V2 position only at -g2, -g2"
+      julia -g2 --project=envs/v2 perf/mwe796.jl
     agents:
       queue: "juliaecosystem"
       os: "macos"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -158,22 +158,19 @@ steps:
     command: |
       echo "--- :git: Setting up worktrees"
       git fetch -q origin 356e7d28ea5c2005aa3bd51ab3a3389cc28ad135
-      git fetch -q origin ab6b7a3d104cb4d7dbd87d00a2e66594656feaf6
+      git fetch -q origin 5604f5e08b1fb90c57f9c72750ad310cef7388f5
       git worktree add worktree-before 356e7d28ea5c2005aa3bd51ab3a3389cc28ad135
-      git worktree add worktree-fix ab6b7a3d104cb4d7dbd87d00a2e66594656feaf6
+      git worktree add worktree-fix 5604f5e08b1fb90c57f9c72750ad310cef7388f5
 
       echo "--- :julia: Instantiating projects"
       julia --project=envs/before -e 'using Pkg; Pkg.develop(path="worktree-before"); Pkg.add("BenchmarkTools"); Pkg.status()'
-      julia --project=envs/after -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.add("BenchmarkTools"); Pkg.status()'
       julia --project=envs/fix -e 'using Pkg; Pkg.develop(path="worktree-fix"); Pkg.add("BenchmarkTools"); Pkg.status()'
 
       echo "+++ :racehorse: BEFORE 796, -g1"
       julia --project=envs/before perf/mwe796.jl
-      echo "+++ :racehorse: AFTER 796, -g1"
-      julia --project=envs/after perf/mwe796.jl
-      echo "+++ :racehorse: FIX tb/fix_796_regression, -g1"
+      echo "+++ :racehorse: FIX tb/cheap_g1_exceptions, -g1"
       julia --project=envs/fix perf/mwe796.jl
-      echo "+++ :racehorse: FIX tb/fix_796_regression, -g2"
+      echo "+++ :racehorse: FIX tb/cheap_g1_exceptions, -g2"
       julia -g2 --project=envs/fix perf/mwe796.jl
     agents:
       queue: "juliaecosystem"

--- a/perf/mwe796.jl
+++ b/perf/mwe796.jl
@@ -1,0 +1,61 @@
+# MWE for the #796 accumulate/checked-indexing benchmark regression.
+# Version-agnostic: runs on both pre- and post-#796 trees.
+
+using Metal
+using BenchmarkTools
+
+@info "Configuration" pkgdir(Metal) Base.pkgversion(Metal.GPUCompiler) Base.JLOptions().debug_level
+
+const n_el = 512 * 1000
+
+# kernels from perf/kernel.jl: identical except for bounds checking,
+# i.e. the presence of an exception (throw) path
+function indexing_kernel(dest, src)
+    i = thread_position_in_grid().x
+    @inbounds dest[i] = src[i]
+    return
+end
+
+function checked_indexing_kernel(dest, src)
+    i = thread_position_in_grid().x
+    dest[i] = src[i]
+    return
+end
+
+src = Metal.rand(Float32, 512, 1000)
+dest = similar(src)
+
+# occupancy proxy: max threads per threadgroup is determined by register usage
+let
+    kern_unchecked = @metal launch=false indexing_kernel(dest, src)
+    kern_checked = @metal launch=false checked_indexing_kernel(dest, src)
+    println("maxTotalThreadsPerThreadgroup:")
+    println("  unchecked: ", kern_unchecked.pipeline.maxTotalThreadsPerThreadgroup)
+    println("  checked:   ", kern_checked.pipeline.maxTotalThreadsPerThreadgroup)
+end
+
+# the scan kernel used by accumulate
+let
+    f = +
+    vec = reshape(src, length(src))
+    output = similar(vec)
+    Rdim = CartesianIndices((n_el,))
+    Rpre = CartesianIndices(())
+    Rpost = CartesianIndices(())
+    Rother = CartesianIndices((1,))
+    maxthreads = 1024
+    kern = @metal launch=false Metal.partial_scan(f, output, vec, Rdim, Rpre, Rpost,
+                                                  Rother, zero(Float32), nothing,
+                                                  Val(maxthreads), Val(true))
+    println("  partial_scan: ", kern.pipeline.maxTotalThreadsPerThreadgroup)
+end
+
+t = @belapsed(Metal.@sync(@metal threads=512 groups=1000 indexing_kernel($dest, $src)))
+println("indexing (unchecked): ", round(t * 1e6; digits=1), " us")
+
+t = @belapsed(Metal.@sync(@metal threads=512 groups=1000 checked_indexing_kernel($dest, $src)))
+println("indexing (checked):   ", round(t * 1e6; digits=1), " us")
+
+gpu_vec = reshape(src, length(src))
+t = @belapsed Metal.@sync accumulate(+, $gpu_vec)
+println("accumulate 1d:        ", round(t * 1e6; digits=1), " us")

--- a/perf/mwe796.jl
+++ b/perf/mwe796.jl
@@ -4,6 +4,11 @@
 using Metal
 using BenchmarkTools
 
+# the GPUCompiler runtime library is cached on disk keyed by target+debug level only, with
+# no hash of the runtime sources: when multiple Metal.jl checkouts share a depot, one tree's
+# runtime (signal_exception etc.) gets linked into the other's kernels. force a rebuild.
+Metal.GPUCompiler.reset_runtime()
+
 @info "Configuration" pkgdir(Metal) Base.pkgversion(Metal.GPUCompiler) Base.JLOptions().debug_level
 
 const n_el = 512 * 1000

--- a/perf/mwe796.jl
+++ b/perf/mwe796.jl
@@ -64,3 +64,24 @@ println("indexing (checked):   ", round(t * 1e6; digits=1), " us")
 gpu_vec = reshape(src, length(src))
 t = @belapsed Metal.@sync accumulate(+, $gpu_vec)
 println("accumulate 1d:        ", round(t * 1e6; digits=1), " us")
+
+# per-debug-level timing of the raw scan kernel (the dominant launch of accumulate 1d),
+# using the per-kernel `debug_level` keyword (part of the compile cache key) so all levels
+# can be compared within one process. only supported on post-#796 trees.
+if :debug_level in Metal.COMPILER_KWARGS
+    vec = gpu_vec
+    output = similar(vec)
+    Rdim = CartesianIndices((n_el,))
+    Rpre = CartesianIndices(())
+    Rpost = CartesianIndices(())
+    Rother = CartesianIndices((1, 1))
+    for level in 0:2
+        kern = @metal launch=false debug_level=level Metal.partial_scan(
+            +, output, vec, Rdim, Rpre, Rpost, Rother, 0.0f0, nothing,
+            Val(1024), Val(true))
+        t = @belapsed Metal.@sync $kern(+, $output, $vec, $Rdim, $Rpre, $Rpost, $Rother,
+                                        0.0f0, nothing, Val(1024), Val(true);
+                                        threads=1024, groups=(500, 1, 1))
+        println("partial_scan -g$level:      ", round(t * 1e6; digits=1), " us")
+    end
+end

--- a/perf/mwe796.jl
+++ b/perf/mwe796.jl
@@ -67,21 +67,8 @@ println("accumulate 1d:        ", round(t * 1e6; digits=1), " us")
 
 # per-debug-level timing of the raw scan kernel (the dominant launch of accumulate 1d),
 # using the per-kernel `debug_level` keyword (part of the compile cache key) so all levels
-# can be compared within one process. only supported on post-#796 trees.
+# can be compared within one process. only supported on post-#796 trees; in a separate file
+# because `@metal debug_level=` is rejected at macro-expansion time on older trees.
 if :debug_level in Metal.COMPILER_KWARGS
-    vec = gpu_vec
-    output = similar(vec)
-    Rdim = CartesianIndices((n_el,))
-    Rpre = CartesianIndices(())
-    Rpost = CartesianIndices(())
-    Rother = CartesianIndices((1, 1))
-    for level in 0:2
-        kern = @metal launch=false debug_level=level Metal.partial_scan(
-            +, output, vec, Rdim, Rpre, Rpost, Rother, 0.0f0, nothing,
-            Val(1024), Val(true))
-        t = @belapsed Metal.@sync $kern(+, $output, $vec, $Rdim, $Rpre, $Rpost, $Rother,
-                                        0.0f0, nothing, Val(1024), Val(true);
-                                        threads=1024, groups=(500, 1, 1))
-        println("partial_scan -g$level:      ", round(t * 1e6; digits=1), " us")
-    end
+    include("mwe796_sweep.jl")
 end

--- a/perf/mwe796_sweep.jl
+++ b/perf/mwe796_sweep.jl
@@ -1,0 +1,19 @@
+# see mwe796.jl: per-debug-level timing of the raw partial_scan kernel; requires the
+# `@metal debug_level=` keyword (post-#796)
+
+let vec = gpu_vec
+    output = similar(vec)
+    Rdim = CartesianIndices((n_el,))
+    Rpre = CartesianIndices(())
+    Rpost = CartesianIndices(())
+    Rother = CartesianIndices((1, 1))
+    for level in 0:2
+        kern = @metal launch=false debug_level=level Metal.partial_scan(
+            +, output, vec, Rdim, Rpre, Rpost, Rother, 0.0f0, nothing,
+            Val(1024), Val(true))
+        t = @belapsed Metal.@sync $kern(+, $output, $vec, $Rdim, $Rpre, $Rpost, $Rother,
+                                        0.0f0, nothing, Val(1024), Val(true);
+                                        threads=1024, groups=(500, 1, 1))
+        println("partial_scan -g$level:      ", round(t * 1e6; digits=1), " us")
+    end
+end


### PR DESCRIPTION
Debug PR, do not merge: in-job A/B of the accumulate/checked-indexing regression introduced by #796 on the M1 benchmark runner, comparing 356e7d28 (pre-#796) against current main with identical GPUCompiler versions, at -g0/-g1/-g2, including pipeline occupancy info.

🤖 Generated with [Claude Code](https://claude.com/claude-code)