### PR TITLE
Remove GPU specification from Benchmark run

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -178,7 +178,6 @@ steps:
       - "benchmarkresults.json"
     agents:
       queue: "metal"
-      gpu: "m1"
     if: |
       build.message =~ /\[only benchmarks\]/ ||
       build.message !~ /\[only/ && !build.pull_request.draft &&


### PR DESCRIPTION
We'll probably want to re-add this tag if we ever get new non-M1 machines