### PR TITLE
Reduce number of API calls required by common operations

### DIFF
--- a/LocalPreferences.toml
+++ b/LocalPreferences.toml
@@ -6,3 +6,7 @@
 # whether to use a nonblocking synchronization mechanism,
 # making it possible to do use cooperative multitasking.
 #nonblocking_synchronization = true
+
+# whether to label Metal resources and command buffers.
+# defaults to true when running Julia with -g2, and false otherwise.
+#label_resources = true

--- a/lib/mtl/MTL.jl
+++ b/lib/mtl/MTL.jl
@@ -9,6 +9,7 @@ refer to the [official Apple documentation](https://developer.apple.com/document
 module MTL
 
 using CEnum
+using GPUToolbox: @memoize, LazyInitialized
 using ObjectiveC, .Foundation, .Dispatch
 
 using ..Metal

--- a/lib/mtl/buffer.jl
+++ b/lib/mtl/buffer.jl
@@ -17,12 +17,23 @@ end
 
 ## allocation
 
+const _max_buffer_length = Dict{MTLDevice, Int}()
+const _max_buffer_length_lock = ReentrantLock()
+
+function max_buffer_length(dev::MTLDevice)
+    Base.@lock _max_buffer_length_lock begin
+        get!(() -> Int(dev.maxBufferLength), _max_buffer_length, dev)
+    end
+end
+
+max_buffer_length(heap::MTLHeap) = max_buffer_length(heap.device)
+
 function MTLBuffer(dev::Union{MTLDevice,MTLHeap}, bytesize::Integer;
                    storage::Type{<:StorageMode}=PrivateStorage, hazard_tracking=DefaultTracking,
                    cache_mode=DefaultCPUCache)
     opts = convert(MTLResourceOptions, storage) | hazard_tracking | cache_mode
 
-    @assert 0 < bytesize <= dev.maxBufferLength # XXX: not supported by MTLHeap
+    @assert 0 < bytesize <= max_buffer_length(dev)
     ptr = alloc_buffer(dev, bytesize, opts)
 
     return MTLBuffer(ptr)
@@ -34,7 +45,7 @@ function MTLBuffer(dev::MTLDevice, bytesize::Integer, ptr::Ptr;
     storage == PrivateStorage && error("Cannot allocate-and-initialize a PrivateStorage buffer")
     opts =  convert(MTLResourceOptions, storage) | hazard_tracking | cache_mode
 
-    @assert 0 < bytesize <= dev.maxBufferLength
+    @assert 0 < bytesize <= max_buffer_length(dev)
     ptr = if nocopy
         alloc_buffer_nocopy(dev, bytesize, opts, ptr)
     else

--- a/lib/mtl/buffer.jl
+++ b/lib/mtl/buffer.jl
@@ -17,13 +17,16 @@ end
 
 ## allocation
 
-const _max_buffer_length = Dict{MTLDevice, Int}()
-const _max_buffer_length_lock = ReentrantLock()
-
 function max_buffer_length(dev::MTLDevice)
-    Base.@lock _max_buffer_length_lock begin
-        get!(() -> Int(dev.maxBufferLength), _max_buffer_length, dev)
+    # Avoid serializing process-local Objective-C pointer keys from precompile workloads.
+    if ccall(:jl_generating_output, Cint, ()) != 0
+        return Int(dev.maxBufferLength)
     end
+
+    key = UInt(pointer(dev))
+    @memoize key::UInt begin
+        Int(dev.maxBufferLength)
+    end::Int
 end
 
 max_buffer_length(heap::MTLHeap) = max_buffer_length(heap.device)

--- a/lib/mtl/command_buf.jl
+++ b/lib/mtl/command_buf.jl
@@ -103,6 +103,14 @@ function last_committed(queue::MTLCommandQueue)
 end
 
 function commit!(cmdbuf::MTLCommandBufferLike)
+    _commit!(cmdbuf, pointer(cmdbuf.commandQueue))
+end
+
+function commit!(cmdbuf::MTLCommandBufferLike, queue::MTLCommandQueue)
+    _commit!(cmdbuf, pointer(queue))
+end
+
+function _commit!(cmdbuf::MTLCommandBufferLike, key::id{MTLCommandQueue})
     cmdbuf.status in [MTLCommandBufferStatusCompleted, MTLCommandBufferStatusCommitted] &&
         error("Cannot commit an already committed/completed command buffer")
     @objc [cmdbuf::id{MTLCommandBuffer} commit]::Nothing
@@ -113,7 +121,6 @@ function commit!(cmdbuf::MTLCommandBufferLike)
     # own retain the wrapper could become a dangling pointer once the GPU is
     # done. The retain on the new entry pairs with a release on the displaced one.
     Foundation.retain(cmdbuf)
-    key = pointer(cmdbuf.commandQueue)
     old = @lock last_committed_lock begin
         prev = get(last_committed_per_queue, key, nothing)
         last_committed_per_queue[key] = cmdbuf

--- a/lib/mtl/command_buf.jl
+++ b/lib/mtl/command_buf.jl
@@ -103,14 +103,14 @@ function last_committed(queue::MTLCommandQueue)
 end
 
 function commit!(cmdbuf::MTLCommandBufferLike)
-    _commit!(cmdbuf, pointer(cmdbuf.commandQueue))
+    commit_with_queue_key!(cmdbuf, pointer(cmdbuf.commandQueue))
 end
 
 function commit!(cmdbuf::MTLCommandBufferLike, queue::MTLCommandQueue)
-    _commit!(cmdbuf, pointer(queue))
+    commit_with_queue_key!(cmdbuf, pointer(queue))
 end
 
-function _commit!(cmdbuf::MTLCommandBufferLike, key::id{MTLCommandQueue})
+function commit_with_queue_key!(cmdbuf::MTLCommandBufferLike, key::id{MTLCommandQueue})
     cmdbuf.status in [MTLCommandBufferStatusCompleted, MTLCommandBufferStatusCommitted] &&
         error("Cannot commit an already committed/completed command buffer")
     @objc [cmdbuf::id{MTLCommandBuffer} commit]::Nothing

--- a/lib/mtl/command_enc/compute.jl
+++ b/lib/mtl/command_enc/compute.jl
@@ -1,5 +1,5 @@
 export MTLComputeCommandEncoder
-export set_function!, set_buffer!, dispatchThreadgroups!, endEncoding!
+export set_function!, set_buffer!, set_bytes!, dispatchThreadgroups!, endEncoding!
 export append_current_function!
 
 # @objcwrapper immutable=false MTLComputeCommandEncoder <: MTLCommandEncoder
@@ -23,6 +23,12 @@ function set_buffer!(cce::MTLComputeCommandEncoder, buf::MTLBuffer, offset, inde
     @objc [cce::id{MTLComputeCommandEncoder} setBuffer:buf::id{MTLBuffer}
                                              offset:offset::NSUInteger
                                              atIndex:(index-1)::NSUInteger]::Nothing
+end
+
+function set_bytes!(cce::MTLComputeCommandEncoder, ptr::Ptr, len::Integer, index::Integer)
+    @objc [cce::id{MTLComputeCommandEncoder} setBytes:ptr::Ptr{Cvoid}
+                                           length:len::NSUInteger
+                                          atIndex:(index-1)::NSUInteger]::Nothing
 end
 
 function dispatchThreadgroups!(cce::MTLComputeCommandEncoder, threadgroupsPerGrid, threadsPerThreadgroup)

--- a/lib/mtl/command_queue.jl
+++ b/lib/mtl/command_queue.jl
@@ -29,3 +29,7 @@ function MTLCommandQueue(dev::MTLDevice)
     finalizer(release, obj)
     return obj
 end
+
+function add_residency_set!(queue::MTLCommandQueue, resset::MTLResidencySet)
+    @objc [queue::id{MTLCommandQueue} addResidencySet:resset::id{MTLResidencySet}]::Nothing
+end

--- a/src/array.jl
+++ b/src/array.jl
@@ -73,7 +73,7 @@ mutable struct MtlArray{T,N,S} <: AbstractGPUArray{T,N}
                 free(buf)
             end
         end
-        data[].label = "MtlArray{$(T),$(N),$(S)}(dims=$dims)"
+        @label! data[] "MtlArray{$(T),$(N),$(S)}(dims=$dims)"
 
         obj = new{T,N,S}(data, maxsize, 0, dims)
         finalizer(unsafe_free!, obj)

--- a/src/compiler/exceptions.jl
+++ b/src/compiler/exceptions.jl
@@ -48,12 +48,12 @@ end
 # device-side exceptions are reported through a host-visible mailbox: an `ExceptionInfo_st`
 # in a shared (CPU+GPU) buffer whose GPU address is handed to each kernel via the
 # `KernelState`. see `device/runtime.jl` for the layout and how the GPU fills it.
-const device_exception_info = Dict{MTLDevice, Tuple{MTLBuffer, Ptr{ExceptionInfo_st}}}()
+const device_exception_info = Dict{MTLDevice, Tuple{MTLBuffer, Ptr{ExceptionInfo_st}, UInt64}}()
 const device_exception_lock = ReentrantLock()
 
-function exception_info_buffer(dev::MTLDevice)
+function exception_info_buffer_info(dev::MTLDevice)
     Base.@lock device_exception_lock begin
-        buf, _ = get!(device_exception_info, dev) do
+        buf, _, gpuaddr = get!(device_exception_info, dev) do
             # `newBufferWithLength:` (a `new*` method) returns retain-count-1, non-autoreleased
             # per Apple's ARC naming convention, so the buffer survives the pool drain. the
             # pool is here to catch any intermediates the alloc call autoreleases internally.
@@ -61,18 +61,20 @@ function exception_info_buffer(dev::MTLDevice)
                 buf = MTLBuffer(dev, sizeof(ExceptionInfo_st); storage=SharedStorage)
                 ptr = convert(Ptr{ExceptionInfo_st}, MTL.contents(buf))
                 unsafe_store!(ptr, ExceptionInfo_st())
-                (buf, ptr)
+                (buf, ptr, UInt64(buf.gpuAddress))
             end
         end
-        return buf
+        return buf, gpuaddr
     end
 end
+
+exception_info_buffer(dev::MTLDevice) = first(exception_info_buffer_info(dev))
 
 # check the exception mailbox of all devices, rethrowing host-side if one was set.
 # the caller is responsible for running inside an autorelease pool (`synchronize` is).
 function check_exceptions()
     Base.@lock device_exception_lock begin
-        for (dev, (_, ptr)) in device_exception_info
+        for (dev, (_, ptr, _)) in device_exception_info
             status_ptr = convert(Ptr{Int32}, ptr)
             # atomic read-and-clear of `status` so concurrent `synchronize`s on the same
             # device can't both observe the set flag and throw duplicate exceptions, nor

--- a/src/compiler/exceptions.jl
+++ b/src/compiler/exceptions.jl
@@ -51,7 +51,7 @@ end
 const device_exception_info = Dict{MTLDevice, Tuple{MTLBuffer, Ptr{ExceptionInfo_st}, UInt64}}()
 const device_exception_lock = ReentrantLock()
 
-function exception_info_buffer_info(dev::MTLDevice)
+function exception_info_buffer_and_gpu_address(dev::MTLDevice)
     Base.@lock device_exception_lock begin
         buf, _, gpuaddr = get!(device_exception_info, dev) do
             # `newBufferWithLength:` (a `new*` method) returns retain-count-1, non-autoreleased
@@ -68,7 +68,7 @@ function exception_info_buffer_info(dev::MTLDevice)
     end
 end
 
-exception_info_buffer(dev::MTLDevice) = first(exception_info_buffer_info(dev))
+exception_info_buffer(dev::MTLDevice) = first(exception_info_buffer_and_gpu_address(dev))
 
 # check the exception mailbox of all devices, rethrowing host-side if one was set.
 # the caller is responsible for running inside an autorelease pool (`synchronize` is).

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -341,7 +341,7 @@ function launch(@nospecialize(kernel::HostKernel), gs::MTLSize, ts::MTLSize,
     else
         MTLCommandBuffer(queue)
     end
-    cmdbuf.label = "MTLCommandBuffer($(nameof(f)))"
+    @label! cmdbuf "MTLCommandBuffer($(nameof(f)))"
     let md = MTL.profile_metadata[]
         md === nothing || MTL.note_operation!(md, cmdbuf,
             (; kind = :kernel, name = string(nameof(f)),

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -354,8 +354,13 @@ function launch(@nospecialize(kernel::HostKernel), gs::MTLSize, ts::MTLSize,
         # the kernel state holds GPU addresses to per-device scratch buffers (malloc bump
         # allocator, exception mailbox) that aren't otherwise bound to the encoder. declare
         # them so Metal Shader Validation tracks the accesses instead of dropping them.
-        MTL.use!(cce, buf, MTL.ReadWriteUsage)
-        MTL.use!(cce, exc, MTL.ReadWriteUsage)
+        if can_use_residency_sets(dev)
+            ensure_queue_residency!(queue, dev, buf, exc)
+        else
+            # DROP-MACOS14: per-launch residency for macOS 14 / virtual GPUs.
+            MTL.use!(cce, buf, MTL.ReadWriteUsage)
+            MTL.use!(cce, exc, MTL.ReadWriteUsage)
+        end
         encode_arguments_nospec!(cce, kernel, kernel_state, f, args)
         MTL.append_current_function!(cce, gs, ts)
     finally

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -166,6 +166,7 @@ struct HostKernel{F,TT}
     maxthreads::Int
     tgmem::Int
     exec_width::Int
+    use_residency_sets::Bool
 end
 
 const mtlfunction_lock = ReentrantLock()
@@ -199,11 +200,13 @@ function mtlfunction(f::F, tt::TT=Tuple{}; name=nothing, kwargs...) where {F,TT}
         kernel = get(_kernel_instances, h, nothing)
         if kernel === nothing
             # create the kernel state object
+            dev = pipeline.device
             kernel = HostKernel{F, tt}(f, pipeline, loggingEnabled,
-                                       pipeline.device,
+                                       dev,
                                        Int(pipeline.maxTotalThreadsPerThreadgroup),
                                        Int(pipeline.staticThreadgroupMemoryLength),
-                                       Int(pipeline.threadExecutionWidth))
+                                       Int(pipeline.threadExecutionWidth),
+                                       can_use_residency_sets(dev))
             _kernel_instances[h] = kernel
         end
         return kernel::HostKernel{F,tt}
@@ -354,7 +357,7 @@ function launch(@nospecialize(kernel::HostKernel), gs::MTLSize, ts::MTLSize,
         # the kernel state holds GPU addresses to per-device scratch buffers (malloc bump
         # allocator, exception mailbox) that aren't otherwise bound to the encoder. declare
         # them so Metal Shader Validation tracks the accesses instead of dropping them.
-        if can_use_residency_sets(dev)
+        if kernel.use_residency_sets
             ensure_queue_residency!(queue, dev, buf, exc)
         else
             # DROP-MACOS14: per-launch residency for macOS 14 / virtual GPUs.

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -209,9 +209,7 @@ const _kernel_instances = Dict{UInt, Any}()
 ## kernel launching and argument encoding
 
 @inline @generated function encode_arguments!(cce, kernel, args::Vararg{Any,N}) where {N}
-    ex = quote
-        buffers = MTLBuffer[]
-    end
+    ex = quote end
 
     # the arguments passed into this function have not been `mtlconvert`ed, because we need
     # to retain the top-level MTLBuffer and MtlPtr objects. eager conversion of nested
@@ -230,36 +228,35 @@ const _kernel_instances = Dict{UInt, Any}()
         elseif isghosttype(argtyp) || Core.Compiler.isconstType(argtyp)
             continue
         else
-            # everything else is passed by reference, in an argument buffer
+            # everything else is passed by reference, copied into Metal's transient buffer
             append!(ex.args, (quote
-                buf = encode_argument!(kernel, mtlconvert($(argex), cce))
-                set_buffer!(cce, buf, 0, $idx)
-                push!(buffers, buf)
+                set_argument!(cce, mtlconvert($(argex), cce), $idx)
             end).args)
         end
         idx += 1
     end
 
-    push!(ex.args, :(return buffers))
+    push!(ex.args, :(return nothing))
 
     ex
 end
 
-@inline function encode_argument!(@nospecialize(kernel), arg)
+@inline function set_argument!(cce::MTLComputeCommandEncoder, arg, idx::Integer)
     argtyp = typeof(arg)
 
     # replace non-isbits arguments (they should be unused, or compilation
     # would have failed) by a dummy reference
     if !isbitstype(argtyp)
-        arg = C_NULL
         argtyp = Ptr{Any}
+        arg = convert(argtyp, C_NULL)
     end
 
-    # pass by reference, in an argument buffer
-    argument_buffer = alloc(kernel.pipeline.device, sizeof(argtyp); storage=SharedStorage)
-    argument_buffer.label = "MTLBuffer for kernel argument"
-    unsafe_store!(convert(Ptr{argtyp}, argument_buffer), arg)
-    return argument_buffer
+    ref = Base.RefValue(arg)
+    GC.@preserve ref begin
+        ptr = Base.unsafe_convert(Ptr{argtyp}, ref)
+        set_bytes!(cce, reinterpret(Ptr{Cvoid}, ptr), sizeof(argtyp), idx)
+    end
+    return
 end
 
 # wraps a single function call, keeping its closure body small.
@@ -341,32 +338,29 @@ function launch(@nospecialize(kernel::HostKernel), gs::MTLSize, ts::MTLSize,
                maxthreads = Int(pipeline.maxTotalThreadsPerThreadgroup)))
     end
     cce = MTLComputeCommandEncoder(cmdbuf)
-    argument_buffers = try
+    try
         MTL.set_function!(cce, pipeline)
         # the kernel state holds GPU addresses to per-device scratch buffers (malloc bump
         # allocator, exception mailbox) that aren't otherwise bound to the encoder. declare
         # them so Metal Shader Validation tracks the accesses instead of dropping them.
         MTL.use!(cce, buf, MTL.ReadWriteUsage)
         MTL.use!(cce, exc, MTL.ReadWriteUsage)
-        bufs = encode_arguments_nospec!(cce, kernel, kernel_state, f, args)
+        encode_arguments_nospec!(cce, kernel, kernel_state, f, args)
         MTL.append_current_function!(cce, gs, ts)
-        bufs
     finally
         close(cce)
     end
 
-    # the command buffer retains resources that are explicitly encoded (i.e. direct buffer
-    # arguments, or the buffers allocated for each other argument), but that doesn't keep
-    # other resources alive for which we've encoded the GPU address ourselves. since it's
-    # possible for buffers to go out of scope while the kernel is still running, which
-    # triggers validation failures, keep track of things we need to keep alive until the
-    # kernel has actually completed.
+    # The command buffer retains explicitly encoded buffers, but that doesn't keep other
+    # resources alive for which we've encoded the GPU address ourselves. Since it's possible
+    # for buffers to go out of scope while the kernel is still running, which triggers
+    # validation failures, keep track of things we need to keep alive until the kernel has
+    # actually completed.
     #
     # TODO: is there a way to bind additional resources to the command buffer?
     roots = Any[f, args]
     MTL.on_completed(cmdbuf) do buf
         empty!(roots)
-        foreach(free, argument_buffers)
 
         # Check for errors
         # XXX: we cannot do this nicely, e.g. throwing an `error` or reporting with `@error`

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -301,10 +301,10 @@ function launch(@nospecialize(kernel::HostKernel), gs::MTLSize, ts::MTLSize,
     tgmem > 32768 &&
         throw(ArgumentError("Total used threadgroupMemoryLength($tgmem) must be <= 32768 bytes."))
 
-    buf = malloc_buffer(dev)
-    buf_ptr = reinterpret(Core.LLVMPtr{UInt8, AS.Device}, UInt64(buf.gpuAddress))
-    exc = exception_info_buffer(dev)
-    exc_ptr = reinterpret(Core.LLVMPtr{UInt8, AS.Device}, UInt64(exc.gpuAddress))
+    buf, buf_addr = malloc_buffer_info(dev)
+    buf_ptr = reinterpret(Core.LLVMPtr{UInt8, AS.Device}, buf_addr)
+    exc, exc_addr = exception_info_buffer_info(dev)
+    exc_ptr = reinterpret(Core.LLVMPtr{UInt8, AS.Device}, exc_addr)
     kernel_state = KernelState(Random.rand(UInt32), buf_ptr, exc_ptr)
 
     cmdbuf = if kernel.loggingEnabled

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -162,6 +162,10 @@ struct HostKernel{F,TT}
     f::F
     pipeline::MTLComputePipelineState
     loggingEnabled::Bool
+    device::MTLDevice
+    maxthreads::Int
+    tgmem::Int
+    exec_width::Int
 end
 
 const mtlfunction_lock = ReentrantLock()
@@ -195,7 +199,11 @@ function mtlfunction(f::F, tt::TT=Tuple{}; name=nothing, kwargs...) where {F,TT}
         kernel = get(_kernel_instances, h, nothing)
         if kernel === nothing
             # create the kernel state object
-            kernel = HostKernel{F, tt}(f, pipeline, loggingEnabled)
+            kernel = HostKernel{F, tt}(f, pipeline, loggingEnabled,
+                                       pipeline.device,
+                                       Int(pipeline.maxTotalThreadsPerThreadgroup),
+                                       Int(pipeline.staticThreadgroupMemoryLength),
+                                       Int(pipeline.threadExecutionWidth))
             _kernel_instances[h] = kernel
         end
         return kernel::HostKernel{F,tt}
@@ -273,8 +281,10 @@ function launch(@nospecialize(kernel::HostKernel), gs::MTLSize, ts::MTLSize,
     (ts.width>0 && ts.height>0 && ts.depth>0) ||
         throw(ArgumentError("All thread dimensions should be non-zero"))
 
-    (ts.width * ts.height * ts.depth) > kernel.pipeline.maxTotalThreadsPerThreadgroup &&
-        throw(ArgumentError("Number of threads in group ($(ts.width * ts.height * ts.depth)) should not exceed $(kernel.pipeline.maxTotalThreadsPerThreadgroup)"))
+    maxthreads = kernel.maxthreads
+    nthreads = ts.width * ts.height * ts.depth
+    nthreads > maxthreads &&
+        throw(ArgumentError("Number of threads in group ($nthreads) should not exceed $maxthreads"))
 
     (gs.width * ts.width) > typemax(UInt32) &&
         throw(ArgumentError("Total threads per grid in a dimension (threads.width($(gs.width)) * groups.width($(ts.width)) = $(gs.width * ts.width)) must not exceed $(typemax(UInt32))"))
@@ -285,13 +295,15 @@ function launch(@nospecialize(kernel::HostKernel), gs::MTLSize, ts::MTLSize,
 
     f = kernel.f
     pipeline = kernel.pipeline
+    dev = kernel.device
+    tgmem = kernel.tgmem
 
-    pipeline.staticThreadgroupMemoryLength > 32768 &&
-        throw(ArgumentError("Total used threadgroupMemoryLength($(pipeline.staticThreadgroupMemoryLength)) must be <= 32768 bytes."))
+    tgmem > 32768 &&
+        throw(ArgumentError("Total used threadgroupMemoryLength($tgmem) must be <= 32768 bytes."))
 
-    buf = malloc_buffer(pipeline.device)
+    buf = malloc_buffer(dev)
     buf_ptr = reinterpret(Core.LLVMPtr{UInt8, AS.Device}, UInt64(buf.gpuAddress))
-    exc = exception_info_buffer(pipeline.device)
+    exc = exception_info_buffer(dev)
     exc_ptr = reinterpret(Core.LLVMPtr{UInt8, AS.Device}, UInt64(exc.gpuAddress))
     kernel_state = KernelState(Random.rand(UInt32), buf_ptr, exc_ptr)
 
@@ -334,8 +346,7 @@ function launch(@nospecialize(kernel::HostKernel), gs::MTLSize, ts::MTLSize,
         md === nothing || MTL.note_operation!(md, cmdbuf,
             (; kind = :kernel, name = string(nameof(f)),
                threadgroups = gs, threads = ts,
-               tgmem = Int(pipeline.staticThreadgroupMemoryLength),
-               maxthreads = Int(pipeline.maxTotalThreadsPerThreadgroup)))
+               tgmem, maxthreads))
     end
     cce = MTLComputeCommandEncoder(cmdbuf)
     try
@@ -403,7 +414,17 @@ function nextwarp(pipe::MTLComputePipelineState, threads::Integer)
     return threads + (ws - threads % ws) % ws
 end
 
+function nextwarp(kernel::HostKernel, threads::Integer)
+    ws = kernel.exec_width
+    return threads + (ws - threads % ws) % ws
+end
+
 @doc (@doc nextwarp) function prevwarp(pipe::MTLComputePipelineState, threads::Integer)
     ws = pipe.threadExecutionWidth
+    return threads - Base.rem(threads, ws)
+end
+
+@doc (@doc nextwarp) function prevwarp(kernel::HostKernel, threads::Integer)
+    ws = kernel.exec_width
     return threads - Base.rem(threads, ws)
 end

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -386,7 +386,7 @@ function launch(@nospecialize(kernel::HostKernel), gs::MTLSize, ts::MTLSize,
         return
     end
 
-    commit!(cmdbuf)
+    commit!(cmdbuf, queue)
     if kernel.loggingEnabled
         # remember this so `synchronize(queue)` can drain its log handler blocks
         # (Metal delivers logs asynchronously on a libdispatch queue; only

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -197,7 +197,7 @@ function mtlfunction(f::F, tt::TT=Tuple{}; name=nothing, kwargs...) where {F,TT}
         # create a callable object that captures the function instance. we don't need to think
         # about world age here, as GPUCompiler already does and will return a different object
         h = hash(pipeline, hash(f, hash(tt)))
-        kernel = get(_kernel_instances, h, nothing)
+        kernel = get(kernel_instances, h, nothing)
         if kernel === nothing
             # create the kernel state object
             dev = pipeline.device
@@ -207,14 +207,14 @@ function mtlfunction(f::F, tt::TT=Tuple{}; name=nothing, kwargs...) where {F,TT}
                                        Int(pipeline.staticThreadgroupMemoryLength),
                                        Int(pipeline.threadExecutionWidth),
                                        can_use_residency_sets(dev))
-            _kernel_instances[h] = kernel
+            kernel_instances[h] = kernel
         end
         return kernel::HostKernel{F,tt}
     end
 end
 
 # cache of kernel instances
-const _kernel_instances = Dict{UInt, Any}()
+const kernel_instances = Dict{UInt, Any}()
 
 
 ## kernel launching and argument encoding
@@ -304,9 +304,9 @@ function launch(@nospecialize(kernel::HostKernel), gs::MTLSize, ts::MTLSize,
     tgmem > 32768 &&
         throw(ArgumentError("Total used threadgroupMemoryLength($tgmem) must be <= 32768 bytes."))
 
-    buf, buf_addr = malloc_buffer_info(dev)
+    buf, buf_addr = malloc_buffer_and_gpu_address(dev)
     buf_ptr = reinterpret(Core.LLVMPtr{UInt8, AS.Device}, buf_addr)
-    exc, exc_addr = exception_info_buffer_info(dev)
+    exc, exc_addr = exception_info_buffer_and_gpu_address(dev)
     exc_ptr = reinterpret(Core.LLVMPtr{UInt8, AS.Device}, exc_addr)
     kernel_state = KernelState(Random.rand(UInt32), buf_ptr, exc_ptr)
 

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -272,13 +272,24 @@ end
 
 # wraps a single function call, keeping its closure body small.
 @autoreleasepool function (kernel::HostKernel)(args...; groups=1, threads=1,
-                                               queue=global_queue(device()))
+                                               queue=nothing)
     # function barrier to avoid capturing the `@autoreleasepool` in the generated code
-    launch(kernel, MTLSize(groups), MTLSize(threads), queue, args)
+    launch_with_queue(kernel, queue, MTLSize(groups), MTLSize(threads), args)
+end
+
+@inline function launch_with_queue(@nospecialize(kernel::HostKernel), ::Nothing,
+                                   gs::MTLSize, ts::MTLSize, @nospecialize(args::Tuple))
+    launch(kernel, gs, ts, global_queue(device()), args, true)
+end
+
+@inline function launch_with_queue(@nospecialize(kernel::HostKernel), queue::MTLCommandQueue,
+                                   gs::MTLSize, ts::MTLSize, @nospecialize(args::Tuple))
+    launch(kernel, gs, ts, queue, args, false)
 end
 
 function launch(@nospecialize(kernel::HostKernel), gs::MTLSize, ts::MTLSize,
-                queue::MTLCommandQueue, @nospecialize(args::Tuple))
+                queue::MTLCommandQueue, @nospecialize(args::Tuple),
+                queue_residency_ready::Bool)
     (gs.width>0 && gs.height>0 && gs.depth>0) ||
         throw(ArgumentError("All group dimensions should be non-zero"))
     (ts.width>0 && ts.height>0 && ts.depth>0) ||
@@ -358,7 +369,7 @@ function launch(@nospecialize(kernel::HostKernel), gs::MTLSize, ts::MTLSize,
         # allocator, exception mailbox) that aren't otherwise bound to the encoder. declare
         # them so Metal Shader Validation tracks the accesses instead of dropping them.
         if kernel.use_residency_sets
-            ensure_queue_residency!(queue, dev, buf, exc)
+            queue_residency_ready || install_queue_residency!(queue, dev)
         else
             # DROP-MACOS14: per-launch residency for macOS 14 / virtual GPUs.
             MTL.use!(cce, buf, MTL.ReadWriteUsage)

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -98,7 +98,7 @@ function Base.unsafe_copyto!(dev::MTLDevice, dst::MtlPtr{T},
             @autoreleasepool begin
                 chunk_size = 2^31
                 cmdbuf = MTLCommandBuffer(queue)
-                cmdbuf.label = "copyto!"
+                @label! cmdbuf "copyto!"
                 let md = MTL.profile_metadata[]
                     md === nothing || MTL.note_operation!(md, cmdbuf,
                         (; kind = :copy, name = "copyto!", bytes = Int(N * sizeof(T))))
@@ -127,7 +127,7 @@ end
                                        async::Bool=false) where T
     if N > 0
         cmdbuf = MTLCommandBuffer(queue)
-        cmdbuf.label = "fill!"
+        @label! cmdbuf "fill!"
         let md = MTL.profile_metadata[]
             md === nothing || MTL.note_operation!(md, cmdbuf,
                 (; kind = :fill, name = "fill!", bytes = Int(N * sizeof(T))))

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -29,6 +29,8 @@ Sys.isapple() && @setup_workload begin
     empty!(_compiler_configs)
     empty!(kernel_instances)
     empty!(global_queues)
+    empty!(queue_residency_sets)
+    empty!(device_malloc_bufs)
     empty!(MTL.last_committed_per_queue)
     empty!(device_exception_info)
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -27,7 +27,7 @@ Sys.isapple() && @setup_workload begin
     # the entries before precompilation finalizes.
     empty!(_compiler_caches)
     empty!(_compiler_configs)
-    empty!(_kernel_instances)
+    empty!(kernel_instances)
     empty!(global_queues)
     empty!(MTL.last_committed_per_queue)
     empty!(device_exception_info)

--- a/src/state.jl
+++ b/src/state.jl
@@ -102,10 +102,10 @@ end
 
 const MALLOC_BUF_SIZE = 1024 * 1024
 
-const device_malloc_bufs = Dict{MTLDevice, MTLBuffer}()
+const device_malloc_bufs = Dict{MTLDevice, Tuple{MTLBuffer, UInt64}}()
 const device_malloc_lock = ReentrantLock()
 
-function malloc_buffer(dev::MTLDevice)
+function malloc_buffer_info(dev::MTLDevice)
     Base.@lock device_malloc_lock begin
         get!(device_malloc_bufs, dev) do
             buf = @autoreleasepool MTLBuffer(dev, MALLOC_BUF_SIZE;
@@ -113,7 +113,9 @@ function malloc_buffer(dev::MTLDevice)
             # initialize the counter (first 4 bytes) to 4 so the first
             # allocation lands past the counter itself
             unsafe_store!(convert(Ptr{UInt32}, MTL.contents(buf)), UInt32(4))
-            buf
+            (buf, UInt64(buf.gpuAddress))
         end
     end
 end
+
+malloc_buffer(dev::MTLDevice) = first(malloc_buffer_info(dev))

--- a/src/state.jl
+++ b/src/state.jl
@@ -7,10 +7,7 @@ log_array(args...)      = log_array()(args...)
 
 const LABEL_RESOURCES = @load_preference("label_resources", nothing)
 
-@inline function label_resources()
-    LABEL_RESOURCES === nothing && return Base.JLOptions().debug_level >= 2
-    return LABEL_RESOURCES
-end
+@inline label_resources() = @something(LABEL_RESOURCES, Base.JLOptions().debug_level >= 2)
 
 macro label!(obj, str)
     quote

--- a/src/state.jl
+++ b/src/state.jl
@@ -101,6 +101,42 @@ function drain_logging_cmdbufs!(queue::MTLCommandQueue)
 end
 
 
+## scratch-buffer residency
+
+const _can_use_residency_sets = Dict{MTLDevice,Bool}()
+const _can_use_residency_sets_lock = ReentrantLock()
+
+# Fast residency path; collapse this to `true` when macOS 14 support is dropped.
+function can_use_residency_sets(dev::MTLDevice)
+    Base.@lock _can_use_residency_sets_lock begin
+        get!(() -> is_macos(v"15") && !is_virtual(dev), _can_use_residency_sets, dev)
+    end
+end
+
+const _queue_residency_sets = WeakKeyDict{MTLCommandQueue,MTLResidencySet}()
+const _queue_residency_sets_lock = ReentrantLock()
+
+function ensure_queue_residency!(queue::MTLCommandQueue, dev::MTLDevice,
+                                 malloc_buf::MTLBuffer, exc_buf::MTLBuffer)
+    Base.@lock _queue_residency_sets_lock begin
+        resset = get(_queue_residency_sets, queue, nothing)
+        resset === nothing || return resset
+
+        desc = MTLResidencySetDescriptor()
+        desc.initialCapacity = 2
+        @label! desc "Metal scratch buffers"
+
+        resset = MTLResidencySet(dev, desc)
+        MTL.add_allocation!(resset, malloc_buf)
+        MTL.add_allocation!(resset, exc_buf)
+        MTL.commit!(resset)
+        MTL.add_residency_set!(queue, resset)
+        _queue_residency_sets[queue] = resset
+        return resset
+    end
+end
+
+
 ## dynamic-memory allocator buffer
 #
 # kernels that perform dynamic memory allocations bump-allocate out of a per-

--- a/src/state.jl
+++ b/src/state.jl
@@ -71,16 +71,16 @@ end
 # `synchronize` can wait on it and thereby drain its `addLogHandler:` blocks
 # (Metal dispatches log delivery asynchronously and offers no flush primitive;
 # `waitUntilCompleted` on the specific cmdbuf is what processes its pending blocks).
-const _logging_cmdbufs = IdDict{MTLCommandQueue,MTLCommandBuffer}()
-const _logging_cmdbufs_lock = ReentrantLock()
+const logging_cmdbufs = IdDict{MTLCommandQueue,MTLCommandBuffer}()
+const logging_cmdbufs_lock = ReentrantLock()
 
 function track_logging_cmdbuf!(queue::MTLCommandQueue, cmdbuf::MTLCommandBuffer)
     # the surrounding `@autoreleasepool` in `(::HostKernel)()` will release the
     # caller's reference on return, so retain a fresh one for the tracking slot.
     retain(cmdbuf)
-    old = Base.@lock _logging_cmdbufs_lock begin
-        prev = get(_logging_cmdbufs, queue, nothing)
-        _logging_cmdbufs[queue] = cmdbuf
+    old = Base.@lock logging_cmdbufs_lock begin
+        prev = get(logging_cmdbufs, queue, nothing)
+        logging_cmdbufs[queue] = cmdbuf
         prev
     end
     old === nothing || release(old)
@@ -88,9 +88,9 @@ function track_logging_cmdbuf!(queue::MTLCommandQueue, cmdbuf::MTLCommandBuffer)
 end
 
 function drain_logging_cmdbufs!(queue::MTLCommandQueue)
-    cmdbuf = Base.@lock _logging_cmdbufs_lock begin
-        prev = get(_logging_cmdbufs, queue, nothing)
-        delete!(_logging_cmdbufs, queue)
+    cmdbuf = Base.@lock logging_cmdbufs_lock begin
+        prev = get(logging_cmdbufs, queue, nothing)
+        delete!(logging_cmdbufs, queue)
         prev
     end
     if cmdbuf !== nothing
@@ -116,13 +116,13 @@ function can_use_residency_sets(dev::MTLDevice)
     end::Bool
 end
 
-const _queue_residency_sets = WeakKeyDict{MTLCommandQueue,MTLResidencySet}()
-const _queue_residency_sets_lock = ReentrantLock()
+const queue_residency_sets = WeakKeyDict{MTLCommandQueue,MTLResidencySet}()
+const queue_residency_sets_lock = ReentrantLock()
 
 function ensure_queue_residency!(queue::MTLCommandQueue, dev::MTLDevice,
                                  malloc_buf::MTLBuffer, exc_buf::MTLBuffer)
-    Base.@lock _queue_residency_sets_lock begin
-        resset = get(_queue_residency_sets, queue, nothing)
+    Base.@lock queue_residency_sets_lock begin
+        resset = get(queue_residency_sets, queue, nothing)
         resset === nothing || return resset
 
         desc = MTLResidencySetDescriptor()
@@ -134,7 +134,7 @@ function ensure_queue_residency!(queue::MTLCommandQueue, dev::MTLDevice,
         MTL.add_allocation!(resset, exc_buf)
         MTL.commit!(resset)
         MTL.add_residency_set!(queue, resset)
-        _queue_residency_sets[queue] = resset
+        queue_residency_sets[queue] = resset
         return resset
     end
 end
@@ -155,7 +155,7 @@ const MALLOC_BUF_SIZE = 1024 * 1024
 const device_malloc_bufs = Dict{MTLDevice, Tuple{MTLBuffer, UInt64}}()
 const device_malloc_lock = ReentrantLock()
 
-function malloc_buffer_info(dev::MTLDevice)
+function malloc_buffer_and_gpu_address(dev::MTLDevice)
     Base.@lock device_malloc_lock begin
         get!(device_malloc_bufs, dev) do
             buf = @autoreleasepool MTLBuffer(dev, MALLOC_BUF_SIZE;
@@ -168,4 +168,4 @@ function malloc_buffer_info(dev::MTLDevice)
     end
 end
 
-malloc_buffer(dev::MTLDevice) = first(malloc_buffer_info(dev))
+malloc_buffer(dev::MTLDevice) = first(malloc_buffer_and_gpu_address(dev))

--- a/src/state.jl
+++ b/src/state.jl
@@ -5,11 +5,16 @@ log_compiler(args...)   = log_compiler()(args...)
 log_array()             = OSLog("org.juliagpu.metal", "Array")
 log_array(args...)      = log_array()(args...)
 
-const LABEL_RESOURCES = @load_preference("label_resources", false)
+const LABEL_RESOURCES = @load_preference("label_resources", nothing)
+
+@inline function label_resources()
+    LABEL_RESOURCES === nothing && return Base.JLOptions().debug_level >= 2
+    return LABEL_RESOURCES
+end
 
 macro label!(obj, str)
     quote
-        if LABEL_RESOURCES
+        if label_resources()
             $(esc(obj)).label = $(esc(str))
         end
         nothing

--- a/src/state.jl
+++ b/src/state.jl
@@ -62,6 +62,7 @@ function global_queue(dev::MTLDevice)
             queue = MTLCommandQueue(dev)
             queue.label = "global_queue($(current_task()))"
             global_queues[queue] = nothing
+            can_use_residency_sets(dev) && install_queue_residency!(queue, dev)
             queue
         end
     end::MTLCommandQueue
@@ -116,13 +117,23 @@ function can_use_residency_sets(dev::MTLDevice)
     end::Bool
 end
 
-const queue_residency_sets = WeakKeyDict{MTLCommandQueue,MTLResidencySet}()
+const queue_residency_sets = Dict{UInt,MTLResidencySet}()
 const queue_residency_sets_lock = ReentrantLock()
 
-function ensure_queue_residency!(queue::MTLCommandQueue, dev::MTLDevice,
-                                 malloc_buf::MTLBuffer, exc_buf::MTLBuffer)
+command_queue_key(queue::MTLCommandQueue) = UInt(pointer(queue))
+
+function install_queue_residency!(queue::MTLCommandQueue, dev::MTLDevice)
+    key = command_queue_key(queue)
     Base.@lock queue_residency_sets_lock begin
-        resset = get(queue_residency_sets, queue, nothing)
+        resset = get(queue_residency_sets, key, nothing)
+        resset === nothing || return resset
+    end
+
+    malloc_buf = malloc_buffer(dev)
+    exc_buf = exception_info_buffer(dev)
+
+    Base.@lock queue_residency_sets_lock begin
+        resset = get(queue_residency_sets, key, nothing)
         resset === nothing || return resset
 
         desc = MTLResidencySetDescriptor()
@@ -134,7 +145,13 @@ function ensure_queue_residency!(queue::MTLCommandQueue, dev::MTLDevice,
         MTL.add_allocation!(resset, exc_buf)
         MTL.commit!(resset)
         MTL.add_residency_set!(queue, resset)
-        queue_residency_sets[queue] = resset
+        queue_residency_sets[key] = resset
+        finalizer(queue) do _
+            Base.@lock queue_residency_sets_lock begin
+                get(queue_residency_sets, key, nothing) === resset &&
+                    delete!(queue_residency_sets, key)
+            end
+        end
         return resset
     end
 end

--- a/src/state.jl
+++ b/src/state.jl
@@ -5,6 +5,17 @@ log_compiler(args...)   = log_compiler()(args...)
 log_array()             = OSLog("org.juliagpu.metal", "Array")
 log_array(args...)      = log_array()(args...)
 
+const LABEL_RESOURCES = @load_preference("label_resources", false)
+
+macro label!(obj, str)
+    quote
+        if LABEL_RESOURCES
+            $(esc(obj)).label = $(esc(str))
+        end
+        nothing
+    end
+end
+
 """
     device()::MTLDevice
 

--- a/src/state.jl
+++ b/src/state.jl
@@ -103,14 +103,17 @@ end
 
 ## scratch-buffer residency
 
-const _can_use_residency_sets = Dict{MTLDevice,Bool}()
-const _can_use_residency_sets_lock = ReentrantLock()
-
 # Fast residency path; collapse this to `true` when macOS 14 support is dropped.
 function can_use_residency_sets(dev::MTLDevice)
-    Base.@lock _can_use_residency_sets_lock begin
-        get!(() -> is_macos(v"15") && !is_virtual(dev), _can_use_residency_sets, dev)
+    # Avoid serializing process-local Objective-C pointer keys from precompile workloads.
+    if ccall(:jl_generating_output, Cint, ()) != 0
+        return is_macos(v"15") && !is_virtual(dev)
     end
+
+    key = UInt(pointer(dev))
+    @memoize key::UInt begin
+        is_macos(v"15") && !is_virtual(dev)
+    end::Bool
 end
 
 const _queue_residency_sets = WeakKeyDict{MTLCommandQueue,MTLResidencySet}()

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -47,6 +47,7 @@ function versioninfo(io::IO=stdout)
 
     prefs = [
         "default_storage" => load_preference(Metal, "default_storage"),
+        "label_resources" => load_preference(Metal, "label_resources"),
         "nonblocking_synchronization" => load_preference(Metal, "nonblocking_synchronization"),
     ]
     if any(x->!isnothing(x[2]), prefs)


### PR DESCRIPTION
Reduces the number of Metal API calls performed by operations like kernel launches:

- **`setBytes` for by-reference arguments** (biggest win). Small, single-use kernel
  arguments (`KernelState`, scalars, RNG state — all ≪4 KB) are now bound with
  `setBytes:length:atIndex:` instead of allocating, labelling, filling, binding, and
  later freeing a fresh shared `MTLBuffer` each. This is the path Apple documents for
  transient <4 KB data; the kernel ABI is unchanged. Removes ~6 calls *plus* a
  `newBufferWithLength:` (3–9 µs each) *plus* a `free` per argument, and removes the
  per-launch buffer alloc/free churn entirely.
- **Cache pipeline/device invariants on `HostKernel`** — `device`,
  `maxTotalThreadsPerThreadgroup`, `staticThreadgroupMemoryLength`,
  `threadExecutionWidth`, and the residency-capability flag are fetched once at
  compile time instead of re-queried via `@autoproperty` on every launch.
- **Cache buffer invariants** — the `gpuAddress` of the per-device scratch/exception
  buffers and `MTLDevice.maxBufferLength` are memoized (via GPUToolbox `@memoize`,
  with a `jl_generating_output` guard so process-local pointers aren't baked into
  precompile images).
- **Opt-in resource labels** — `MtlArray`/command-buffer/copy/fill labels are now
  gated behind a `label_resources` preference (default `false`) through a `@label!`
  macro that also skips the (surprisingly expensive) `NSString` interpolation. See
  note below.
- **Avoid the command-queue lookup on commit** — `commit!` takes the queue directly
  instead of re-deriving it via `cmdbuf.commandQueue`.
- **Residency set for scratch buffers** — on macOS 15+, the bindlessly-accessed
  malloc/exception scratch buffers are made resident once via a per-queue
  `MTLResidencySet` instead of a per-launch `useResource:` pair.

Before:

```
julia> Metal.@profile trace=true @metal identity(nothing)

Host-side activity: 26 Objective-C calls taking 226.88 µs (0.39% of wall-clock)
┌────┬─────────┬───────────┬────────────────────────────────────────────────────────────────────────┐
│ ID │   Start │      Time │ Name                                                                   │
├────┼─────────┼───────────┼────────────────────────────────────────────────────────────────────────┤
│  3 │ 8.01 ms │   1.62 µs │ [MTLComputePipelineState maxTotalThreadsPerThreadgroup]                │
│  4 │ 8.01 ms │ 541.67 ns │ [MTLComputePipelineState staticThreadgroupMemoryLength]                │
│  5 │ 8.01 ms │ 916.67 ns │ [MTLComputePipelineState device]                                       │
│  6 │ 8.01 ms │   1.17 µs │ [MTLBuffer gpuAddress]                                                 │
│  7 │ 8.02 ms │ 208.33 ns │ [MTLComputePipelineState device]                                       │
│  8 │ 8.02 ms │  41.67 ns │ [MTLBuffer gpuAddress]                                                 │
│  9 │ 8.03 ms │  25.75 µs │ [MTLCommandQueue commandBuffer]                                        │
│ 10 │ 8.06 ms │  11.21 µs │ [MTLCommandBuffer setLabel:]                                           │
│ 12 │ 8.07 ms │  83.33 ns │ [MTLComputePipelineState staticThreadgroupMemoryLength]                │
│ 13 │ 8.07 ms │  83.33 ns │ [MTLComputePipelineState maxTotalThreadsPerThreadgroup]                │
│ 14 │ 8.08 ms │   75.5 µs │ [MTLCommandBuffer computeCommandEncoder]                               │
│ 15 │ 8.15 ms │   2.33 µs │ [MTLComputeCommandEncoder setComputePipelineState:]                    │
│ 16 │ 8.16 ms │   2.79 µs │ [MTLComputeCommandEncoder useResource:usage:]                          │
│ 17 │ 8.16 ms │  625.0 ns │ [MTLComputeCommandEncoder useResource:usage:]                          │
│ 18 │ 8.16 ms │  41.67 ns │ [MTLComputePipelineState device]                                       │
│ 21 │ 8.17 ms │   1.62 µs │ [MTLDevice maxBufferLength]                                            │
│ 22 │ 8.18 ms │   51.5 µs │ [MTLDevice newBufferWithLength:options:]                               │
│ 25 │ 8.23 ms │   1.88 µs │ [MTLResource setLabel:]                                                │
│ 26 │ 8.23 ms │  41.67 ns │ [MTLResource storageMode]                                              │
│ 27 │ 8.23 ms │  375.0 ns │ [MTLBuffer contents]                                                   │
│ 28 │ 8.24 ms │  750.0 ns │ [MTLComputeCommandEncoder setBuffer:offset:atIndex:]                   │
│ 29 │ 8.24 ms │  15.58 µs │ [MTLComputeCommandEncoder dispatchThreadgroups:threadsPerThreadgroup:] │
│ 30 │ 8.25 ms │   2.79 µs │ [MTLCommandEncoder endEncoding]                                        │
│ 32 │ 8.27 ms │ 416.67 ns │ [MTLCommandBuffer addCompletedHandler:]                                │
│ 34 │ 8.27 ms │  28.96 µs │ [MTLCommandBuffer commit]                                              │
│ 36 │  8.3 ms │  41.67 ns │ [MTLCommandBuffer commandQueue]                                        │
└────┴─────────┴───────────┴────────────────────────────────────────────────────────────────────────┘


julia> Metal.@profile trace=true Metal.rand(1024, 1024)

Host-side activity: 61 Objective-C calls taking 140.54 µs (0.88% of wall-clock)
┌────┬──────────┬───────────┬────────────────────────────────────────────────────────────────────────┐
│ ID │    Start │      Time │ Name                                                                   │
├────┼──────────┼───────────┼────────────────────────────────────────────────────────────────────────┤
│  3 │ 14.91 ms │   1.29 µs │ [MTLDevice maxBufferLength]                                            │
│  4 │ 14.91 ms │  47.17 µs │ [MTLDevice newBufferWithLength:options:]                               │
│  6 │ 14.98 ms │   3.62 µs │ [MTLResource setLabel:]                                                │
│  8 │ 14.99 ms │  125.0 ns │ [MTLBuffer gpuAddress]                                                 │
│  9 │ 15.01 ms │  375.0 ns │ [MTLComputePipelineState maxTotalThreadsPerThreadgroup]                │
│ 12 │ 15.03 ms │  41.67 ns │ [MTLComputePipelineState maxTotalThreadsPerThreadgroup]                │
│ 13 │ 15.03 ms │ 333.33 ns │ [MTLComputePipelineState staticThreadgroupMemoryLength]                │
│ 14 │ 15.03 ms │ 333.33 ns │ [MTLComputePipelineState device]                                       │
│ 15 │ 15.03 ms │  125.0 ns │ [MTLBuffer gpuAddress]                                                 │
│ 16 │ 15.03 ms │    0.0 ns │ [MTLComputePipelineState device]                                       │
│ 17 │ 15.03 ms │  41.67 ns │ [MTLBuffer gpuAddress]                                                 │
│ 18 │ 15.04 ms │   7.79 µs │ [MTLCommandQueue commandBuffer]                                        │
│ 20 │ 15.05 ms │   1.17 µs │ [MTLCommandBuffer setLabel:]                                           │
│ 21 │ 15.05 ms │  41.67 ns │ [MTLComputePipelineState staticThreadgroupMemoryLength]                │
│ 22 │ 15.05 ms │  41.67 ns │ [MTLComputePipelineState maxTotalThreadsPerThreadgroup]                │
│ 23 │ 15.05 ms │   9.75 µs │ [MTLCommandBuffer computeCommandEncoder]                               │
│ 24 │ 15.06 ms │  875.0 ns │ [MTLComputeCommandEncoder setComputePipelineState:]                    │
│ 25 │ 15.06 ms │   1.04 µs │ [MTLComputeCommandEncoder useResource:usage:]                          │
│ 26 │ 15.06 ms │  375.0 ns │ [MTLComputeCommandEncoder useResource:usage:]                          │
│ 27 │ 15.06 ms │    0.0 ns │ [MTLComputePipelineState device]                                       │
│ 30 │ 15.07 ms │ 166.67 ns │ [MTLDevice maxBufferLength]                                            │
│ 31 │ 15.07 ms │  15.38 µs │ [MTLDevice newBufferWithLength:options:]                               │
│ 34 │ 15.08 ms │ 791.67 ns │ [MTLResource setLabel:]                                                │
│ 35 │ 15.08 ms │  41.67 ns │ [MTLResource storageMode]                                              │
│ 36 │ 15.08 ms │ 208.33 ns │ [MTLBuffer contents]                                                   │
│ 37 │ 15.09 ms │ 708.33 ns │ [MTLComputeCommandEncoder setBuffer:offset:atIndex:]                   │
│ 38 │ 15.09 ms │    0.0 ns │ [MTLComputePipelineState device]                                       │
│ 41 │ 15.09 ms │  41.67 ns │ [MTLDevice maxBufferLength]                                            │
│ 42 │ 15.09 ms │   8.96 µs │ [MTLDevice newBufferWithLength:options:]                               │
│ 44 │  15.1 ms │  500.0 ns │ [MTLResource setLabel:]                                                │
│ 46 │  15.1 ms │    0.0 ns │ [MTLResource storageMode]                                              │
│ 47 │  15.1 ms │  83.33 ns │ [MTLBuffer contents]                                                   │
│ 48 │  15.1 ms │ 291.67 ns │ [MTLComputeCommandEncoder setBuffer:offset:atIndex:]                   │
│ 49 │  15.1 ms │    0.0 ns │ [MTLComputePipelineState device]                                       │
│ 52 │  15.1 ms │  41.67 ns │ [MTLDevice maxBufferLength]                                            │
│ 53 │  15.1 ms │   3.88 µs │ [MTLDevice newBufferWithLength:options:]                               │
│ 56 │ 15.11 ms │  375.0 ns │ [MTLResource setLabel:]                                                │
│ 57 │ 15.11 ms │    0.0 ns │ [MTLResource storageMode]                                              │
│ 58 │ 15.11 ms │  41.67 ns │ [MTLBuffer contents]                                                   │
│ 59 │ 15.11 ms │ 208.33 ns │ [MTLComputeCommandEncoder setBuffer:offset:atIndex:]                   │
│ 60 │ 15.11 ms │  41.67 ns │ [MTLComputePipelineState device]                                       │
│ 63 │ 15.11 ms │    0.0 ns │ [MTLDevice maxBufferLength]                                            │
│ 64 │ 15.11 ms │   3.17 µs │ [MTLDevice newBufferWithLength:options:]                               │
│ 67 │ 15.11 ms │ 416.67 ns │ [MTLResource setLabel:]                                                │
│ 68 │ 15.11 ms │  41.67 ns │ [MTLResource storageMode]                                              │
│ 69 │ 15.11 ms │  41.67 ns │ [MTLBuffer contents]                                                   │
│ 70 │ 15.11 ms │ 333.33 ns │ [MTLComputeCommandEncoder setBuffer:offset:atIndex:]                   │
│ 71 │ 15.11 ms │ 541.67 ns │ [MTLComputeCommandEncoder useResource:usage:]                          │
│ 72 │ 15.12 ms │    0.0 ns │ [MTLBuffer gpuAddress]                                                 │
│ 73 │ 15.12 ms │    0.0 ns │ [MTLComputePipelineState device]                                       │
│ 76 │ 15.12 ms │  41.67 ns │ [MTLDevice maxBufferLength]                                            │
│ 77 │ 15.12 ms │   3.92 µs │ [MTLDevice newBufferWithLength:options:]                               │
│ 79 │ 15.12 ms │ 458.33 ns │ [MTLResource setLabel:]                                                │
│ 81 │ 15.12 ms │  41.67 ns │ [MTLResource storageMode]                                              │
│ 82 │ 15.12 ms │  41.67 ns │ [MTLBuffer contents]                                                   │
│ 83 │ 15.12 ms │ 208.33 ns │ [MTLComputeCommandEncoder setBuffer:offset:atIndex:]                   │
│ 84 │ 15.12 ms │    7.0 µs │ [MTLComputeCommandEncoder dispatchThreadgroups:threadsPerThreadgroup:] │
│ 85 │ 15.13 ms │   1.29 µs │ [MTLCommandEncoder endEncoding]                                        │
│ 87 │ 15.14 ms │  250.0 ns │ [MTLCommandBuffer addCompletedHandler:]                                │
│ 89 │ 15.14 ms │  16.38 µs │ [MTLCommandBuffer commit]                                              │
│ 91 │ 15.16 ms │  83.33 ns │ [MTLCommandBuffer commandQueue]                                        │
└────┴──────────┴───────────┴────────────────────────────────────────────────────────────────────────┘
```

After:

```
julia> Metal.@profile trace=true @metal identity(nothing)

Host-side activity: 8 Objective-C calls taking 56.08 µs (1.28% of wall-clock)
┌────┬─────────┬───────────┬────────────────────────────────────────────────────────────────────────┐
│ ID │   Start │      Time │ Name                                                                   │
├────┼─────────┼───────────┼────────────────────────────────────────────────────────────────────────┤
│  3 │ 2.64 ms │   9.54 µs │ [MTLCommandQueue commandBuffer]                                        │
│  4 │ 2.65 ms │  26.04 µs │ [MTLCommandBuffer computeCommandEncoder]                               │
│  5 │ 2.68 ms │  875.0 ns │ [MTLComputeCommandEncoder setComputePipelineState:]                    │
│  6 │ 2.68 ms │ 208.33 ns │ [MTLComputeCommandEncoder setBytes:length:atIndex:]                    │
│  7 │ 2.68 ms │   4.62 µs │ [MTLComputeCommandEncoder dispatchThreadgroups:threadsPerThreadgroup:] │
│  8 │ 2.69 ms │    1.0 µs │ [MTLCommandEncoder endEncoding]                                        │
│ 10 │ 2.69 ms │ 208.33 ns │ [MTLCommandBuffer addCompletedHandler:]                                │
│ 12 │  2.7 ms │  13.58 µs │ [MTLCommandBuffer commit]                                              │
└────┴─────────┴───────────┴────────────────────────────────────────────────────────────────────────┘


julia> Metal.@profile trace=true Metal.rand(1024, 1024)

Host-side activity: 18 Objective-C calls taking 66.67 µs (0.77% of wall-clock)
┌────┬─────────┬───────────┬────────────────────────────────────────────────────────────────────────┐
│ ID │   Start │      Time │ Name                                                                   │
├────┼─────────┼───────────┼────────────────────────────────────────────────────────────────────────┤
│  3 │ 7.39 ms │ 833.33 ns │ [MTLDevice maxBufferLength]                                            │
│  4 │ 7.39 ms │  32.21 µs │ [MTLDevice newBufferWithLength:options:]                               │
│  6 │ 7.43 ms │  41.67 ns │ [MTLBuffer gpuAddress]                                                 │
│  7 │ 7.45 ms │ 166.67 ns │ [MTLComputePipelineState maxTotalThreadsPerThreadgroup]                │
│ 10 │ 7.46 ms │   4.08 µs │ [MTLCommandQueue commandBuffer]                                        │
│ 11 │ 7.47 ms │  17.21 µs │ [MTLCommandBuffer computeCommandEncoder]                               │
│ 12 │ 7.48 ms │ 333.33 ns │ [MTLComputeCommandEncoder setComputePipelineState:]                    │
│ 13 │ 7.49 ms │  83.33 ns │ [MTLComputeCommandEncoder setBytes:length:atIndex:]                    │
│ 14 │ 7.49 ms │  41.67 ns │ [MTLComputeCommandEncoder setBytes:length:atIndex:]                    │
│ 15 │ 7.49 ms │    0.0 ns │ [MTLComputeCommandEncoder setBytes:length:atIndex:]                    │
│ 16 │ 7.49 ms │  41.67 ns │ [MTLComputeCommandEncoder setBytes:length:atIndex:]                    │
│ 17 │ 7.49 ms │ 208.33 ns │ [MTLComputeCommandEncoder useResource:usage:]                          │
│ 18 │ 7.49 ms │    0.0 ns │ [MTLBuffer gpuAddress]                                                 │
│ 19 │ 7.49 ms │    0.0 ns │ [MTLComputeCommandEncoder setBytes:length:atIndex:]                    │
│ 20 │ 7.49 ms │   4.08 µs │ [MTLComputeCommandEncoder dispatchThreadgroups:threadsPerThreadgroup:] │
│ 21 │ 7.49 ms │ 458.33 ns │ [MTLCommandEncoder endEncoding]                                        │
│ 23 │  7.5 ms │  83.33 ns │ [MTLCommandBuffer addCompletedHandler:]                                │
│ 25 │  7.5 ms │   6.79 µs │ [MTLCommandBuffer commit]                                              │
└────┴─────────┴───────────┴────────────────────────────────────────────────────────────────────────┘
```

Sadly, doesn't meaningfully impact the 10us launch cost of an identity kernel.