### PR TITLE
Add 64-bit atomic min/max support

### DIFF
--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -550,7 +550,7 @@ function compile_to_metallib(@nospecialize(job::CompilerJob))
         has_i64_atomic_modify =
             haskey(functions(mod), "air.atomic.global.min.u.i64") ||
             haskey(functions(mod), "air.atomic.global.max.u.i64")
-        if has_i64_atomic_modify && (is_nothing(job.config.params.gpufamily) ||
+        if has_i64_atomic_modify && (isnothing(job.config.params.gpufamily) ||
            job.config.params.gpufamily < MTL.MTLGPUFamilyApple8)
             error("""64-bit atomic modify intrinsics (`atomic_min_explicit`/`atomic_max_explicit` on `UInt64`) \
                      require `MTLGPUFamilyApple8` (M2 or newer). Guard usage with \

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -547,8 +547,8 @@ function compile_to_metallib(@nospecialize(job::CompilerJob))
         if has_i64_atomic_modify &&
            !MTL.supports_family(device(), MTL.MTLGPUFamilyApple9)
             error("""64-bit atomic modify intrinsics (`atomic_min_explicit`/`atomic_max_explicit` on `UInt64`) \
-                     require `MTLGPUFamilyApple9` (M3 or newer). Guard usage with \
-                     `MTL.supports_family(device(), MTL.MTLGPUFamilyApple9)`.""")
+                     require `MTLGPUFamilyApple8` (M2 or newer). Guard usage with \
+                     `MTL.supports_family(device(), MTL.MTLGPUFamilyApple8)`.""")
         end
 
         @signpost_interval log=log_compiler() "Downgrade to AIR" begin

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -475,6 +475,9 @@ end
     end
     if gpufamily === nothing
         highest_family = MTL.highest_apple_family(dev)
+        if highest_family === nothing
+            error("""Metal.jl requires Metal5 or newer; cannot target Metal$(highest_family).""")
+        end
         gpufamily = isnothing(highest_family) ? nothing : MTL.MTLGPUFamily(1000 + highest_family)
     end
 

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -474,8 +474,8 @@ end
             error("""Metal $(metal) requires AIR $(air_floor(metal)) or newer; cannot target AIR $(air).""")
     end
     if gpufamily === nothing
-        highest_family = MTL.highest_apple_family(device())
-        gpufamily = isnothing(highest_family) ? nothing : MTL.MTLGPUFamily(1000 | highest_family)
+        highest_family = MTL.highest_apple_family(dev)
+        gpufamily = isnothing(highest_family) ? nothing : MTL.MTLGPUFamily(1000 + highest_family)
     end
 
     # create GPUCompiler objects

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -1,6 +1,8 @@
 ## gpucompiler interface implementation
 
-struct MetalCompilerParams <: AbstractCompilerParams end
+struct MetalCompilerParams <: AbstractCompilerParams
+    gpufamily::Union{Nothing, MTL.MTLGPUFamily}
+end
 const MetalCompilerConfig = CompilerConfig{MetalCompilerTarget, MetalCompilerParams}
 const MetalCompilerJob = CompilerJob{MetalCompilerTarget, MetalCompilerParams}
 
@@ -451,7 +453,7 @@ end
                                          debug_level=Base.JLOptions().debug_level,
                                          opt_level=2,
                                          macos=nothing, air=nothing, metal=nothing,
-                                         kwargs...)
+                                         gpufamily=nothing, kwargs...)
     # determine the versions of things to target
     if macos === nothing
         macos = macos_version()
@@ -471,10 +473,14 @@ end
     elseif air < air_floor(metal)
             error("""Metal $(metal) requires AIR $(air_floor(metal)) or newer; cannot target AIR $(air).""")
     end
+    if gpufamily === nothing
+        highest_family = MTL.highest_apple_family(device())
+        gpufamily = isnothing(highest_family) ? nothing : MTL.MTLGPUFamily(1000 | highest_family)
+    end
 
     # create GPUCompiler objects
     target = MetalCompilerTarget(; macos, air, metal, kwargs...)
