### PR TITLE
[NFC] Fixup MPSGraph reduce/scan/sort PR #855

### DIFF
--- a/src/accumulate.jl
+++ b/src/accumulate.jl
@@ -170,49 +170,50 @@ end
 ## Base interface
 
 const scan_alg = ScopedValue(:auto)
-const mps_scan_threshold = 64 * 1024
+const mpsgraph_scan_threshold = 64 * 1024
 
-# MPS cumulative max/min ignore NaNs; Base accumulate(max/min) propagates them.
-mps_scan_operation(::typeof(+)) = :sum
-mps_scan_operation(::typeof(Base.add_sum)) = :sum
-mps_scan_operation(::typeof(*)) = :product
-mps_scan_operation(::typeof(Base.mul_prod)) = :product
-mps_scan_operation(op) = nothing
+# MPSGraph cumulative max/min ignore NaNs while Base accumulate(max/min)
+# propagates them, so don't use MPSGraph scan for these operations.
+mpsgraph_scan_operation(::typeof(+)) = :sum
+mpsgraph_scan_operation(::typeof(Base.add_sum)) = :sum
+mpsgraph_scan_operation(::typeof(*)) = :product
+mpsgraph_scan_operation(::typeof(Base.mul_prod)) = :product
+mpsgraph_scan_operation(op) = nothing
 
