### PR TITLE
Lower cost of exception reporting

### DIFF
--- a/docs/src/usage/kernel.md
+++ b/docs/src/usage/kernel.md
@@ -142,15 +142,15 @@ path stays as small as the level allows:
 
 - At `-g0`, only the fact that an exception occurred is reported:
   `KernelException: an exception was thrown on device Apple M1`.
-- At `-g1` (the default), the type and reason are reported, as shown above. The common
-  implicit exceptions (bounds, domain, overflow, inexact, and so on) carry a precise type
-  and reason; other throws report whatever type the compiler could deduce, which is often
-  a generic `exception`.
+- At `-g1` (the default), the type and reason are reported, as shown above, for the common
+  implicit exceptions (bounds, domain, overflow, inexact, and so on); other throws only
+  report that an exception occurred.
 - At `-g2`, the faulting position (`... was thrown by thread 1×1×1 in threadgroup 1×1×1`)
-  and a device-side stack trace are additionally reported. (The position is not recorded
-  at `-g1` because keeping it would tax every kernel that can throw, even when nothing
-  ever throws: the exception path grows and the thread-position inputs are kept live,
-  which measurably slows kernels down on M1/M2 GPUs.)
+  and a device-side stack trace are additionally reported, and throws not covered above
+  report whatever type name the compiler could deduce (often a generic `exception`).
+  This extra detail is not recorded at `-g1` because its machinery taxes every kernel
+  that can throw, even when nothing ever throws, measurably slowing down kernels on
+  M1-era GPUs.
 
 The level can also be set per launch, independent of the session's `-g`, with the
 `debug_level` keyword — for example `@metal debug_level=2 kernel(args...)` to capture a

--- a/docs/src/usage/kernel.md
+++ b/docs/src/usage/kernel.md
@@ -135,6 +135,7 @@ julia> @metal threads=1 kernel(Metal.zeros(Float32, 1));
 
 julia> synchronize()
 ERROR: KernelException: A BoundsError was thrown on device Apple M1: Out-of-bounds array access
+For more details, run Julia with `-g2`, or launch the kernel with `@metal debug_level=2`.
 ```
 
 How much detail is reported depends on Julia's debug level (the `-g` flag), so the unhappy

--- a/docs/src/usage/kernel.md
+++ b/docs/src/usage/kernel.md
@@ -134,7 +134,7 @@ julia> function kernel(a)
 julia> @metal threads=1 kernel(Metal.zeros(Float32, 1));
 
 julia> synchronize()
-ERROR: KernelException: A BoundsError was thrown by thread 1×1×1 in threadgroup 1×1×1 on device Apple M1: Out-of-bounds array access
+ERROR: KernelException: A BoundsError was thrown on device Apple M1: Out-of-bounds array access
 ```
 
 How much detail is reported depends on Julia's debug level (the `-g` flag), so the unhappy
@@ -142,11 +142,15 @@ path stays as small as the level allows:
 
 - At `-g0`, only the fact that an exception occurred is reported:
   `KernelException: an exception was thrown on device Apple M1`.
-- At `-g1` (the default), the type, reason, and faulting position are reported, as shown
-  above. The common implicit exceptions (bounds, domain, overflow, inexact, and so on)
-  carry a precise type and reason; other throws report whatever type the compiler could
-  deduce, which is often a generic `exception`.
-- At `-g2`, a device-side stack trace is additionally captured and appended.
+- At `-g1` (the default), the type and reason are reported, as shown above. The common
+  implicit exceptions (bounds, domain, overflow, inexact, and so on) carry a precise type
+  and reason; other throws report whatever type the compiler could deduce, which is often
+  a generic `exception`.
+- At `-g2`, the faulting position (`... was thrown by thread 1×1×1 in threadgroup 1×1×1`)
+  and a device-side stack trace are additionally reported. (The position is not recorded
+  at `-g1` because keeping it would tax every kernel that can throw, even when nothing
+  ever throws: the exception path grows and the thread-position inputs are kept live,
+  which measurably slows kernels down on M1/M2 GPUs.)
 
 The level can also be set per launch, independent of the session's `-g`, with the
 `debug_level` keyword — for example `@metal debug_level=2 kernel(args...)` to capture a