-    params = MetalCompilerParams()
+    params = MetalCompilerParams(gpufamily)
     CompilerConfig(target, params; kernel, name, always_inline, debug_level, opt_level)
 end
 
@@ -544,8 +550,8 @@ function compile_to_metallib(@nospecialize(job::CompilerJob))
         has_i64_atomic_modify =
             haskey(functions(mod), "air.atomic.global.min.u.i64") ||
             haskey(functions(mod), "air.atomic.global.max.u.i64")
-        if has_i64_atomic_modify &&
-           !MTL.supports_family(device(), MTL.MTLGPUFamilyApple9)
+        if has_i64_atomic_modify && (is_nothing(job.config.params.gpufamily) ||
+           job.config.params.gpufamily < MTL.MTLGPUFamilyApple8)
             error("""64-bit atomic modify intrinsics (`atomic_min_explicit`/`atomic_max_explicit` on `UInt64`) \
                      require `MTLGPUFamilyApple8` (M2 or newer). Guard usage with \
                      `MTL.supports_family(device(), MTL.MTLGPUFamilyApple8)`.""")

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -539,6 +539,18 @@ function compile_to_metallib(@nospecialize(job::CompilerJob))
         # Detect logging after optimization so dead logging calls do not enable log state.
         loggingEnabled = haskey(functions(mod), "air.os_log")
 
+        # 64-bit atomic modify intrinsics (`atomic_{min,max}_explicit` on `atomic_ulong`)
+        # require the newer Apple GPU families that implement this optional feature.
+        has_i64_atomic_modify =
+            haskey(functions(mod), "air.atomic.global.min.u.i64") ||
+            haskey(functions(mod), "air.atomic.global.max.u.i64")
+        if has_i64_atomic_modify &&
+           !MTL.supports_family(device(), MTL.MTLGPUFamilyApple9)
+            error("""64-bit atomic modify intrinsics (`atomic_min_explicit`/`atomic_max_explicit` on `UInt64`) \
+                     require `MTLGPUFamilyApple9` (M3 or newer). Guard usage with \
+                     `MTL.supports_family(device(), MTL.MTLGPUFamilyApple9)`.""")
+        end
+
         @signpost_interval log=log_compiler() "Downgrade to AIR" begin
             # generate AIR, having GPUCompiler lower the IR to AIR-compatible form and
             # invoke the LLVM downgrader (both as part of Metal's `mcgen`)

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -1,6 +1,9 @@
 ## gpucompiler interface implementation
 
-struct MetalCompilerParams <: AbstractCompilerParams end
+struct MetalCompilerParams <: AbstractCompilerParams
+    # Highest targeted MTLGPUFamilyApple<n>, or 0 if the device reports none.
+    apple_family::Int
+end
 const MetalCompilerConfig = CompilerConfig{MetalCompilerTarget, MetalCompilerParams}
 const MetalCompilerJob = CompilerJob{MetalCompilerTarget, MetalCompilerParams}
 
@@ -87,6 +90,13 @@ GPUCompiler.isintrinsic(@nospecialize(job::MetalCompilerJob), fn::String) =
 
 function GPUCompiler.finish_module!(@nospecialize(job::MetalCompilerJob),
                                     mod::LLVM.Module, entry::LLVM.Function)
+    # Materialize apple_family() before GPUCompiler optimizes the linked module.
+    if haskey(globals(mod), "apple_family")
+        gv = globals(mod)["apple_family"]
+        initializer!(gv, ConstantInt(LLVM.Int32Type(), job.config.params.apple_family))
+        linkage!(gv, LLVM.API.LLVMPrivateLinkage)
+    end
+
     entry = invoke(GPUCompiler.finish_module!,
                    Tuple{CompilerJob{MetalCompilerTarget}, LLVM.Module, LLVM.Function},
                    job, mod, entry)
@@ -480,7 +490,7 @@ end
                                          debug_level=Base.JLOptions().debug_level,
                                          opt_level=2,
                                          macos=nothing, air=nothing, metal=nothing,
