### PR TITLE
Add unsafe_wrap for MtlPtr to create multi-dimensional MtlArrays

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -585,6 +585,21 @@ function Base.unsafe_wrap(t::Type{<:Array{T}}, ptr::MtlPtr{T}, dims; own=false) 
     return unsafe_wrap(t, convert(Ptr{T}, ptr), dims; own)
 end
 
+# wrap a Metal pointer (e.g. `pointer(vec)`) in an `MtlArray` of the given shape,
+# sharing the underlying buffer. This is useful to reinterpret a vector as a
+# multi-dimensional array without copying. The resulting array does not own the
+# buffer, so the original allocation must be kept alive for as long as it is used.
+function Base.unsafe_wrap(::Type{<:MtlArray}, ptr::MtlPtr{T},
+                          dims::NTuple{N,<:Integer}) where {T,N}
+    # use a non-owning `DataRef` (no finalizer) so we never free a buffer we
+    # don't own; the original array remains responsible for the allocation.
+    data = DataRef(ptr.buffer)
+    return MtlArray{T,N}(data, Dims(dims); offset=convert(Int, ptr.offset))
+end
+function Base.unsafe_wrap(t::Type{<:MtlArray}, ptr::MtlPtr, dim::Integer)
+    return unsafe_wrap(t, ptr, (dim,))
+end
+
 function Base.unsafe_wrap(A::Type{<:MtlArray{T,N}}, arr::Array, dims=size(arr);
                           dev=device(), kwargs...) where {T,N}
     GC.@preserve arr begin

--- a/test/array.jl
+++ b/test/array.jl
@@ -514,6 +514,28 @@ end
     # test that you cannot create an array with a different eltype
     marr3 = mtl(zeros(Float32, 10); storage = Metal.SharedStorage)
     @test_throws MethodError unsafe_wrap(Array{Float16}, marr3)
+
+    @testset "wrap MtlPtr as multi-dimensional array" begin
+        dims = (2, 3, 4, 5, 6)
+        n = prod(dims)
+        vec = MtlVector{Float32, Metal.SharedStorage}(undef, n)
+        vec .= Float32.(1:n)
+
+        marr = unsafe_wrap(MtlArray, pointer(vec), dims)
+        @test marr isa MtlArray{Float32,5}
+        @test size(marr) == dims
+        @test Array(marr) == reshape(Float32.(1:n), dims)
+
+        # the buffer is shared: changes are visible in both views
+        Metal.@sync marr .+= 1
+        @test Array(vec) == Float32.(2:(n + 1))
+
+        # single-dimension wrapping
+        mvec = unsafe_wrap(MtlArray, pointer(vec), n)
+        @test mvec isa MtlArray{Float32,1}
+        @test size(mvec) == (n,)
+        @test Array(mvec) == Array(vec)
+    end
 end
 
 @testset "ReshapedArray" begin


### PR DESCRIPTION
## Summary

Adds `unsafe_wrap(MtlArray, pointer(vec), dims)` so a vector can be reinterpreted as a multi-dimensional `MtlArray` without copying. This fills the missing signature `unsafe_wrap(::Type{MtlArray}, ::MtlPtr{T}, ::NTuple{N, Int})`.

The wrapped array shares the underlying buffer via a non-owning `DataRef` (no finalizer), so the original allocation remains responsible for freeing the memory. As with any `unsafe_wrap`, the source must be kept alive for as long as the wrapper is in use.

A scalar-dimension method is also provided for the one-dimensional case.

## Tests

Adds a testset under `unsafe_wrap` that:
- wraps a shared-storage `MtlVector` into a 5-dimensional `MtlArray` and checks shape/contents,
- verifies the buffer is shared (mutations via the wrapper are visible in the original), and
- covers the single-dimension form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)