### PR TITLE
Disable auto selection of tensor matmul in julia 1.10/1.11

### DIFF
--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -435,7 +435,7 @@ function gemm!(C::MtlMatrix, tA::Char, tB::Char, A::MtlMatrix, B::MtlMatrix,
     # `:auto` picks the Metal 4 tensor-ops fast path when the device and operands allow it,
     # then the portable simdgroup kernel for floats, then the scalar fallback; an
     # explicit `kernel` forces one of them.
-    if kernel === :tensor || (kernel === :auto && supports_tensor_matmul(C, A, B, tA, tB, alpha, beta))
+    if kernel === :tensor || (kernel === :auto && supports_tensor_matmul(C, A, B, tA, tB, alpha, beta) && VERSION >= v"1.12")
         gemm_tensor!(C, A, B, alpha, beta, tA, tB)
     elseif kernel === :simd || (kernel === :auto && supports_simd_matmul(C, A, B, tA, tB, alpha, beta))
         gemm_simd!(C, A, B, alpha, beta, tA, tB)

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -230,8 +230,8 @@ end
                 ref = Array(A) * Array(B)
                 @test Metal.supports_tensor_matmul(MtlArray(zeros(T, M, N)), A, B, 'N', 'N', true, false)
                 Ct = MtlArray(zeros(T, M, N))
-                @with (Metal.matmul_alg => :tensor) mul!(Ct, A, B)
-                @test isapprox(Array(Ct), ref; rtol=ttol(T))
+                @test (@with (Metal.matmul_alg => :tensor) mul!(Ct, A, B)) isa MtlArray broken=VERSION<v"1.12"
+                @test isapprox(Array(Ct), ref; rtol=ttol(T)) broken=VERSION<v"1.12"
             end
 
             # forcing `:tensor` on operands it can't handle errors (like an unsupported :MPS)


### PR DESCRIPTION
Workaround to unblock CI (esp GPUArrays) until #825 is resolved.

Done in a convoluted way to ensure the tests run but are marked broken