-                                         kwargs...)
+                                         gpufamily=nothing, kwargs...)
     # determine the versions of things to target
     if macos === nothing
         macos = macos_version()
@@ -500,10 +510,21 @@ end
     elseif air < air_floor(metal)
             error("""Metal $(metal) requires AIR $(air_floor(metal)) or newer; cannot target AIR $(air).""")
     end
+    # Only Apple family values form the capability sequence used by device code.
+    if gpufamily === nothing
+        highest_family = MTL.highest_apple_family(dev)
+        apple_family = something(highest_family, 0)
+    else
+        gpufamily = convert(MTL.MTLGPUFamily, gpufamily)
+        apple_family = Int(gpufamily) - 1000
+        if !(1 <= apple_family <= 10)
+            throw(ArgumentError("gpufamily must be an MTLGPUFamilyApple<n>, got $(gpufamily)"))
+        end
+    end
 
     # create GPUCompiler objects
     target = MetalCompilerTarget(; macos, air, metal, kwargs...)
-    params = MetalCompilerParams()
+    params = MetalCompilerParams(apple_family)
     CompilerConfig(target, params; kernel, name, always_inline, debug_level, opt_level)
 end
 

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -4,7 +4,7 @@ export @metal
 ## high-level @metal interface
 
 const MACRO_KWARGS = [:launch]