-function mps_scan_supported(op, output::MtlArray{T}, input::MtlArray{T},
+function mpsgraph_scan_supported(op, output::MtlArray{T}, input::MtlArray{T},
                             dims::Integer, init::Nothing) where {T}
-    mps_scan_operation(op) === nothing && return false
+    mpsgraph_scan_operation(op) === nothing && return false
     T <: MPSGraphs.MPSGRAPH_VALID_SCAN_TYPES || return false
     axes(output) == axes(input) || return false
     1 <= dims <= ndims(input) || return false
     return output.offset == 0 && input.offset == 0
 end
 
-mps_scan_supported(op, output, input, dims::Integer, init) = false
+mpsgraph_scan_supported(op, output, input, dims::Integer, init) = false
 
-function mps_scan!(op, output::MtlArray{T}, input::MtlArray{T}; dims::Integer,
+# same as MPSGraphs.graph_scan!, but errors on unsupported input when explicitly requested
+function mpsgraph_scan!(op, output::MtlArray{T}, input::MtlArray{T}; dims::Integer,
                    init) where {T}
     init === nothing ||
         throw(ArgumentError("MPSGraph scan does not support init"))
     return MPSGraphs.graph_scan!(op, output, input; dim=dims)
 end
-
-function mps_scan!(op, output, input; dims::Integer, init)
+function mpsgraph_scan!(op, output, input; dims::Integer, init)
     throw(ArgumentError("MPSGraph scan does not support this accumulate query"))
 end
 
 function scan_with_algorithm!(op, output::WrappedMtlArray, input::WrappedMtlArray;
                               dims::Integer, init=nothing)
     alg = scan_alg[]
-    supported = mps_scan_supported(op, output, input, dims, init)
-    if alg === :MPS
-        return mps_scan!(op, output, input; dims, init)
-    elseif alg === :auto && supported && length(input) >= mps_scan_threshold
+    supported = mpsgraph_scan_supported(op, output, input, dims, init)
+    if alg === :MPSGraph
+        return mpsgraph_scan!(op, output, input; dims, init)
+    elseif alg === :auto && supported && length(input) >= mpsgraph_scan_threshold
         return MPSGraphs.graph_scan!(op, output, input; dim=dims)
     elseif alg === :auto || alg === :native
         return scan!(op, output, input; dims, init)
     else
-        error(":$alg is not a valid scan algorithm. Options are: `:auto`, `:MPS`, `:native`")
+        error(":$alg is not a valid scan algorithm. Options are: `:auto`, `:MPSGraph`, `:native`")
     end
 end
 

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -177,17 +177,17 @@ end
 
 const reduce_alg = ScopedValue(:auto)
 
-reduction_operation(::typeof(+)) = :sum
-reduction_operation(::typeof(Base.add_sum)) = :sum
-reduction_operation(::typeof(*)) = :product
-reduction_operation(::typeof(Base.mul_prod)) = :product
-reduction_operation(::typeof(max)) = :maximum
-reduction_operation(::typeof(min)) = :minimum
-reduction_operation(op) = nothing
+mpsgraph_reduction_operation(::typeof(+)) = :sum
+mpsgraph_reduction_operation(::typeof(Base.add_sum)) = :sum
+mpsgraph_reduction_operation(::typeof(*)) = :product
+mpsgraph_reduction_operation(::typeof(Base.mul_prod)) = :product
+mpsgraph_reduction_operation(::typeof(max)) = :maximum
+mpsgraph_reduction_operation(::typeof(min)) = :minimum
+mpsgraph_reduction_operation(op) = nothing
 
-function mps_reduction_init_supported(op, ::Type{T}, init) where {T}
+function mpsgraph_reduction_init_supported(op, ::Type{T}, init) where {T}
     init === nothing && return true
-    reduction_operation(op) === nothing && return false
+    mpsgraph_reduction_operation(op) === nothing && return false
     return isequal(init, GPUArrays.neutral_element(op, T))
 end
 
@@ -206,32 +206,32 @@ function reduced_dimensions(R::MtlArray, A::MtlArray)
     return isempty(dims) ? nothing : Tuple(dims)
 end
 
-function mps_reduce_dimensions(f, op, R::MtlArray{T}, A::MtlArray{T},
+function mpsgraph_reduce_dimensions(f, op, R::MtlArray{T}, A::MtlArray{T},
                                init) where {T}
     f === identity || return nothing
-    reduction_operation(op) === nothing && return nothing
+    mpsgraph_reduction_operation(op) === nothing && return nothing
     T <: MPSGraphs.MPSGRAPH_VALID_REDUCTION_TYPES || return nothing
-    mps_reduction_init_supported(op, T, init) || return nothing
+    mpsgraph_reduction_init_supported(op, T, init) || return nothing
     R.offset == 0 && A.offset == 0 || return nothing
     return reduced_dimensions(R, A)
 end
 
-mps_reduce_dimensions(f, op, R, A, init) = nothing
+mpsgraph_reduce_dimensions(f, op, R, A, init) = nothing
 
-function mps_reduce_auto(R::MtlArray, A::MtlArray, dims)
+function mpsgraph_reduce_auto(R::MtlArray, A::MtlArray, dims)
     length(R) > 1 && any(dim -> dim > 1 && size(A, dim) > 1, dims)
 end
 
-function mps_mapreducedim!(f, op, R::MtlArray{T}, A::MtlArray{T};
+# same as MPSGraphs.graph_mapreducedim!, but errors on unsupported input when explicitly requested
+function mpsgraph_mapreducedim!(f, op, R::MtlArray{T}, A::MtlArray{T};
                            init) where {T}
     f === identity ||
         throw(ArgumentError("MPSGraph reduction only supports identity mapping"))
-    mps_reduction_init_supported(op, T, init) ||
+    mpsgraph_reduction_init_supported(op, T, init) ||
         throw(ArgumentError("MPSGraph reduction does not support this initializer"))
     return MPSGraphs.graph_mapreducedim!(op, R, A)
 end
-
-function mps_mapreducedim!(f, op, R, A; init)
+function mpsgraph_mapreducedim!(f, op, R, A; init)
     throw(ArgumentError("MPSGraph reduction does not support this mapreduce query"))
 end
 
@@ -252,13 +252,13 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::WrappedMtlArray{T},
     end
 
     alg = reduce_alg[]
-    if !(alg === :auto || alg === :MPS || alg === :native)
-        error(":$alg is not a valid reduction algorithm. Options are: `:auto`, `:MPS`, `:native`")
+    if !(alg === :auto || alg === :MPSGraph || alg === :native)
+        error(":$alg is not a valid reduction algorithm. Options are: `:auto`, `:MPSGraph`, `:native`")
     end
-    dims = mps_reduce_dimensions(f, op, R, A, init)
-    if alg === :MPS
-        return mps_mapreducedim!(f, op, R, A; init)
-    elseif dims !== nothing && alg === :auto && mps_reduce_auto(R, A, dims)
+    dims = mpsgraph_reduce_dimensions(f, op, R, A, init)
+    if alg === :MPSGraph
+        return mpsgraph_mapreducedim!(f, op, R, A; init)
+    elseif dims !== nothing && alg === :auto && mpsgraph_reduce_auto(R, A, dims)
         return MPSGraphs.graph_mapreducedim!(op, R, A)
     end
 

--- a/test/array.jl
+++ b/test/array.jl
@@ -634,7 +634,7 @@ end
 
     scan_input = reshape(Float32[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37], 3, 4)
     product_input = scan_input ./ 10
-    for alg in (:native, :MPS), dims in 1:2
+    for alg in (:native, :MPSGraph), dims in 1:2
         @with (Metal.scan_alg => alg) begin
             @test Array(accumulate(+, MtlArray(scan_input); dims)) ≈
                 accumulate(+, scan_input; dims)
@@ -654,7 +654,7 @@ end
         end
     end
 
-    @with (Metal.scan_alg => :MPS) begin
+    @with (Metal.scan_alg => :MPSGraph) begin
         int_input = Int32[1, 2, 3, 4]
         @test_throws ArgumentError accumulate(+, MtlArray(int_input))
         @test_throws ArgumentError accumulate(+, MtlArray(scan_input); dims=1,
@@ -665,7 +665,7 @@ end
         @test_throws ArgumentError accumulate(min, MtlArray(nan_input))
     end
 
-    large_nan_input = ones(Float32, Metal.mps_scan_threshold + 1)
+    large_nan_input = ones(Float32, Metal.mpsgraph_scan_threshold + 1)
     large_nan_input[2] = NaN
     @test isequal(Array(accumulate(max, MtlArray(large_nan_input))),
                   accumulate(max, large_nan_input))
@@ -675,7 +675,7 @@ end
 
 @testset "reduced dimensions" begin
     reduce_input = reshape(Float32.(1:24) ./ 10, 3, 4, 2)
-    for alg in (:native, :MPS), dims in 1:3
+    for alg in (:native, :MPSGraph), dims in 1:3
         @with (Metal.reduce_alg => alg) begin
             @test Array(sum(MtlArray(reduce_input); dims)) ≈
                 sum(reduce_input; dims)
@@ -688,7 +688,7 @@ end
         end
     end
 
-    @with (Metal.reduce_alg => :MPS) begin
+    @with (Metal.reduce_alg => :MPSGraph) begin
         int_input = reshape(Int32.(1:12), 3, 4)
         @test_throws ArgumentError sum(MtlArray(int_input); dims=2)
         @test_throws ArgumentError sum(abs2, MtlArray(reduce_input); dims=2)


### PR DESCRIPTION
MPS sort of has support for reductions, which #855 doesn't touch. This just makes it clear that all operations are being done with MPSGraph.