--- a/src/compiler/exceptions.jl
+++ b/src/compiler/exceptions.jl
@@ -25,7 +25,9 @@ function Base.showerror(io::IO, err::KernelException)
     end
     print(io, " on device $(String(err.dev.name))")
     isempty(err.reason) || print(io, ": ", err.reason)
-    if !isempty(err.backtrace)
+    if err.thread == (0, 0, 0)
+        print(io, "\nFor more details, run Julia with `-g2`, or launch the kernel with `@metal debug_level=2`")
+    else
         print(io, "\nStacktrace:")
         for (i, (func, file, line)) in enumerate(err.backtrace)
             print(io, "\n [", i, "] ", func)

--- a/src/device/runtime.jl
+++ b/src/device/runtime.jl
@@ -37,7 +37,8 @@ struct ExceptionInfo_st
     status::Int32
     # whether a lane has claimed the mailbox (0 -> 1); only the holder writes a record
     output_lock::Int32
-    # the position of the faulting lane (also used to recognize the lock holder)
+    # the position of the faulting lane, recorded at debug level >= 2 (also used to
+    # recognize the lock holder for the multi-call -g2 reporting sequence)
     thread::NTuple{3, UInt32}
     threadgroup::NTuple{3, UInt32}
     # the exception type name and reason, as null-terminated text the host reads back
@@ -110,8 +111,8 @@ const EXCEPTION_FRAME_SIZE = sizeof(ExceptionFrame_st)
     return Expr(:block, exprs...)
 end
 
-# claim the mailbox for the calling lane. returns `true` to the single lane that wins the
-# claim and, re-entrantly, to that same lane on later calls (recognized by its recorded
+# claim the mailbox for the calling lane. returns `true` to the lane that wins the claim
+# (at `-g2` also re-entrantly to that same lane on later calls, recognized by its recorded
 # position), so it can go on to write the name, reason, and stack frames. any other faulting
 # lane gets `false` and leaves the record untouched (no spin, so a divergent threadgroup
 # can't deadlock here).
@@ -130,6 +131,19 @@ end
 # to a handful of calls.
 @noinline function claim_output!(info)
     lock_ptr = info_field(info, Val(:output_lock))
+    if kernel_debug_level() < 2
+        # one-shot claim: at `-g1` each lane records everything it has to say (the name
+        # and reason) under a single call, so no re-entrancy is needed -- and skipping the
+        # position keeps the cold path free of thread-position uses. those reads cost every
+        # throw-capable kernel even when nothing ever throws: the positions are kernel
+        # inputs held live for the cold path's sake, and the extra cold code itself is
+        # penalized by the M1/macOS 15 backend (the #796 regression). the lane's position
+        # is hence only reported at `-g2`.
+        return atomic_exchange_explicit(lock_ptr, Int32(1)) == Int32(0)
+    end
+    # re-entrant claim: the `-g2` reporting sequence spans multiple calls (the exception
+    # name, then each stack frame), so the holder must be able to re-claim, recognized by
+    # its recorded position (which doubles as the reported fault location).
     t  = thread_position_in_threadgroup()
     tg = threadgroup_position_in_grid()
     if atomic_exchange_explicit(lock_ptr, Int32(1)) == Int32(0)

--- a/src/device/runtime.jl
+++ b/src/device/runtime.jl
@@ -134,11 +134,14 @@ end
     if kernel_debug_level() < 2
         # one-shot claim: at `-g1` each lane records everything it has to say (the name
         # and reason) under a single call, so no re-entrancy is needed -- and skipping the
-        # position keeps the cold path free of thread-position uses. those reads cost every
-        # throw-capable kernel even when nothing ever throws: the positions are kernel
-        # inputs held live for the cold path's sake, and the extra cold code itself is
-        # penalized by the M1/macOS 15 backend (the #796 regression). the lane's position
-        # is hence only reported at `-g2`.
+        # position recording keeps the unhappy path down to this single atomic exchange.
+        # that frugality is measured, not aesthetic: the position machinery (reading the
+        # thread-position kernel inputs, keeping them live into cold code, and the
+        # re-entrant comparisons below) is penalized by the M1 (macOS 15) backend in every
+        # kernel that can throw, even when no exception is ever thrown -- it alone
+        # regressed accumulate by ~50% (JuliaGPU/Metal.jl#796), independently of the
+        # other costly construct (see `report_exception`). the lane's position is hence
+        # only recorded, and reported, at `-g2`.
         return atomic_exchange_explicit(lock_ptr, Int32(1)) == Int32(0)
     end
     # re-entrant claim: the `-g2` reporting sequence spans multiple calls (the exception