-const COMPILER_KWARGS = [:kernel, :name, :always_inline, :debug_level, :opt_level, :macos, :air, :metal]
+const COMPILER_KWARGS = [:kernel, :name, :always_inline, :debug_level, :opt_level, :macos, :air, :metal, :gpufamily]
 const LAUNCH_KWARGS = [:groups, :threads, :queue, :submit]
 
 """
@@ -188,6 +188,8 @@ a callable kernel object. For a higher-level interface, use [`@metal`](@ref).
 The following keyword arguments are supported:
 - `macos`, `metal` and `air`: to override the macOS OS, Metal language and AIR bitcode
    versions used during compilation. Value should be a valid version number.
+- `gpufamily`: to override the Apple GPU family (`MTL.MTLGPUFamilyApple<n>`) that the
+   generated code may rely on. Defaults to the highest family the device supports.
 
 The output of this function is automatically cached, i.e. you can simply call `mtlfunction`
 in a hot path without degrading performance. New code will be generated automatically when

--- a/src/device/intrinsics/atomics.jl
+++ b/src/device/intrinsics/atomics.jl
@@ -161,7 +161,18 @@ function atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{Float32,AS}, expecte
                                                                      flags))
 end
 
-# TODO: non-fetch 64-bit min/max atomics (hardware support?)
+# 64-bit atomics are currently exposed in Metal as non-fetching min/max modify operations
+# on `atomic_ulong` in device memory.
+for op in (:min, :max)
+    f = Symbol("atomic_$(op)_explicit")
+    @eval begin
+        function $f(ptr::LLVMPtr{UInt64,AS.Device}, desired::UInt64)
+            @typed_ccall($"air.atomic.global.$op.u.i64", llvmcall, Nothing,
+                         (LLVMPtr{UInt64,AS.Device}, UInt64, Int32, Int32, Bool),
+                         ptr, desired, Val(memory_order_relaxed), Val(Int32(2)), Val(true))
+        end
+    end
+end
 
 # generic atomic support using compare-and-swap
 @inline atomic_fetch_op_failure_order(order::Val) = order

--- a/src/device/intrinsics/atomics.jl
+++ b/src/device/intrinsics/atomics.jl
@@ -81,20 +81,37 @@ const atomic_value_intrinsics = (
     (:fetch_and, "and",   (:Int32, :UInt32),           true),
     (:fetch_or,  "or",    (:Int32, :UInt32),           true),
     (:fetch_xor, "xor",   (:Int32, :UInt32),           true),
+    # atomic_ulong only supports non-fetching min/max on device memory.
+    (:min,       "min",   (:UInt64,),                  false),
+    (:max,       "max",   (:UInt64,),                  false),
 )
 
 for (op, air_op, types, returns) in atomic_value_intrinsics, typ in types,
     (as, memnam, scope) in atomic_memory_spaces
-    typnam = typ === :Float32 ? "f32" : "i32"
+    typ === :UInt64 && as !== AS.Device && continue
+    typnam = typ === :Float32 ? "f32" : typ === :UInt64 ? "i64" : "i32"
     if op ∉ (:store, :exchange) && typ !== :Float32
         typnam = "$(typ === :Int32 ? "s" : "u").$typnam"
     end
     f = Symbol("atomic_$(op)_explicit")
     return_type = returns ? typ : :Nothing
-    availability = op ∈ (:fetch_add, :fetch_sub) && typ === :Float32 && as === AS.ThreadGroup ?
-        :(@static_assert(metal_version() >= sv"4.1",
-                          "Float32 threadgroup atomic operations require Metal 4.1 or newer.")) :
+    requirements = if op ∈ (:fetch_add, :fetch_sub) && typ === :Float32 && as === AS.ThreadGroup
+        quote
+            @static_assert(metal_version() >= sv"4.1",
+                           "Float32 threadgroup atomic operations require Metal 4.1 or newer.")
+        end
+    elseif typ === :UInt64
+        quote
+            @static_assert(order === memory_order_relaxed,
+                           "64-bit atomic min/max only supports relaxed ordering.")
+            @static_assert(flags == MemoryFlagNone,
+                           "64-bit atomic min/max does not support memory flags.")
+            @static_assert(apple_family() >= 8,
+                           "64-bit atomic min/max requires Apple8 or newer.")
+        end
+    else
         nothing
+    end
 
     @eval begin
         @inline function $f(
@@ -105,8 +122,8 @@ for (op, air_op, types, returns) in atomic_value_intrinsics, typ in types,
         end
 
         function $f(ptr::LLVMPtr{$typ,$as}, desired::$typ, ::Val{order}, ::Val{flags}) where {order, flags}
+            $requirements
             validate_atomic_arguments(Val(order), Val(flags))
-            $availability
             @typed_ccall($"air.atomic.$memnam.$air_op.$typnam", llvmcall, $return_type,
                          (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Int32, Bool),
                          ptr, desired, Val(order), Val($scope), Val(flags), Val(false))
@@ -161,7 +178,6 @@ function atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{Float32,AS}, expecte
                                                                      flags))
 end
 
-# TODO: non-fetch 64-bit min/max atomics (hardware support?)
 
 # generic atomic support using compare-and-swap
 @inline atomic_fetch_op_failure_order(order::Val) = order
@@ -298,7 +314,9 @@ for (op,impl,typ) in [(:(+), :(atomic_fetch_add_explicit), [:UInt32,:Int32,:Floa
                       (:(|), :(atomic_fetch_or_explicit),  [:UInt32,:Int32]),
                       (:(⊻), :(atomic_fetch_xor_explicit), [:UInt32,:Int32]),
                       (:max, :(atomic_fetch_max_explicit), [:UInt32,:Int32]),
-                      (:min, :(atomic_fetch_min_explicit), [:UInt32,:Int32])]
+                      (:min, :(atomic_fetch_min_explicit), [:UInt32,:Int32]),
+                      (:max, :(atomic_max_explicit),       [:UInt64]),
+                      (:min, :(atomic_min_explicit),       [:UInt64])]
     @eval @inline atomic_arrayset(A::AbstractArray{T}, I::Integer, ::typeof($op),
                                   val::T) where {T<:Union{$(typ...)}} =
         $impl(pointer(A, I), val)

--- a/src/device/intrinsics/version.jl
+++ b/src/device/intrinsics/version.jl
@@ -1,8 +1,8 @@
-## accessors for the Metal and AIR version
+## accessors for the Metal and AIR version, and the targeted GPU family
 
-export metal_version, air_version, @sv_str
+export metal_version, air_version, apple_family, @sv_str
 
-for var in ["metal_major", "metal_minor", "air_major", "air_minor"]
+for var in ["metal_major", "metal_minor", "air_major", "air_minor", "apple_family"]
     @eval @device_function @inline $(Symbol(var))() =
         Base.llvmcall(
             $("""@$var = external global i32
