### PR TITLE
Fix simd GEMM: bank conflicts, occupancy, arithmetic intensity

### DIFF
--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -139,6 +139,12 @@ end
 # threadgroup covers a BM×BN = (8·TM·WM)×(8·TN·WN) tile of C. BK = 8·KB is the
 # contraction tile depth. Tiles are staged in threadgroup memory as Float32 and
 # accumulated in Float32.
+#
+# Threadgroup memory bank conflicts: Apple GPU threadgroup memory has 32 banks of 4
+# bytes each. Without padding, As (BM×BK) with BM=64 has a 64-float column stride;
+# 64%32=0 so all columns of each A-fragment map to the same bank (8-way conflict).
+# Similarly Bs (BK×BN) with BK=8 causes 2-4-way conflicts. Adding 4-float (16-byte)
+# padding to the leading dimension of each tile eliminates these conflicts.
 function gemm_simd_kernel!(C, A, B, alpha::Float32, beta::Float32,
                             M, N, K, ::Val{TA}, ::Val{TB},
                             ::Val{WM}, ::Val{WN}, ::Val{TM}, ::Val{TN},
@@ -154,9 +160,12 @@ function gemm_simd_kernel!(C, A, B, alpha::Float32, beta::Float32,
     bm0 = (Int(threadgroup_position_in_grid().x) - 1) * BM  # 0-based row origin in C
     bn0 = (Int(threadgroup_position_in_grid().y) - 1) * BN  # 0-based col origin in C
 
-    As = MtlThreadGroupArray(Float32, (BM, BK))
-    Bs = MtlThreadGroupArray(Float32, (BK, BN))
-    scratch = MtlThreadGroupArray(Float32, (8, EDGE ? 8 * WM * WN : 0))
+    # 4-float (16-byte) padding per leading dimension avoids bank conflicts.
+    # simdgroup_load/store use size(arr)[1] as the leading dimension, so they
+    # automatically pick up the padded stride.
+    As = MtlThreadGroupArray(Float32, (BM + 4, BK))
+    Bs = MtlThreadGroupArray(Float32, (BK + 4, BN))
+    scratch = MtlThreadGroupArray(Float32, (8 + 4, EDGE ? 8 * WM * WN : 0))
 
     # TM×TN accumulators (ti fastest), all zero-initialized, kept in registers
     acc = ntuple(_ -> ntuple(_ -> VecElement{Float32}(0.0f0), Val(64)), Val(TM * TN))
@@ -364,12 +373,14 @@ end
 # tile configuration for the fast path. WM×WN simdgroups per threadgroup, each with
 # a TM×TN grid of 8x8 accumulators (keep TM·TN ≤ 16 to avoid register spilling),
 # contraction depth BK = 8·KB. BM×BN = (8·TM·WM)×(8·TN·WN) output per threadgroup.
-# WM=WN=4 (512 threads) maximizes occupancy / latency hiding on current hardware.
-const GEMM_SIMD_WM = 4
-const GEMM_SIMD_WN = 4
-const GEMM_SIMD_TM = 2
-const GEMM_SIMD_TN = 2
-const GEMM_SIMD_KB = 1
+# WM=WN=2 (128 threads, 4 simdgroups): matches MLX/m5-gemm; gives 4× more concurrent
+# threadgroups per core vs WM=WN=4. TM=TN=4 gives 16 MACs per simdgroup per K-step
+# (vs 4 for TM=TN=2), maximizing arithmetic intensity. KB=2 halves barrier count.
+const GEMM_SIMD_WM = 2
+const GEMM_SIMD_WN = 2
+const GEMM_SIMD_TM = 4
+const GEMM_SIMD_TN = 4
+const GEMM_SIMD_KB = 2
 
 function gemm_simd!(C, A, B, alpha, beta, cA::Char, cB::Char)
     M = size(C, 1); N = size(C, 2)


### PR DESCRIPTION
Three issues caused the simd kernel to underperform the scalar fallback:

1. 8-way threadgroup memory bank conflicts: As/Bs had column strides of BM=64 and BK=8 floats respectively; 64%32=0 and 8%32=8 map tile columns to the same banks on every simdgroup_load. Fix: 4-float (16-byte) padding on each tile's leading dimension, matching MLX's tgp_padding convention.

2. Poor occupancy: WM=WN=4 (512 threads) allowed only ~1 threadgroup per GPU core. Switch to WM=WN=2 (128 threads, 4 simdgroups) for 4× more concurrent threadgroups per core and better latency hiding.

3. Low arithmetic intensity: TM=TN=2 (4 MACs/simdgroup/K-step) and KB=1 (BK=8). Switch to TM=TN=4 (16 MACs/simdgroup/K-step) and KB=2 (BK=16), halving barrier count and matching the MLX/m5-gemm reference config.

Result on M3 Pro (Float32/Float16 4096³): simd is now 22%/5% faster than scalar; the :auto path correctly prefers :simd without heuristic changes.

Closes https://github.com/JuliaGPU/Metal.jl/issues/829