### PR TITLE
Reduce reliance on ObjC blocks

### DIFF
--- a/lib/mtl/command_buf.jl
+++ b/lib/mtl/command_buf.jl
@@ -252,3 +252,14 @@ function on_completed(f::Base.Callable, cmdbuf::MTLCommandBufferLike)
     block = _command_buffer_callback(f)
     @objc [cmdbuf::id{MTLCommandBuffer} addCompletedHandler:block::id{NSBlock}]::Nothing
 end
+
+"""
+    on_completed(cmdbuf::MTLCommandBuffer, cond::Base.AsyncCondition)
+
+Signal `cond` when execution of the command buffer is completed, without running
+Julia code on Metal's completion-handler thread.
+"""
+function on_completed(cmdbuf::MTLCommandBufferLike, cond::Base.AsyncCondition)
+    block = @objcasyncblock(cond)
+    @objc [cmdbuf::id{MTLCommandBuffer} addCompletedHandler:block::id{NSBlock}]::Nothing
+end

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -389,16 +389,6 @@ function launch(@nospecialize(kernel::HostKernel), gs::MTLSize, ts::MTLSize,
     #
     # TODO: is there a way to bind additional resources to the command buffer?
     roots = Any[f, args]
-    MTL.on_completed(cmdbuf) do buf
-        empty!(roots)
-
-        # Check for errors
-        # XXX: we cannot do this nicely, e.g. throwing an `error` or reporting with `@error`
-        #      because we're not allowed to switch tasks from this contexts.
-        if buf.status == MTL.MTLCommandBufferStatusError
-            Core.println("ERROR: Failed to submit command buffer: $(buf.error.localizedDescription)")
-        end
-    end
 
     # HACK: don't actually commit when precompiling to prevent holding onto resources
     if ccall(:jl_generating_output, Cint, ()) != 0
@@ -406,6 +396,8 @@ function launch(@nospecialize(kernel::HostKernel), gs::MTLSize, ts::MTLSize,
     end
 
     commit!(cmdbuf, queue)
+    defer_cleanup!(queue, cmdbuf, roots)
+
     if kernel.loggingEnabled
         # remember this so `synchronize(queue)` can drain its log handler blocks
         # (Metal delivers logs asynchronously on a libdispatch queue; only

--- a/src/state.jl
+++ b/src/state.jl
@@ -159,6 +159,58 @@ function install_queue_residency!(queue::MTLCommandQueue, dev::MTLDevice)
 end
 
 
+# Per-launch cleanup used to be performed from a Metal completion-handler
+# block. Those handlers run on libdispatch worker threads, where compiling or
+# running Julia code can overflow the small foreign stack. Keep the command
+# buffer alive and drain the Julia-side cleanup from normal managed threads.
+struct PendingCleanup
+    cmdbuf::MTLCommandBuffer
+    roots::Vector{Any}
+end
+
+const _pending_cleanups = IdDict{MTLCommandQueue,Vector{PendingCleanup}}()
+const _pending_cleanups_lock = ReentrantLock()
+
+function defer_cleanup!(queue::MTLCommandQueue, cmdbuf::MTLCommandBuffer, roots::Vector{Any})
+    retain(cmdbuf)
+    Base.@lock _pending_cleanups_lock begin
+        push!(get!(() -> PendingCleanup[], _pending_cleanups, queue),
+              PendingCleanup(cmdbuf, roots))
+    end
+    return
+end
+
+function drain_cleanups!(queue::MTLCommandQueue; force::Bool=false)
+    cleanups = Base.@lock _pending_cleanups_lock begin
+        list = get(_pending_cleanups, queue, nothing)
+        list === nothing && return
+
+        n = 0
+        for cleanup in list
+            if !(force || cleanup.cmdbuf.status >= MTL.MTLCommandBufferStatusCompleted)
+                break
+            end
+            n += 1
+        end
+        n == 0 && return
+
+        completed = list[1:n]
+        deleteat!(list, 1:n)
+        isempty(list) && delete!(_pending_cleanups, queue)
+        completed
+    end
+
+    for cleanup in cleanups
+        if cleanup.cmdbuf.status == MTL.MTLCommandBufferStatusError
+            @error "Command buffer failed" reason=cleanup.cmdbuf.error.localizedDescription
+        end
+        empty!(cleanup.roots)
+        release(cleanup.cmdbuf)
+    end
+    return
+end
+
+
 ## dynamic-memory allocator buffer
 #
 # kernels that perform dynamic memory allocations bump-allocate out of a per-

--- a/src/synchronization.jl
+++ b/src/synchronization.jl
@@ -43,12 +43,14 @@ function nonblocking_synchronization(cmdbuf::MTL.MTLCommandBufferLike)
     end
 
     sentinel = MTLCommandBuffer(cmdbuf.commandQueue)
-    done = Base.Event()
-    on_completed(sentinel) do _
-        notify(done)
-    end
+    done = Base.AsyncCondition()
+    on_completed(sentinel, done)
     commit!(sentinel)
-    wait(done)
+    try
+        wait(done)
+    finally
+        close(done)
+    end
     return
 end
 

--- a/src/synchronization.jl
+++ b/src/synchronization.jl
@@ -85,6 +85,8 @@ Wait for currently committed GPU work on `queue` to finish.
         release(last)
     end
 
+    drain_cleanups!(queue; force=true)
+
     # surface any device-side exception thrown by the work we just waited on
     check_exceptions()
     return

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -166,6 +166,29 @@ vecA = unsafe_wrap(Vector{Int}, pointer(bufferA), tuple(bufferSize))
     @test all(vecA .== Int(5))
 end
 
+@testset "kernel launch cleanup" begin
+    function scalar_arg_kernel(A, val)
+        A[1] = val
+        return
+    end
+
+    A = MtlArray{Int32}(undef, 1)
+    kernel = @metal launch=false scalar_arg_kernel(A, Int32(1))
+
+    kernel(A, Int32(1))
+    synchronize()
+
+    stats0 = copy(Metal.alloc_stats)
+    kernel(A, Int32(2))
+    synchronize()
+    stats1 = copy(Metal.alloc_stats)
+    diff = stats1 - stats0
+
+    @test Array(A) == Int32[2]
+    @test diff.alloc_count == diff.free_count
+    @test diff.alloc_bytes == diff.free_bytes
+end
+
 @testset "device synchronization" begin
     t = @async begin
         @metal threads=(bufferSize) tester(bufferA)


### PR DESCRIPTION
ObjC blocks are executed on Metal's stack, which may have a more limited stack size that could explain the crashes seen in https://github.com/JuliaGPU/Metal.jl/pull/822#issuecomment-4742161067 when compilation is triggered on that stack. So instead, rely on a deferred mechanism that triggers when synchronizing. This should ideally also improve launch overhead because we don't need to allocate a block anymore.