@@ -16,3 +16,12 @@ end
 
 @device_function @inline metal_version() = SimpleVersion(metal_major(), metal_minor())
 @device_function @inline air_version() = SimpleVersion(air_major(), air_minor())
+
+"""
+    apple_family()
+
+Return the highest targeted `MTLGPUFamilyApple<n>` as `n`, or `0` if the device reports no
+Apple family. Like `metal_version()`, this is a compile-time constant and can guard
+family-specific device code.
+"""
+apple_family

--- a/test/device/intrinsics/atomics.jl
+++ b/test/device/intrinsics/atomics.jl
@@ -417,6 +417,40 @@ n = 128 # NOTE: also hard-coded in MtlThreadGroupArray constructors
         @metal guarded_ordered_fetch_kernel(a)
         @test Array(a) == Int32[Metal.metal_target() >= v"4.1" ? 2 : 1]
     end
+
+    @testset "64-bit modify (min/max)" begin
+        function max_kernel(a, val)
+            i = thread_position_in_grid().x
+            Metal.atomic_max_explicit(pointer(a, i), val)
+            return
+        end
+
+        function min_kernel(a, val)
+            i = thread_position_in_grid().x
+            Metal.atomic_min_explicit(pointer(a, i), val)
+            return
+        end
+
+        if MTL.supports_family(device(), MTL.MTLGPUFamilyApple9)
+            a = MtlArray(fill(UInt64(1), n))
+            @metal threads=n max_kernel(a, UInt64(42))
+            @test all(isequal(UInt64(42)), Array(a))
+
+            b = MtlArray(fill(UInt64(100), n))
+            @metal threads=n min_kernel(b, UInt64(42))
+            @test all(isequal(UInt64(42)), Array(b))
+        else
+            a = MtlArray(fill(UInt64(1), n))
+            @test_throws "MTLGPUFamilyApple9" begin
+                kernel = @metal launch=false max_kernel(a, UInt64(42))
+                kernel(a, UInt64(42); threads=n)
+            end
+            @test_throws "MTLGPUFamilyApple9" begin
+                kernel = @metal launch=false min_kernel(a, UInt64(42))
+                kernel(a, UInt64(42); threads=n)
+            end
+        end
+    end
 end
 
 @testset "high-level" begin

--- a/test/device/intrinsics/atomics.jl
+++ b/test/device/intrinsics/atomics.jl
@@ -431,7 +431,7 @@ n = 128 # NOTE: also hard-coded in MtlThreadGroupArray constructors
             return
         end
 
-        if MTL.supports_family(device(), MTL.MTLGPUFamilyApple9)
+        if MTL.supports_family(device(), MTL.MTLGPUFamilyApple8)
             a = MtlArray(fill(UInt64(1), n))
             @metal threads=n max_kernel(a, UInt64(42))
             @test all(isequal(UInt64(42)), Array(a))
@@ -441,11 +441,11 @@ n = 128 # NOTE: also hard-coded in MtlThreadGroupArray constructors
             @test all(isequal(UInt64(42)), Array(b))
         else
             a = MtlArray(fill(UInt64(1), n))
-            @test_throws "MTLGPUFamilyApple9" begin
+            @test_throws "MTLGPUFamilyApple8" begin
                 kernel = @metal launch=false max_kernel(a, UInt64(42))
                 kernel(a, UInt64(42); threads=n)
             end
-            @test_throws "MTLGPUFamilyApple9" begin
+            @test_throws "MTLGPUFamilyApple8" begin
                 kernel = @metal launch=false min_kernel(a, UInt64(42))
                 kernel(a, UInt64(42); threads=n)
             end