@@ -201,12 +204,22 @@ end
 # debug level 1 (`report_exception`) or >= 2 (`report_exception_name`). record it as the
 # type name, unless a quirk's `@gputhrow` already wrote a more precise name (in which case
 # the name buffer is non-empty and we leave it alone).
+#
+# recording only happens at debug level >= 2: copying the runtime name string requires
+# `store_cstring!`'s data-dependent byte loop, and a loop on the unhappy path is one of the
+# constructs the M1 (macOS 15) backend penalizes in every kernel that can throw, even when
+# no exception is ever thrown (it alone regressed accumulate by more than 50%; see
+# `claim_output!` for the other one). at `-g1` this folds to an empty function, and quirk
+# throws -- the common exceptions -- still record their full name and reason through
+# `record_exception!`'s loop-free word stores.
 function report_exception(ex)
-    info = kernel_state().exception_info
-    name = info_field(info, Val(:name))
-    if lock_output!(info) &&
-       unsafe_load(reinterpret(Core.LLVMPtr{UInt8, AS.Device}, name)) == 0x00
-        store_cstring!(name, ex)
+    if kernel_debug_level() >= 2
+        info = kernel_state().exception_info
+        name = info_field(info, Val(:name))
+        if lock_output!(info) &&
+           unsafe_load(reinterpret(Core.LLVMPtr{UInt8, AS.Device}, name)) == 0x00
+            store_cstring!(name, ex)
+        end
     end
     return
 end

--- a/src/device/runtime.jl
+++ b/src/device/runtime.jl
@@ -123,12 +123,11 @@ end
 @inline lock_output!(info) = kernel_debug_level() < 1 ? false : claim_output!(info)
 
 # the body of `lock_output!`, kept out of line. with `--check-bounds=yes` every indexing
-# operation grows a throw path, and inlining this claim (atomic exchange + SIMD position
-# reads + the re-entrant comparison) into each one balloons the kernel. Apple's shader
-# validator compiles that bloated kernel on every PSO creation and, on the macOS 15 CI
-# runner, crashes doing so; the backend then retries, which is what made the validation suite
-# time out. one shared, called-into copy keeps each kernel's unhappy path to a handful of
-# calls.
+# operation grows a throw path, and inlining this claim into each one balloons the kernel.
+# Apple's shader validator compiles that bloated kernel on every PSO creation and, on the
+# macOS 15 CI runner, crashes doing so; the backend then retries, which is what made the
+# validation suite time out. one shared, called-into copy keeps each kernel's unhappy path
+# to a handful of calls.
 @noinline function claim_output!(info)
     lock_ptr = info_field(info, Val(:output_lock))
     t  = thread_position_in_threadgroup()
@@ -162,12 +161,24 @@ end
     return
 end
 
+# record a compile-time exception name and reason in the mailbox, claiming it first. one
+# out-of-line copy serves every `@gputhrow` site of a given exception (see the macro),
+# keeping per-site cold code to a single call whose only argument is the mailbox pointer.
+@noinline function record_exception!(info, ::Val{name}, ::Val{reason}) where {name, reason}
+    if lock_output!(info)
+        store_string!(info_field(info, Val(:name)),   Val(name))
+        store_string!(info_field(info, Val(:reason)), Val(reason))
+    end
+    return
+end
+
 function signal_exception()
     info = kernel_state().exception_info
-    # record our position if we're the first faulting lane to reach the mailbox; at `-g0`
-    # `lock_output!` is a no-op (returns `false`), leaving only the status flag below
-    lock_output!(info)
-    # raise the host-visible flag so the exception isn't silently swallowed
+    # raise the host-visible flag so the exception isn't silently swallowed. no claiming
+    # here: at debug level >= 1 the reporting calls preceding this one (`report_exception`,
+    # `@gputhrow`) have already claimed the mailbox and recorded what there is to record,
+    # and at `-g0` there is nothing to claim for, keeping this -- the one call present at
+    # every throw site regardless of debug level -- free of mailbox traffic.
     atomic_store_explicit(info_field(info, Val(:status)), Int32(1))
     return
 end

