### PR TITLE
Make Metal intrinsics device-only

### DIFF
--- a/src/device/intrinsics/synchronization.jl
+++ b/src/device/intrinsics/synchronization.jl
@@ -33,22 +33,24 @@ Possible values:
 end
 
 
-"""
+@device_function @inline threadgroup_barrier(flag=MemoryFlagNone) =
+    ccall("extern air.wg.barrier", llvmcall, Cvoid, (Cuint, Cuint, ), flag, UInt32(1))
+
+@device_function @inline simdgroup_barrier(flag=MemoryFlagNone) =
+    ccall("extern air.simdgroup.barrier", llvmcall, Cvoid, (Cuint, Cuint, ), flag, UInt32(1))
+
+@doc """
     threadgroup_barrier(flag=MemoryFlagNone)
 
 Synchronize all threads in a threadgroup.
 
 Possible flags that affect the memory synchronization behavior are found in [`MemoryFlags`](@ref)
-"""
-@inline threadgroup_barrier(flag=MemoryFlagNone) =
-    ccall("extern air.wg.barrier", llvmcall, Cvoid, (Cuint, Cuint, ), flag, UInt32(1))
+""" threadgroup_barrier
 
-"""
+@doc """
     simdgroup_barrier(flag=MemoryFlagNone)
 
 Synchronize all threads in a SIMD-group.
 
 Possible flags that affect the memory synchronization behavior are found in [`MemoryFlags`](@ref)
-"""
-@inline simdgroup_barrier(flag=MemoryFlagNone) =
-    ccall("extern air.simdgroup.barrier", llvmcall, Cvoid, (Cuint, Cuint, ), flag, UInt32(1))
+""" simdgroup_barrier

--- a/src/device/intrinsics/version.jl
+++ b/src/device/intrinsics/version.jl
@@ -3,7 +3,7 @@
 export metal_version, air_version, @sv_str
 
 for var in ["metal_major", "metal_minor", "air_major", "air_minor"]
-    @eval @inline $(Symbol(var))() =
+    @eval @device_function @inline $(Symbol(var))() =
         Base.llvmcall(
             $("""@$var = external global i32
                  define i32 @entry() #0 {


### PR DESCRIPTION
## Summary

This marks the Metal barrier and version intrinsics as device functions so host-side AOT/codegen does not emit AIR/Metal device-only references for these APIs.

The change keeps the existing docstrings attached to the public functions while moving the actual intrinsic bodies behind `@device_function`.

## Why

Including Metal in a host sysimage can expose device-only AIR/Metal symbols to the host linker. These intrinsics are only valid for Metal device compilation and should not create host link obligations.

## Validation

- Rebased onto latest `JuliaGPU/Metal.jl:main` at `224d0e29`.
- `git merge-tree --write-tree upstream/main HEAD` completed successfully, producing merge tree `cfb1bf62cfd5171e8eeeac7f0e80850bf00fa866`.
- `julia --project scripts/check_host_device_intrinsic_regression.jl` passed from the repro environment with required failures: 0 and candidate leaks: 0.

## Notes

The repro environment resolved `Metal v1.10.0` from `/Users/ian/Documents/Metal.jl` and `GPUCompiler v1.22.3` from `JuliaGPU/GPUCompiler.jl#main`.