--- a/test/device/intrinsics/atomics.jl
+++ b/test/device/intrinsics/atomics.jl
@@ -417,6 +417,104 @@ n = 128 # NOTE: also hard-coded in MtlThreadGroupArray constructors
         @metal guarded_ordered_fetch_kernel(a)
         @test Array(a) == Int32[Metal.metal_target() >= v"4.1" ? 2 : 1]
     end
+
+    @testset "64-bit modify (min/max)" begin
+        function modify_kernel(f, a, val)
+            i = thread_position_in_grid().x
+            f(pointer(a, i), val)
+            return
+        end
+        modify_ops = ((Metal.atomic_max_explicit, UInt64(1)),
+                      (Metal.atomic_min_explicit, UInt64(100)))
+
+        # AIR 2.9 added the flags operand; Metal 4.1 made atomic pointers non-volatile.
+        function u64_abi(ptr::Core.LLVMPtr{UInt64,Metal.AS.Device})
+            Metal.atomic_max_explicit(ptr, UInt64(1))
+            return
+        end
+        function u64_ordered(a)
+            Metal.atomic_max_explicit(pointer(a, 1), UInt64(1),
+                                      Metal.memory_order_release)
+            return
+        end
+        function u64_flagged(a)
+            Metal.atomic_max_explicit(pointer(a, 1), UInt64(1),
+                                      Metal.memory_order_relaxed, Metal.MemoryFlagDevice)
+            return
+        end
+        u64_tt = Tuple{Core.LLVMPtr{UInt64,Metal.AS.Device}}
+        u64_ir = sprint(io -> Metal.code_llvm(io, u64_abi, u64_tt; kernel=true,
+                                              gpufamily=MTL.MTLGPUFamilyApple8,
+                                              metal=v"4.1", air=v"2.9", dump_module=true))
+        u64_volatile_ir = sprint(io -> Metal.code_llvm(io, u64_abi, u64_tt; kernel=true,
+                                                       gpufamily=MTL.MTLGPUFamilyApple8,
+                                                       metal=v"4.0", air=v"2.9", dump_module=true))
+        u64_legacy_ir = sprint(io -> Metal.code_llvm(io, u64_abi, u64_tt; kernel=true,
+                                                     gpufamily=MTL.MTLGPUFamilyApple8,
+                                                     metal=v"4.0", air=v"2.8", dump_module=true))
+        u64_ptr = raw"(?:ptr addrspace\(1\)|i64 addrspace\(1\)\*)"
+        u64_abi_pattern = Regex(raw"@air\.atomic\.global\.max\.u\.i64\(" * u64_ptr *
+                                raw", i64, i32, i32, i32, i1\)")
+        u64_legacy_pattern = Regex(raw"@air\.atomic\.global\.max\.u\.i64\(" * u64_ptr *
+                                   raw", i64, i32, i32, i1\)")
+        @test occursin(u64_abi_pattern, u64_ir)
+        @test occursin("i32 0, i32 2, i32 0, i1 false", u64_ir)
+        @test occursin(u64_abi_pattern, u64_volatile_ir)
+        @test occursin("i32 0, i32 2, i32 0, i1 true", u64_volatile_ir)
+        @test occursin(u64_legacy_pattern, u64_legacy_ir)
+        @test occursin("i32 0, i32 2, i1 true", u64_legacy_ir)
+
+        a = Metal.zeros(UInt64, 1)
+        for (f, message) in (
+            (u64_ordered, "64-bit atomic min/max only supports relaxed ordering."),
+            (u64_flagged, "64-bit atomic min/max does not support memory flags."),
+        )
+            err = try
+                @metal launch=false gpufamily=MTL.MTLGPUFamilyApple8 metal=v"4.1" air=v"2.9" f(a)
+                nothing
+            catch err
+                err
+            end
+            @test err isa Metal.InvalidIRError
+            @test occursin(message, sprint(showerror, err))
+        end
+
+        for (f, init) in modify_ops
+            a = MtlArray(fill(init, n))
+            if MTL.supports_family(device(), MTL.MTLGPUFamilyApple8)
+                @metal threads=n modify_kernel(f, a, UInt64(42))
+                @test all(isequal(UInt64(42)), Array(a))
+            end
+
+            # the intrinsic statically asserts the targeted family, which can be overridden
+            err = try
+                @metal launch=false gpufamily=MTL.MTLGPUFamilyApple7 modify_kernel(f, a, UInt64(42))
+                nothing
+            catch err
+                err
+            end
+            @test err isa Metal.InvalidIRError
+            @test occursin("64-bit atomic min/max requires Apple8 or newer.",
+                           sprint(showerror, err))
+        end
+
+        # device code can guard on the family itself
+        function guarded_max_kernel(a, val)
+            i = thread_position_in_grid().x
+            if Metal.apple_family() >= 8
+                Metal.atomic_max_explicit(pointer(a, i), val)
+            else
+                a[i] = val
+            end
+            return
+        end
+        a = MtlArray(fill(UInt64(1), n))
+        @metal threads=n guarded_max_kernel(a, UInt64(42))
+        @test all(isequal(UInt64(42)), Array(a))
+        b = MtlArray(fill(UInt64(1), n))
+        @metal threads=n gpufamily=MTL.MTLGPUFamilyApple7 guarded_max_kernel(b, UInt64(42))
+        @test all(isequal(UInt64(42)), Array(b))
+    end
 end
 
 @testset "high-level" begin