--- a/src/device/utils.jl
+++ b/src/device/utils.jl
@@ -3,14 +3,16 @@ Base.Experimental.@MethodTable(method_table)
 
 # throw a device-side exception, recording its type name and reason in the exception
 # mailbox so the host can report them (see `device/runtime.jl`, `compiler/exceptions.jl`).
+# the recording happens in a single out-of-line helper (`record_exception!`): GPUCompiler
+# force-inlines throwing functions into their callers, so anything in this macro lands at
+# every single throw site of every kernel.
 macro gputhrow(name::String, reason::String)
     name_q = QuoteNode(Symbol(name))
     reason_q = QuoteNode(Symbol(reason))
     return quote
-        info = kernel_state().exception_info
-        if lock_output!(info)
-            store_string!(info_field(info, Val(:name)),   Val($name_q))
-            store_string!(info_field(info, Val(:reason)), Val($reason_q))
+        # the gate folds to a constant, so `-g0` kernels don't even carry the call
+        if kernel_debug_level() >= 1
+            record_exception!(kernel_state().exception_info, Val($name_q), Val($reason_q))
         end
         throw(nothing)
     end

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -157,8 +157,9 @@ end
     @metal threads=1 throwing_kernel(a)
     @test_throws Metal.KernelException synchronize()
 
-    # the faulting lane's position is recorded at debug level >= 2 (recording it at lower
-    # levels would cost every kernel two extra position inputs; see `claim_output!`)
+    # the faulting lane's position is recorded at debug level >= 2 (the recording machinery
+    # slows down every kernel that can throw, even when nothing ever does; see
+    # `claim_output!`)
     function throw_at_three(a)
         if thread_position_in_threadgroup().x == 3
             a[2] = 1f0  # out-of-bounds store on a length-1 array
@@ -204,19 +205,23 @@ end
     @test exc0.thread == (0, 0, 0)
     @test isempty(exc0.backtrace)
 
-    # -g1: the faulting type and reason; no position (recording it would cost every kernel
-    # that can throw two extra position inputs, hurting occupancy even when nothing throws)
+    # -g1: the faulting type and reason for quirk throws; no position (the recording
+    # machinery slows down every kernel that can throw, even when nothing ever does;
+    # see `claim_output!`)
     exc1 = throw_at(1, bounds_oob, Metal.zeros(Float32, 1))
     @test exc1.name == "BoundsError"
     @test exc1.reason == "Out-of-bounds array access"
     @test exc1.thread == (0, 0, 0)
     @test isempty(exc1.backtrace)
 
-    # a non-quirk throw records whatever type the compiler deduced (here `jl_throw`'s
-    # generic "exception"), via report_exception at debug level >= 1
+    # a non-quirk throw records the compiler-deduced type name (here `jl_throw`'s generic
+    # "exception") only at debug level >= 2: copying that runtime string takes a byte loop
+    # on the unhappy path, which is similarly penalized (see `report_exception`)
     excn = throw_at(1, nonquirk, Metal.zeros(Int32, 1), MtlArray(Int32[0]))
     @test excn isa Metal.KernelException
-    @test excn.name == "exception"
+    @test isempty(excn.name)
+    excn2 = throw_at(2, nonquirk, Metal.zeros(Int32, 1), MtlArray(Int32[0]))
+    @test excn2.name == "exception"
 
     # -g2: adds the faulting position and the device stack trace
     exc2 = throw_at(2, bounds_oob, Metal.zeros(Float32, 1))

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -157,16 +157,15 @@ end
     @metal threads=1 throwing_kernel(a)
     @test_throws Metal.KernelException synchronize()
 
