### PR TITLE
Default MtlArray storage to SharedStorage

### DIFF
--- a/docs/src/api/array.md
+++ b/docs/src/api/array.md
@@ -15,7 +15,7 @@ MtlVecOrMat
 
 ## Storage modes
 
-The Metal API has various storage modes that dictate how a resource can be accessed. `MtlArray`s are `Metal.PrivateStorage` by default, but they can also be `Metal.SharedStorage` or `Metal.ManagedStorage`. For more information on storage modes, see the official [Metal documentation](https://developer.apple.com/documentation/metal/resource_fundamentals/setting_resource_storage_modes).
+The Metal API has various storage modes that dictate how a resource can be accessed. `MtlArray`s are `Metal.SharedStorage` by default — zero-copy on unified-memory (Apple Silicon) GPUs — but they can also be `Metal.PrivateStorage` or `Metal.ManagedStorage`. On a discrete GPU, set the `default_storage` preference to `"private"` for best performance. For more information on storage modes, see the official [Metal documentation](https://developer.apple.com/documentation/metal/resource_fundamentals/setting_resource_storage_modes).
 
 ```@docs
 Metal.PrivateStorage

--- a/src/array.jl
+++ b/src/array.jl
@@ -39,7 +39,7 @@ end
 
 `N`-dimensional Metal array with storage mode `S` and elements of type `T`.
 
-`S` can be `Metal.PrivateStorage` (default), `Metal.SharedStorage`.
+`S` can be `Metal.SharedStorage` (default) or `Metal.PrivateStorage`.
 
 See the Array Programming section of the Metal.jl docs for more details.
 """
@@ -190,14 +190,16 @@ See also `VecOrMat`(@ref) for examples.
 """
 const MtlVecOrMat{T,S} = Union{MtlVector{T,S},MtlMatrix{T,S}}
 
-# default to private memory
-const DefaultStorageMode = let str = @load_preference("default_storage", "private")
-    if str == "private"
-        PrivateStorage
-    elseif str == "shared"
+# Default to shared storage: zero-copy on unified-memory (Apple Silicon) GPUs and
+# valid on discrete GPUs too (`__init__` steers discrete-GPU users to `private`).
+# Override with the `default_storage` preference.
+const DefaultStorageMode = let str = @load_preference("default_storage", "shared")
+    if str == "shared"
         SharedStorage
+    elseif str == "private"
+        PrivateStorage
     else
-        error("unknown default storage mode: $default_storage")
+        error("unknown default storage mode: $str (expected \"shared\" or \"private\")")
     end
 end
 
@@ -475,9 +477,9 @@ function Adapt.adapt_storage(to::MtlArrayAdaptor{S}, xs::AbstractArray{T,N}) whe
 end
 
 """
-    mtl(A; storage=Metal.PrivateStorage)
+    mtl(A; storage=Metal.SharedStorage)
 
-`storage` can be `Metal.PrivateStorage` (default) or `Metal.SharedStorage`.
+`storage` can be `Metal.SharedStorage` (default) or `Metal.PrivateStorage`.
 
 Opinionated GPU array adaptor, which may alter the element type `T` of arrays:
 * For `T<:AbstractFloat`, it makes a `MtlArray{Float32}` for performance and compatibility

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -79,6 +79,19 @@ function __init__()
         return
     end
 
+    # The default `SharedStorage` is optimal on unified-memory (Apple Silicon) GPUs
+    # and works everywhere, but on a discrete GPU `PrivateStorage` is usually faster.
+    # Steer those (rare) users to the preference, unless they already chose a default.
+    if DefaultStorageMode == SharedStorage &&
+            load_preference(Metal, "default_storage", nothing) === nothing &&
+            functional() && !device().hasUnifiedMemory
+        @warn """Metal.jl defaults to `SharedStorage`, which is optimal on unified-memory
+                 (Apple Silicon) GPUs. This GPU does not have unified memory, where
+                 `PrivateStorage` is usually faster. To switch the default, run
+                     using Preferences; set_preferences!(Metal, "default_storage" => "private")
+                 and restart Julia.""" maxlog = 1
+    end
+
     # ensure that operations executed by the REPL back-end finish before returning,
     # because displaying values happens on a different task
     if isdefined(Base, :active_repl_backend) && !isnothing(Base.active_repl_backend)

--- a/test/array.jl
+++ b/test/array.jl
@@ -72,6 +72,12 @@ end
     @test Adapt.adapt(MtlMatrix{ComplexF32, Metal.SharedStorage}, [1 2;3 4]) isa MtlArray{ComplexF32, 2, Metal.SharedStorage}
     @test Adapt.adapt(MtlArray{Float16}, Float64[1]) isa MtlArray{Float16}
 
+    # MtlArrays default to shared storage; explicit storage modes still resolve.
+    @test Metal.DefaultStorageMode === Metal.SharedStorage
+    @test Metal.is_shared(MtlArray{Int}(undef, 4))
+    @test Metal.is_shared(mtl([1.0f0, 2.0f0, 3.0f0]))
+    @test Metal.is_private(MtlArray{Int, 1, Metal.PrivateStorage}(undef, 4))
+
     # Test a few explicitly unsupported types
     @test_throws "MtlArray only supports element types that are stored inline" MtlArray(BigInt[1])
     @test_throws "Metal does not support Float64 values" MtlArray(Float64[1])


### PR DESCRIPTION
## Summary

Change the default `MtlArray` storage mode from `PrivateStorage` to `SharedStorage`. On unified-memory (Apple Silicon) GPUs — essentially every supported Mac — `SharedStorage` is zero-copy between CPU and GPU and matches Apple's guidance. Discrete GPUs keep working (and get a one-time notice steering them to `PrivateStorage`).

```julia
using Metal
a = MtlArray(rand(Float32, 1024, 1024))   # SharedStorage by default now
w = unsafe_wrap(Array, a)                  # zero-copy CPU view — no Array() copy
```

This supersedes #717 with a clean, minimal diff (**+31 / −10** across 4 files, vs #717's +655 / −606).

## Motivation

- **Apple's guidance.** For unified memory, the [Metal Best Practices Guide](https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/MTLBestPracticesGuide/ResourceOptions.html) states *"the Shared mode is usually the correct choice."* The previous `PrivateStorage` default came from discrete-GPU guidance.
- **All supported Macs are Apple Silicon** (unified memory), so this is the right default for ~every user.
- **Zero-copy CPU access.** `SharedStorage` enables `unsafe_wrap(Array, x)`, avoiding the allocate-and-copy of `Array()`.

## Benchmarks

**No performance regression** (M2 Max) — `SharedStorage` ≈ `PrivateStorage`:

| size  | op        | Shared   | Private  |
|-------|-----------|---------:|---------:|
| 512²  | broadcast | 0.057 ms | 0.056 ms |
| 512²  | matmul    | 0.286 ms | 0.291 ms |
| 1024² | broadcast | 0.135 ms | 0.132 ms |
| 1024² | matmul    | 0.664 ms | 0.788 ms |

Consistent with the original 67-benchmark sweep: 78% ties, identical for `copyto!` / `fill!` / MPS-matmul, and all ties at ≥ 512 MB.

**Faster CPU access** via zero-copy `unsafe_wrap(Array, x)` instead of `Array()`
(M2 Max, best of 5; both paths `sum()` to force a full read):

| size   | `Array()` + use | `unsafe_wrap` + use | speedup |
|--------|----------------:|--------------------:|--------:|
| 512 MB | 17.1 ms  | 9.0 ms  | 1.9× |
| 1 GB   | 37.5 ms  | 18.2 ms | 2.1× |
| 2 GB   | 249.7 ms | 36.4 ms | 6.9× |
| 4 GB   | 539.2 ms | 72.5 ms | 7.4× |

(The jump at ≥ 2 GB is `Array()`'s GPU→CPU blit crossing into chunked copies;
`unsafe_wrap` stays flat because it never copies.)

## Implementation

- The `default_storage` preference now defaults to `"shared"`. Every constructor (`mtl`, `zeros`, `fill`, `similar`, …) already resolves through `DefaultStorageMode`, so they follow automatically.
- The default stays a **compile-time `const`** — type-stable and with **no device access during precompilation**. (It is *not* a `MTLDevice(…).hasUnifiedMemory` call baked into a precompiled constant.)
- On the rare **non-unified-memory (discrete) GPU**, `__init__` emits a one-time notice pointing the user to `set_preferences!(Metal, "default_storage" => "private")`. `SharedStorage` still works there; this just flags the faster option.
- Also fixes a latent bug in the old error message (`$default_storage` → `$str`).

## Notes

Supersedes #717, closed as *"this will probably eventually happen but it'll be easier to do it in a separate PR than to rebase and clean up this one."* This is that clean PR: no formatting churn, no test rewrite, just the default plus the discrete-GPU notice, docs, and a focused test.

Related: #717