@@ -472,6 +570,49 @@ end
         a = MtlArray(T[2n])
         @metal threads=n kernel(a)
         @test Array(a)[1] == 0
+    end
+
+    @testset "max $T" for T in [Int32, UInt32, UInt64]
+        function kernel(a)
+            i = thread_position_in_grid().x
+            Metal.@atomic a[1] = max(a[1], eltype(a)(i))
+            return
+        end
+
+        a = Metal.zeros(T)
+        if T !== UInt64 || MTL.supports_family(device(), MTL.MTLGPUFamilyApple8)
+            @metal threads=n kernel(a)
+            @test Array(a)[1] == n
+        end
+
+        if T === UInt64
+            # the 64-bit operation should be native, not the compare-and-swap fallback
+            ir = sprint(io -> Metal.code_llvm(
+                io, kernel, Tuple{typeof(Metal.mtlconvert(a))};
+                kernel=true, gpufamily=MTL.MTLGPUFamilyApple8))
+            @test occursin("air.atomic.global.max.u.i64", ir)
+        end
+    end
+
+    @testset "min $T" for T in [Int32, UInt32, UInt64]
+        function kernel(a)
+            i = thread_position_in_grid().x
+            Metal.@atomic a[1] = min(a[1], eltype(a)(i))
+            return
+        end
+
+        a = MtlArray(T[n+1])
+        if T !== UInt64 || MTL.supports_family(device(), MTL.MTLGPUFamilyApple8)
+            @metal threads=n kernel(a)
+            @test Array(a)[1] == 1
+        end
+
+        if T === UInt64
+            ir = sprint(io -> Metal.code_llvm(
+                io, kernel, Tuple{typeof(Metal.mtlconvert(a))};
+                kernel=true, gpufamily=MTL.MTLGPUFamilyApple8))
+            @test occursin("air.atomic.global.min.u.i64", ir)
+        end
     end
 end
 

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -138,6 +138,11 @@ end
 
     # set macOS, AIR, and Metal versions
     let
+        @test_throws ArgumentError Metal.compiler_config(
+            device(); gpufamily=MTL.MTLGPUFamilyMetal3)
+        @test Metal.compiler_config(
+            device(); gpufamily=MTL.MTLGPUFamilyApple7).params.apple_family == 7
+
         @test occursin("""!{!"Metal", i32 3, i32 2, i32 1}""",
                        sprint(io->Metal.code_llvm(io, dummy, Tuple{}; metal=v"3.2.1",
                                                       dump_module=true, kernel=true)))


### PR DESCRIPTION
Implement device-side / for  by wiring Metal AIR i64 atomics, add compilation-time GPU family gating for Apple9+, and cover both supported and unsupported hardware paths in atomics tests.

fixes #477

Assisted by: Copilot
