### PR TITLE
Support the non-transposed simdgroup matrix layout

### DIFF
--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -74,6 +74,24 @@ function GPUCompiler.finish_module!(@nospecialize(job::MetalCompilerJob),
     return entry
 end
 
+# the statically-known integer in lane `i` of a vector value, or `nothing` if that lane
+# isn't a compile-time constant. looks through the `insertelement` chains and constant
+# vectors that the simdgroup intrinsics build their dims/strides operands from.
+function static_vector_lane(v::LLVM.Value, i::Integer)
+    if v isa LLVM.InsertElementInst
+        base, elt, idx = operands(v)
+        idx isa LLVM.ConstantInt || return nothing  # unknown insert position
+        if convert(Int, idx) == i
+            return elt isa LLVM.ConstantInt ? convert(Int, elt) : nothing
+        end
+        return static_vector_lane(base, i)  # this lane is untouched by the insert
+    end
+    elref = LLVM.API.LLVMGetAggregateElement(v, UInt32(i))
+    elref == C_NULL && return nothing
+    el = LLVM.Value(elref)
+    return el isa LLVM.ConstantInt ? convert(Int, el) : nothing
+end
+
 function GPUCompiler.finish_ir!(@nospecialize(job::MetalCompilerJob),
                                     mod::LLVM.Module, entry::LLVM.Function)
     entry = invoke(GPUCompiler.finish_ir!,
@@ -84,11 +102,13 @@ function GPUCompiler.finish_ir!(@nospecialize(job::MetalCompilerJob),
     if job.config.target.air < v"2.8"
         # AIR 2.8 generalized the simdgroup matrix load/store intrinsics, replacing
         # the elements-per-row scalar, matrix origin, and transposition flag with
-        # vectors describing the dimensions, strides and origin of the memory operand.
-        # this rewrite blindly projects onto the legacy transposed encoding, i.e.,
-        # epr = dims[2] with a swapped origin and transpose = true, because that is the
-        # only layout our device code emits (keep in sync with `simdgroup_load/store`
-        # in src/device/intrinsics/simd.jl).
+        # vectors describing the dimensions, strides and origin of the memory operand,
+        # with transposition expressed by swapping those vectors' elements (see
+        # `simdgroup_load/store` in src/device/intrinsics/simd.jl). recover the legacy
+        # operands from the 2.8 layout: the elements-per-row is the non-unit stride, the
+        # transpose flag is statically recovered from which stride is unit (the legacy
+        # intrinsic needs it as an immediate), and the transposed layout's swapped origin
+        # is unswapped back.
         for f in collect(functions(mod))
             fn = LLVM.name(f)
             m = match(r"^air\.simdgroup_matrix_8x8_(load|store)\.", fn)
@@ -127,18 +147,36 @@ function GPUCompiler.finish_ir!(@nospecialize(job::MetalCompilerJob),
 
                     args = collect(arguments(call))
                     prefix = is_load ? args[1:1] : args[1:2]
-                    dims, _, origin = args[end-2:end]
+                    _, strides, origin = args[end-2:end]
 
-                    epr = extract_element!(builder, dims, ConstantInt(Int32(1)))
-                    o1 = extract_element!(builder, origin, ConstantInt(Int32(0)))
-                    o2 = extract_element!(builder, origin, ConstantInt(Int32(1)))
-                    swapped = insert_element!(builder, UndefValue(T_vec2), o2,
-                                              ConstantInt(Int32(0)))
-                    swapped = insert_element!(builder, swapped, o1,
-                                              ConstantInt(Int32(1)))
+                    # the transposed layout has a unit stride in the second dimension;
+                    # the non-transposed one in the first. one of the two is always the
+                    # literal 1, so this is statically decidable.
+                    transposed = static_vector_lane(strides, 1) == 1
+                    @assert transposed || static_vector_lane(strides, 0) == 1 """
+                        unexpected simdgroup matrix strides $(strides); the AIR downgrade \
+                        only handles the transposed and non-transposed column-major layouts \
+                        emitted by `simdgroup_load`/`simdgroup_store`"""
+
+                    # elements per row is the non-unit (leading-dimension) stride
+                    epr = extract_element!(builder, strides,
+                                           ConstantInt(Int32(transposed ? 0 : 1)))
+
+                    # the transposed layout emits a row/column-swapped origin; unswap it
+                    # for the legacy form, which leaves the non-transposed origin as-is
+                    legacy_origin = origin
+                    if transposed
+                        o1 = extract_element!(builder, origin, ConstantInt(Int32(0)))
+                        o2 = extract_element!(builder, origin, ConstantInt(Int32(1)))
+                        legacy_origin = insert_element!(builder, UndefValue(T_vec2), o2,
+                                                        ConstantInt(Int32(0)))
+                        legacy_origin = insert_element!(builder, legacy_origin, o1,
+                                                        ConstantInt(Int32(1)))
+                    end
 
                     new_call = call!(builder, old_ft, old_f,
-                                     [prefix..., epr, swapped, ConstantInt(T_bool, true)])
+                                     [prefix..., epr, legacy_origin,
+                                      ConstantInt(T_bool, transposed)])
                     replace_uses!(call, new_call)
                     erase!(call)
                 end

--- a/src/device/intrinsics/simd.jl
+++ b/src/device/intrinsics/simd.jl
@@ -9,39 +9,48 @@ function convert_origin(origin::NTuple{2, Int64})
 end
 
 # the load/store intrinsics use their newest (AIR 2.8) signature, taking dims, strides
-# and origin vectors; here always the transposed layout of a column-major matrix, i.e.,
-# dims = (8, epr), strides = (epr, 1), and a row/column-swapped origin. when targeting
-# older AIR versions, `finish_ir!` rewrites these calls to the legacy signature, relying
-# on this being the only emitted layout (keep in sync with the downgrade rule in
-# src/compiler/compilation.jl).
+# and origin vectors. AIR 2.8 expresses transposition by swapping those vectors' elements:
+# the transposed layout of a column-major matrix is dims = (8, epr), strides = (epr, 1),
+# and a row/column-swapped origin, while the non-transposed layout swaps each to
+# dims = (epr, 8), strides = (1, epr) and an unswapped origin. when targeting older AIR
+# versions, `finish_ir!` rewrites these calls to the legacy elements-per-row + transpose
+# flag signature (keep in sync with the downgrade rule in src/compiler/compilation.jl).
 for (jltype, suffix) in ((:Float16, "f16"), (:Float32, "f32"))
     for as in (AS.Device, AS.ThreadGroup)
         @eval begin
             @device_function simdgroup_load(
                 data::MtlDeviceArray{$jltype, <:Any, $as},
                 matrix_origin::NTuple{2, Int64} = (1, 1),
-            ) = @typed_ccall($"air.simdgroup_matrix_8x8_load.v64$suffix.p$as$suffix",
+                ::Val{transpose} = Val(true),
+            ) where {transpose} = @typed_ccall($"air.simdgroup_matrix_8x8_load.v64$suffix.p$as$suffix",
                 llvmcall, NTuple{64, VecElement{$jltype}},
                 (LLVMPtr{$jltype, $as}, NTuple{2, VecElement{Int64}},
                  NTuple{2, VecElement{Int64}}, NTuple{2, VecElement{Int64}}),
                 pointer(data),
-                (VecElement{Int64}(8), VecElement{Int64}(size(data)[1])),
-                (VecElement{Int64}(size(data)[1]), VecElement{Int64}(1)),
-                convert_origin(reverse(matrix_origin)))
+                transpose ? (VecElement{Int64}(8), VecElement{Int64}(size(data)[1])) :
+                            (VecElement{Int64}(size(data)[1]), VecElement{Int64}(8)),
+                transpose ? (VecElement{Int64}(size(data)[1]), VecElement{Int64}(1)) :
+                            (VecElement{Int64}(1), VecElement{Int64}(size(data)[1])),
+                transpose ? convert_origin(reverse(matrix_origin)) :
+                            convert_origin(matrix_origin))
 
             @device_function simdgroup_store(
                 src::NTuple{64, VecElement{$jltype}},
                 dest::MtlDeviceArray{$jltype, <:Any, $as},
                 matrix_origin::NTuple{2, Int64} = (1, 1),
-            ) = @typed_ccall($"air.simdgroup_matrix_8x8_store.v64$suffix.p$as$suffix",
+                ::Val{transpose} = Val(true),
+            ) where {transpose} = @typed_ccall($"air.simdgroup_matrix_8x8_store.v64$suffix.p$as$suffix",
                 llvmcall, Cvoid,
                 (NTuple{64, VecElement{$jltype}}, LLVMPtr{$jltype, $as},
                  NTuple{2, VecElement{Int64}}, NTuple{2, VecElement{Int64}},
                  NTuple{2, VecElement{Int64}}),
                 src, pointer(dest),
-                (VecElement{Int64}(8), VecElement{Int64}(size(dest)[1])),
-                (VecElement{Int64}(size(dest)[1]), VecElement{Int64}(1)),
-                convert_origin(reverse(matrix_origin)))
+                transpose ? (VecElement{Int64}(8), VecElement{Int64}(size(dest)[1])) :
+                            (VecElement{Int64}(size(dest)[1]), VecElement{Int64}(8)),
+                transpose ? (VecElement{Int64}(size(dest)[1]), VecElement{Int64}(1)) :
+                            (VecElement{Int64}(1), VecElement{Int64}(size(dest)[1])),
+                transpose ? convert_origin(reverse(matrix_origin)) :
+                            convert_origin(matrix_origin))
         end
     end
 
@@ -68,23 +77,29 @@ end
 ## Documentation
 
 @doc """
-    simdgroup_load(data::MtlDeviceArray{T}, matrix_origin=(1, 1))
+    simdgroup_load(data::MtlDeviceArray{T}, matrix_origin=(1, 1), Val(transpose)=Val(true))
 
 Loads data from device or threadgroup memory into an 8x8 SIMD-group matrix
 and returns it. `T` must be either `Float16` or `Float32`.
 
 # Arguments
 - `matrix_origin::NTuple{2, Int64}=(1, 1)`: origin in the source memory to load from.
+- `Val(transpose)::Val{Bool}=Val(true)`: whether to transpose the loaded matrix. The
+  default `Val(true)` treats the column-major source as a regular (non-transposed)
+  matrix; pass `Val(false)` to load the transpose.
 """ simdgroup_load
 
 @doc """
-    simdgroup_store(src, dest::MtlDeviceArray{T}, matrix_origin=(1, 1))
+    simdgroup_store(src, dest::MtlDeviceArray{T}, matrix_origin=(1, 1), Val(transpose)=Val(true))
 
 Stores data from an 8x8 SIMD-group matrix into device or threadgroup memory.
 `T` must be either `Float16` or `Float32`.
 
 # Arguments
 - `matrix_origin::NTuple{2, Int64}=(1, 1)`: origin in the destination memory to store to.
+- `Val(transpose)::Val{Bool}=Val(true)`: whether to transpose the matrix on store. The
+  default `Val(true)` matches the column-major convention; pass `Val(false)` to store the
+  transpose.
 """ simdgroup_store
 
 @doc """

--- a/test/device/intrinsics/simd.jl
+++ b/test/device/intrinsics/simd.jl
@@ -334,5 +334,40 @@ end # @testset "shuffle functions"
         # the downgraded form executes correctly
         @metal threads=(8, 8) macos=v"14" kernel(a, b)
         @test Array(a)[3:10, 2:9] == Array(b)[2:9, 4:11]
+
+        # the non-transposed layout (`Val(false)`) swaps the dims/strides/origin vectors,
+        # so it downgrades to an *unswapped* origin and a cleared transpose flag rather
+        # than the transposed encoding above (regression test: the downgrade used to
+        # project every call onto the transposed form)
+        function kernel_nt(a, b)
+            sg = simdgroup_load(a, (3, 2), Val(false))
+            simdgroup_store(sg, b, (2, 4), Val(false))
+            return
+        end
+
+        # AIR 2.8: the non-transposed origin is *not* row/column-swapped
+        asm = sprint() do io
+            Metal.code_air(io, kernel_nt, tt; kernel=true, macos=v"26")
+        end
+        @test occursin(r"call <64 x float> @air\.simdgroup_matrix_8x8_load\.v64f32\.p1f32\(float addrspace\(1\)\* %\S+, <2 x i64> %\S+, <2 x i64> %\S+, <2 x i64> <i64 2, i64 1>\)", asm)
+        @test occursin(r"call void @air\.simdgroup_matrix_8x8_store\.v64f32\.p1f32\(<64 x float> %\S+, float addrspace\(1\)\* %\S+, <2 x i64> %\S+, <2 x i64> %\S+, <2 x i64> <i64 1, i64 3>\)", asm)
+
+        # AIR < 2.8: unswapped origin and a `false` transpose flag
+        asm = sprint() do io
+            Metal.code_air(io, kernel_nt, tt; kernel=true, macos=v"14")
+        end
+        @test occursin(r"call <64 x float> @air\.simdgroup_matrix_8x8_load\.v64f32\.p1f32\(float addrspace\(1\)\* %\S+, i64 %\S+, <2 x i64> <i64 2, i64 1>, i1 false\)", asm)
+        @test occursin(r"call void @air\.simdgroup_matrix_8x8_store\.v64f32\.p1f32\(<64 x float> %\S+, float addrspace\(1\)\* %\S+, i64 %\S+, <2 x i64> <i64 1, i64 3>, i1 false\)", asm)
+
+        # the downgraded non-transposed load executes with transpose semantics
+        function kernel_nt_exec(a, b)
+            m = simdgroup_load(a, (1, 1), Val(false))
+            simdgroup_store(m, b, (1, 1), Val(true))
+            return
+        end
+        c = MtlArray(rand(Float32, 8, 8))
+        d = MtlArray(zeros(Float32, 8, 8))
+        @metal threads=32 macos=v"14" kernel_nt_exec(c, d)
+        @test Array(d) == permutedims(Array(c))
     end
 end # End Matrix Functions


### PR DESCRIPTION
Parameterize the simdgroup load/store transpose flag (`Val(true)` by default, preserving the prior behavior) so device code can emit either layout of the AIR 2.8 load/store intrinsics. The transposed layout of a column-major matrix is dims = (8, epr), strides = (epr, 1) with a row/column-swapped origin; the non-transposed one swaps each to dims = (epr, 8), strides = (1, epr) with an unswapped origin.

The AIR <2.8 downgrade, however, projected every call onto the transposed legacy encoding: it always swapped the origin and hard-coded transpose = true. A `Val(false)` load/store would therefore have miscompiled on macOS 14/15, loading/storing the wrong block with the wrong orientation. Recover the legacy operands from whichever 2.8 layout was emitted instead: the elements-per-row is the non-unit stride, the transpose flag is decided statically from which stride is unit (the legacy intrinsic needs it as an immediate), and only the transposed layout's swapped origin is unswapped.