-    # the faulting lane's type, reason, and position are reported at debug level >= 1 (the
-    # default); at -g0 only the bare status flag is written and everything stays at its
-    # sentinel, so the host reports just that an exception occurred
+    # the faulting lane's position is recorded at debug level >= 2 (recording it at lower
+    # levels would cost every kernel two extra position inputs; see `claim_output!`)
     function throw_at_three(a)
         if thread_position_in_threadgroup().x == 3
             a[2] = 1f0  # out-of-bounds store on a length-1 array
         end
         return
     end
-    @metal threads=4 throw_at_three(a)
+    @metal threads=4 debug_level=2 throw_at_three(a)
     exc = try
         synchronize()
         nothing
@@ -205,11 +204,12 @@ end
     @test exc0.thread == (0, 0, 0)
     @test isempty(exc0.backtrace)
 
-    # -g1: the faulting type, reason, and position
+    # -g1: the faulting type and reason; no position (recording it would cost every kernel
+    # that can throw two extra position inputs, hurting occupancy even when nothing throws)
     exc1 = throw_at(1, bounds_oob, Metal.zeros(Float32, 1))
     @test exc1.name == "BoundsError"
     @test exc1.reason == "Out-of-bounds array access"
-    @test exc1.thread == (1, 1, 1)
+    @test exc1.thread == (0, 0, 0)
     @test isempty(exc1.backtrace)
 
     # a non-quirk throw records whatever type the compiler deduced (here `jl_throw`'s
@@ -218,9 +218,11 @@ end
     @test excn isa Metal.KernelException
     @test excn.name == "exception"
 
-    # -g2: adds the device stack trace
+    # -g2: adds the faulting position and the device stack trace
     exc2 = throw_at(2, bounds_oob, Metal.zeros(Float32, 1))
     @test exc2.name == "BoundsError"
+    @test exc2.thread == (1, 1, 1)
+    @test exc2.threadgroup == (1, 1, 1)
     @test !isempty(exc2.backtrace)
     @test any(frame -> occursin("throw_boundserror", frame[1]), exc2.backtrace)
 end


### PR DESCRIPTION
Turns out the added cold-path code to the exception mechanism has a performance impact on the benchmark runner (M1/macos 15). I'm not sure if it's processor or toolchain related, but let's only do the apparently expensive stuff on higher debug levels. This does regress the default experience, but with the `debug_level` kwarg it's at least easy to bump without having to restart the session:

```
julia> function vadd(arr)
           arr[1] = 0
           return
       end

julia> arr = MtlArray{Int64}(undef, 0);

julia> @metal vadd(arr)
ERROR: KernelException: A BoundsError was thrown on device Apple M3 Pro: Out-of-bounds array access
For more details, run Julia with `-g2`, or launch the kernel with `@metal debug_level=2`
Stacktrace:
  [1] macro expansion
    @ ~/Julia/pkg/Metal-796-fix/src/compiler/exceptions.jl:92 [inlined]
  [2] macro expansion
    @ ./lock.jl:376 [inlined]
  [3] check_exceptions()
    @ Metal ~/Julia/pkg/Metal-796-fix/src/compiler/exceptions.jl:74

julia> @metal debug_level=2 vadd(arr)
ERROR: KernelException: A BoundsError was thrown by thread 1×1×1 in threadgroup 1×1×1 on device Apple M3 Pro: Out-of-bounds array access
Stacktrace:
 [1] macro expansion at /Users/tim/Julia/pkg/Metal-796-fix/src/device/utils.jl:17
 [2] throw_boundserror at /Users/tim/Julia/pkg/Metal-796-fix/src/device/quirks.jl:37
 [3] checkbounds at ./abstractarray.jl:699
 [4] arrayset at /Users/tim/Julia/pkg/Metal-796-fix/src/device/array.jl:86
 [5] setindex! at /Users/tim/Julia/pkg/Metal-796-fix/src/device/array.jl:105
 [6] vadd at ./REPL[2]:2
Stacktrace:
  [1] macro expansion
    @ ~/Julia/pkg/Metal-796-fix/src/compiler/exceptions.jl:92 [inlined]
  [2] macro expansion
    @ ./lock.jl:376 [inlined]
  [3] check_exceptions()
    @ Metal ~/Julia/pkg/Metal-796-fix/src/compiler/exceptions.jl:74
```

x-ref https://github.com/JuliaGPU/Metal.jl/pull/796#issuecomment-4617491472