### PR TITLE
Add ordered atomics

### DIFF
--- a/src/MetalKernels.jl
+++ b/src/MetalKernels.jl
@@ -33,7 +33,7 @@ KA.synchronize(::MetalBackend) = synchronize()
 KA.functional(::MetalBackend) = Metal.functional()
 
 KA.supports_float64(::MetalBackend) = false
-KA.supports_atomics(::MetalBackend) = false
+KA.supports_atomics(::MetalBackend) = true
 KA.supports_unified(::MetalBackend) = true
 
 Adapt.adapt_storage(::MetalBackend, a::Array) = Adapt.adapt(MtlArray, a)

--- a/src/MetalKernels.jl
+++ b/src/MetalKernels.jl
@@ -33,7 +33,7 @@ KA.synchronize(::MetalBackend) = synchronize()
 KA.functional(::MetalBackend) = Metal.functional()
 
 KA.supports_float64(::MetalBackend) = false
-KA.supports_atomics(::MetalBackend) = true
+KA.supports_atomics(::MetalBackend) = metal_support() >= v"4.1"
 KA.supports_unified(::MetalBackend) = true
 
 Adapt.adapt_storage(::MetalBackend, a::Array) = Adapt.adapt(MtlArray, a)

--- a/src/device/intrinsics/atomics.jl
+++ b/src/device/intrinsics/atomics.jl
@@ -1,37 +1,5 @@
 # Atomic Functions
 
-@enum memory_order::Int32 begin
-    memory_order_relaxed = 0
-    memory_order_acquire = 2
-    memory_order_release = 3
-    memory_order_acq_rel = 4
-    memory_order_seq_cst = 5
-end
-
-# Ordered atomics are only available in newer Metal language versions. Keep this
-# check in device code so target constants can propagate and an enclosing
-# `metal_version()` guard can eliminate an otherwise unsupported operation.
-@inline function check_memory_order(::Val{order}) where {order}
-    if order === memory_order_relaxed
-        return
-    elseif order === memory_order_seq_cst
-        @static_assert(metal_version() >= sv"4.0",
-                       "Atomic memory_order_seq_cst requires Metal 4.0 or newer.")
-    elseif order === memory_order_acquire
-        @static_assert(metal_version() >= sv"4.1",
-                       "Atomic memory_order_acquire requires Metal 4.1 or newer.")
-    elseif order === memory_order_release
-        @static_assert(metal_version() >= sv"4.1",
-                       "Atomic memory_order_release requires Metal 4.1 or newer.")
-    elseif order === memory_order_acq_rel
-        @static_assert(metal_version() >= sv"4.1",
-                       "Atomic memory_order_acq_rel requires Metal 4.1 or newer.")
-    else
-        @static_assert(false, "Invalid atomic memory ordering.")
-    end
-    return
-end
-
 # XXX: the integers should come from some enum
 const atomic_memory_names = Dict(
     AS.Device      => ("global", Int32(2)),
@@ -51,6 +19,7 @@ const atomic_type_names = Dict(
 for typ in (:Int32, :UInt32), as in (AS.Device, AS.ThreadGroup)
     typnam = atomic_type_names[typ]
     memnam, memid = atomic_memory_names[as]
+    default_flags = as === AS.Device ? MemoryFlagDevice : MemoryFlagThreadGroup
 
     @eval begin
         @inline atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ) =
@@ -58,33 +27,65 @@ for typ in (:Int32, :UInt32), as in (AS.Device, AS.ThreadGroup)
         @inline atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
                                       order::memory_order) =
             atomic_store_explicit(ptr, desired, Val(order))
+        @inline atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                                      order::Val{memory_order_relaxed}) =
+            atomic_store_relaxed(ptr, desired)
+        @inline atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                                      order::Val) =
+            atomic_store_explicit(ptr, desired, order, Val($default_flags))
+        @inline atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                                      order::memory_order,
+                                      flags::Union{MemoryFlags,UInt32}) =
+            atomic_store_explicit(ptr, desired, Val(order), Val(flags))
+
+        function atomic_store_relaxed(ptr::LLVMPtr{$typ,$as}, desired::$typ)
+            @typed_ccall($"air.atomic.$memnam.store.$typnam", llvmcall, Nothing,
+                         (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Bool),
+                         ptr, desired, Val(memory_order_relaxed), Val($memid), Val(true))
+        end
 
         function atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
-                                       order::Val{O}) where {O}
+                                       order::Val{O}, flags::Val{F}) where {O,F}
             if !(O in (memory_order_relaxed, memory_order_release, memory_order_seq_cst))
                 @static_assert(false,
                                "atomic_store_explicit only supports relaxed, release, or sequentially consistent ordering.")
             end
-            check_memory_order(order)
+            check_atomic_memory_order(order)
+            check_atomic_flags()
             @typed_ccall($"air.atomic.$memnam.store.$typnam", llvmcall, Nothing,
-                         (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Bool),
-                         ptr, desired, order, Val($memid), Val(true))
+                         (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Int32, Bool),
+                         ptr, desired, order, Val($memid), flags, Val(false))
         end
 
         @inline atomic_load_explicit(ptr::LLVMPtr{$typ,$as}) =
             atomic_load_explicit(ptr, Val(memory_order_relaxed))
         @inline atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, order::memory_order) =
             atomic_load_explicit(ptr, Val(order))
+        @inline atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, order::Val{memory_order_relaxed}) =
+            atomic_load_relaxed(ptr)
+        @inline atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, order::Val) =
+            atomic_load_explicit(ptr, order, Val($default_flags))
+        @inline atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, order::memory_order,
+                                     flags::Union{MemoryFlags,UInt32}) =
+            atomic_load_explicit(ptr, Val(order), Val(flags))
 
-        function atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, order::Val{O}) where {O}
+        function atomic_load_relaxed(ptr::LLVMPtr{$typ,$as})
+            @typed_ccall($"air.atomic.$memnam.load.$typnam", llvmcall, $typ,
+                         (LLVMPtr{$typ,$as}, Int32, Int32, Bool),
+                         ptr, Val(memory_order_relaxed), Val($memid), Val(true))
+        end
+
+        function atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, order::Val{O},
+                                      flags::Val{F}) where {O,F}
             if !(O in (memory_order_relaxed, memory_order_acquire, memory_order_seq_cst))
                 @static_assert(false,
                                "atomic_load_explicit only supports relaxed, acquire, or sequentially consistent ordering.")
             end
-            check_memory_order(order)
+            check_atomic_memory_order(order)
+            check_atomic_flags()
             @typed_ccall($"air.atomic.$memnam.load.$typnam", llvmcall, $typ,
-                         (LLVMPtr{$typ,$as}, Int32, Int32, Bool),
-                         ptr, order, Val($memid), Val(true))
+                         (LLVMPtr{$typ,$as}, Int32, Int32, Int32, Bool),
+                         ptr, order, Val($memid), flags, Val(false))
         end
 
         @inline atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ) =
@@ -92,13 +93,30 @@ for typ in (:Int32, :UInt32), as in (AS.Device, AS.ThreadGroup)
         @inline atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
                                          order::memory_order) =
             atomic_exchange_explicit(ptr, desired, Val(order))
+        @inline atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                                         order::Val{memory_order_relaxed}) =
+            atomic_exchange_relaxed(ptr, desired)
+        @inline atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                                         order::Val) =
+            atomic_exchange_explicit(ptr, desired, order, Val($default_flags))
+        @inline atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                                         order::memory_order,
+                                         flags::Union{MemoryFlags,UInt32}) =
+            atomic_exchange_explicit(ptr, desired, Val(order), Val(flags))
 
-        function atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
-                                          order::Val)
-            check_memory_order(order)
+        function atomic_exchange_relaxed(ptr::LLVMPtr{$typ,$as}, desired::$typ)
             @typed_ccall($"air.atomic.$memnam.xchg.$typnam", llvmcall, $typ,
                          (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Bool),
-                         ptr, desired, order, Val($memid), Val(true))
+                         ptr, desired, Val(memory_order_relaxed), Val($memid), Val(true))
+        end
+
+        function atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                                          order::Val{O}, flags::Val{F}) where {O,F}
+            check_atomic_memory_order(order)
+            check_atomic_flags()
+            @typed_ccall($"air.atomic.$memnam.xchg.$typnam", llvmcall, $typ,
+                         (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Int32, Bool),
+                         ptr, desired, order, Val($memid), flags, Val(false))
         end
 
         @inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
@@ -113,11 +131,40 @@ for typ in (:Int32, :UInt32), as in (AS.Device, AS.ThreadGroup)
             atomic_compare_exchange_weak_explicit(ptr, expected, desired,
                                                   Val(success_order),
                                                   Val(failure_order))
+        @inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
+                                                      expected::$typ, desired::$typ,
+                                                      success_order::Val{memory_order_relaxed},
+                                                      failure_order::Val{memory_order_relaxed}) =
+            atomic_compare_exchange_weak_relaxed(ptr, expected, desired)
+        @inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
+                                                      expected::$typ, desired::$typ,
+                                                      success_order::Val,
+                                                      failure_order::Val) =
+            atomic_compare_exchange_weak_explicit(ptr, expected, desired, success_order,
+                                                  failure_order, Val($default_flags))
+        @inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
+                                                      expected::$typ, desired::$typ,
+                                                      success_order::memory_order,
+                                                      failure_order::memory_order,
+                                                      flags::Union{MemoryFlags,UInt32}) =
+            atomic_compare_exchange_weak_explicit(ptr, expected, desired, Val(success_order),
+                                                  Val(failure_order), Val(flags))
+
+        function atomic_compare_exchange_weak_relaxed(ptr::LLVMPtr{$typ,$as},
+                                                       expected::$typ, desired::$typ)
+            expected_box = Ref(expected)
+            @typed_ccall($"air.atomic.$memnam.cmpxchg.weak.$typnam", llvmcall, $typ,
+                         (LLVMPtr{$typ,$as}, Ptr{$typ}, $typ, Int32, Int32, Int32, Bool),
+                         ptr, expected_box, desired, Val(memory_order_relaxed),
+                         Val(memory_order_relaxed),
+                         Val($memid), Val(true))
+            expected_box[]
+        end
 
         function atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
                                                        expected::$typ, desired::$typ,
-                                                       success_order::Val{S},
-                                                       failure_order::Val{F}) where {S,F}
+                                                       success_order::Val{S}, failure_order::Val{F},
+                                                       flags::Val{G}) where {S,F,G}
             if !(F in (memory_order_relaxed, memory_order_acquire, memory_order_seq_cst)) ||
                (S === memory_order_relaxed && F !== memory_order_relaxed) ||
                (S === memory_order_acquire && F === memory_order_seq_cst) ||
@@ -126,16 +173,17 @@ for typ in (:Int32, :UInt32), as in (AS.Device, AS.ThreadGroup)
                 @static_assert(false,
                                "atomic_compare_exchange_weak_explicit failure ordering must be relaxed, acquire, or sequentially consistent and no stronger than the success ordering.")
             end
-            check_memory_order(success_order)
-            check_memory_order(failure_order)
+            check_atomic_memory_order(success_order)
+            check_atomic_memory_order(failure_order)
+            check_atomic_flags()
             # NOTE: we deviate slightly from the Metal/C++ API here, not returning the
             #       status boolean, but the contents of the expected value box, which will
             #       have been changed to the current value if the exchange failed.
             expected_box = Ref(expected)
             @typed_ccall($"air.atomic.$memnam.cmpxchg.weak.$typnam", llvmcall, $typ,
-                         (LLVMPtr{$typ,$as}, Ptr{$typ}, $typ, Int32, Int32, Int32, Bool),
+                         (LLVMPtr{$typ,$as}, Ptr{$typ}, $typ, Int32, Int32, Int32, Int32, Bool),
                          ptr, expected_box, desired, success_order,
-                         failure_order, Val($memid), Val(true))
+                         failure_order, Val($memid), flags, Val(false))
             expected_box[]
         end
     end
@@ -149,24 +197,46 @@ end
                               order::memory_order) where {AS} =
     atomic_store_explicit(ptr, desired, Val(order))
 @inline atomic_store_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
+                              order::memory_order,
+                              flags::Union{MemoryFlags,UInt32}) where {AS} =
+    atomic_store_explicit(ptr, desired, Val(order), Val(flags))
+@inline atomic_store_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
                               order::Val) where {AS} =
     atomic_store_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr),
                           reinterpret(UInt32, desired), order)
+@inline atomic_store_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
+                              order::Val, flags::Val) where {AS} =
+    atomic_store_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr),
+                          reinterpret(UInt32, desired), order, flags)
 @inline atomic_load_explicit(ptr::LLVMPtr{Float32,AS}) where {AS} =
     atomic_load_explicit(ptr, Val(memory_order_relaxed))
 @inline atomic_load_explicit(ptr::LLVMPtr{Float32,AS}, order::memory_order) where {AS} =
     atomic_load_explicit(ptr, Val(order))
+@inline atomic_load_explicit(ptr::LLVMPtr{Float32,AS}, order::memory_order,
+                             flags::Union{MemoryFlags,UInt32}) where {AS} =
+    atomic_load_explicit(ptr, Val(order), Val(flags))
 @inline atomic_load_explicit(ptr::LLVMPtr{Float32,AS}, order::Val) where {AS} =
     reinterpret(Float32, atomic_load_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr), order))
+@inline atomic_load_explicit(ptr::LLVMPtr{Float32,AS}, order::Val, flags::Val) where {AS} =
+    reinterpret(Float32,
+                atomic_load_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr), order, flags))
 @inline atomic_exchange_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32) where {AS} =
     atomic_exchange_explicit(ptr, desired, Val(memory_order_relaxed))
 @inline atomic_exchange_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
                                  order::memory_order) where {AS} =
     atomic_exchange_explicit(ptr, desired, Val(order))
 @inline atomic_exchange_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
+                                 order::memory_order,
+                                 flags::Union{MemoryFlags,UInt32}) where {AS} =
+    atomic_exchange_explicit(ptr, desired, Val(order), Val(flags))
+@inline atomic_exchange_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
                                  order::Val) where {AS} =
     reinterpret(Float32, atomic_exchange_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr),
                                                   reinterpret(UInt32, desired), order))
+@inline atomic_exchange_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
+                                 order::Val, flags::Val) where {AS} =
+    reinterpret(Float32, atomic_exchange_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr),
+                                                  reinterpret(UInt32, desired), order, flags))
 @inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{Float32,AS}, expected::Float32,
                                               desired::Float32) where {AS} =
     atomic_compare_exchange_weak_explicit(ptr, expected, desired,
@@ -178,6 +248,13 @@ end
                                               failure_order::memory_order) where {AS} =
     atomic_compare_exchange_weak_explicit(ptr, expected, desired,
                                           Val(success_order), Val(failure_order))
+@inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{Float32,AS}, expected::Float32,
+                                              desired::Float32,
+                                              success_order::memory_order,
+                                              failure_order::memory_order,
+                                              flags::Union{MemoryFlags,UInt32}) where {AS} =
+    atomic_compare_exchange_weak_explicit(ptr, expected, desired,
+                                          Val(success_order), Val(failure_order), Val(flags))
 function atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{Float32,AS}, expected::Float32,
                                                desired::Float32,
                                                success_order::Val,
@@ -187,6 +264,18 @@ function atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{Float32,AS}, expecte
     desired′ = reinterpret(UInt32, desired)
     return reinterpret(Float32, atomic_compare_exchange_weak_explicit(ptr′, expected′, desired′,
                                                                      success_order, failure_order))
+end
+function atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{Float32,AS}, expected::Float32,
+                                               desired::Float32,
+                                               success_order::Val,
+                                               failure_order::Val,
+                                               flags::Val) where {AS}
+    ptr′ = reinterpret(LLVMPtr{UInt32,AS}, ptr)
+    expected′ = reinterpret(UInt32, expected)
+    desired′ = reinterpret(UInt32, desired)
+    return reinterpret(Float32, atomic_compare_exchange_weak_explicit(ptr′, expected′, desired′,
+                                                                     success_order, failure_order,
+                                                                     flags))
 end
 
 const atomic_fetch_and_modify = [
@@ -207,18 +296,35 @@ for (op, types) in atomic_fetch_and_modify, typ in types, as in (AS.Device, AS.T
         typnam = "u.$typnam"
     end
     memnam, memid = atomic_memory_names[as]
+    default_flags = as === AS.Device ? MemoryFlagDevice : MemoryFlagThreadGroup
     f = Symbol("atomic_fetch_$(op)_explicit")
+    relaxed_f = Symbol("atomic_fetch_$(op)_relaxed")
     @eval begin
         @inline $f(ptr::LLVMPtr{$typ,$as}, desired::$typ) =
             $f(ptr, desired, Val(memory_order_relaxed))
         @inline $f(ptr::LLVMPtr{$typ,$as}, desired::$typ, order::memory_order) =
             $f(ptr, desired, Val(order))
+        @inline $f(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                   order::Val{memory_order_relaxed}) =
+            $relaxed_f(ptr, desired)
+        @inline $f(ptr::LLVMPtr{$typ,$as}, desired::$typ, order::Val) =
+            $f(ptr, desired, order, Val($default_flags))
+        @inline $f(ptr::LLVMPtr{$typ,$as}, desired::$typ, order::memory_order,
+                   flags::Union{MemoryFlags,UInt32}) =
+            $f(ptr, desired, Val(order), Val(flags))
 
-        function $f(ptr::LLVMPtr{$typ,$as}, desired::$typ, order::Val)
-            check_memory_order(order)
+        function $relaxed_f(ptr::LLVMPtr{$typ,$as}, desired::$typ)
             @typed_ccall($"air.atomic.$memnam.$op.$typnam", llvmcall, $typ,
                          (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Bool),
-                         ptr, desired, order, Val($memid), Val(true))
+                         ptr, desired, Val(memory_order_relaxed), Val($memid), Val(true))
+        end
+
+        function $f(ptr::LLVMPtr{$typ,$as}, desired::$typ, order::Val, flags::Val)
+            check_atomic_memory_order(order)
+            check_atomic_flags()
+            @typed_ccall($"air.atomic.$memnam.$op.$typnam", llvmcall, $typ,
+                         (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Int32, Bool),
+                         ptr, desired, order, Val($memid), flags, Val(false))
         end
     end
 end
@@ -235,6 +341,10 @@ end
 @inline atomic_fetch_op_explicit(ptr::LLVMPtr{T}, op::Function, val,
                                  order::memory_order) where {T} =
     atomic_fetch_op_explicit(ptr, op, val, Val(order))
+@inline atomic_fetch_op_explicit(ptr::LLVMPtr{T}, op::Function, val,
+                                 order::memory_order,
+                                 flags::Union{MemoryFlags,UInt32}) where {T} =
+    atomic_fetch_op_explicit(ptr, op, val, Val(order), Val(flags))
 
 @inline function atomic_fetch_op_explicit(ptr::LLVMPtr{T}, op::Function, val,
                                           order::Val) where {T}
@@ -244,6 +354,19 @@ end
         cmp = old
         new = convert(T, op(old, val))
         old = atomic_compare_exchange_weak_explicit(ptr, cmp, new, order, failure_order)
+        isequal(old, cmp) && return old
+    end
+end
+
+@inline function atomic_fetch_op_explicit(ptr::LLVMPtr{T}, op::Function, val,
+                                          order::Val, flags::Val) where {T}
+    failure_order = atomic_fetch_op_failure_order(order)
+    old = atomic_load_explicit(ptr, failure_order, flags)
+    while true
+        cmp = old
+        new = convert(T, op(old, val))
+        old = atomic_compare_exchange_weak_explicit(ptr, cmp, new, order, failure_order,
+                                                    flags)
         isequal(old, cmp) && return old
     end
 end

--- a/src/device/intrinsics/atomics.jl
+++ b/src/device/intrinsics/atomics.jl
@@ -1,5 +1,13 @@
 # Atomic Functions
 
+@enum memory_order::Int32 begin
+    memory_order_relaxed = 0
+    memory_order_acquire = 2
+    memory_order_release = 3
+    memory_order_acq_rel = 4
+    memory_order_seq_cst = 5
+end
+
 # XXX: the integers should come from some enum
 const atomic_memory_names = Dict(
     AS.Device      => ("global", Int32(2)),
@@ -21,34 +29,68 @@ for typ in (:Int32, :UInt32), as in (AS.Device, AS.ThreadGroup)
     memnam, memid = atomic_memory_names[as]
 
     @eval begin
-        function atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ)
+        @inline atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ) =
+            atomic_store_explicit(ptr, desired, Val(memory_order_relaxed))
+        @inline atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                                      order::memory_order) =
+            atomic_store_explicit(ptr, desired, Val(order))
+
+        function atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                                       order::Val)
             @typed_ccall($"air.atomic.$memnam.store.$typnam", llvmcall, Nothing,
                          (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Bool),
-                         ptr, desired, Val(memory_order_relaxed), Val($memid), Val(true))
+                         ptr, desired, order, Val($memid), Val(true))
         end
 
-        function atomic_load_explicit(ptr::LLVMPtr{$typ,$as})
+        @inline atomic_load_explicit(ptr::LLVMPtr{$typ,$as}) =
+            atomic_load_explicit(ptr, Val(memory_order_relaxed))
+        @inline atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, order::memory_order) =
+            atomic_load_explicit(ptr, Val(order))
+
+        function atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, order::Val)
             @typed_ccall($"air.atomic.$memnam.load.$typnam", llvmcall, $typ,
                          (LLVMPtr{$typ,$as}, Int32, Int32, Bool),
-                         ptr, Val(memory_order_relaxed), Val($memid), Val(true))
+                         ptr, order, Val($memid), Val(true))
         end
 
-        function atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ)
+        @inline atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ) =
+            atomic_exchange_explicit(ptr, desired, Val(memory_order_relaxed))
+        @inline atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                                         order::memory_order) =
+            atomic_exchange_explicit(ptr, desired, Val(order))
+
+        function atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                                          order::Val)
             @typed_ccall($"air.atomic.$memnam.xchg.$typnam", llvmcall, $typ,
                          (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Bool),
-                         ptr, desired, Val(memory_order_relaxed), Val($memid), Val(true))
+                         ptr, desired, order, Val($memid), Val(true))
         end
 
+        @inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
+                                                      expected::$typ, desired::$typ) =
+            atomic_compare_exchange_weak_explicit(ptr, expected, desired,
+                                                  Val(memory_order_relaxed),
+                                                  Val(memory_order_relaxed))
+        @inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
+                                                      expected::$typ, desired::$typ,
+                                                      success_order::memory_order,
+                                                      failure_order::memory_order) =
+            atomic_compare_exchange_weak_explicit(ptr, expected, desired,
+                                                  Val(success_order),
+                                                  Val(failure_order))
+
         function atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
-                                                       expected::$typ, desired::$typ)
+                                                       expected::$typ, desired::$typ,
+                                                       success_order::Val,
+                                                       failure_order::Val)
             # NOTE: we deviate slightly from the Metal/C++ API here, not returning the
             #       status boolean, but the contents of the expected value box, which will
             #       have been changed to the current value if the exchange failed.
             expected_box = Ref(expected)
             @typed_ccall($"air.atomic.$memnam.cmpxchg.weak.$typnam", llvmcall, $typ,
                          (LLVMPtr{$typ,$as}, Ptr{$typ}, $typ, Int32, Int32, Int32, Bool),
-                         ptr, expected_box, desired, Val(memory_order_relaxed),
-                         Val(memory_order_relaxed), Val($memid), Val(true))
+                         ptr, expected_box, desired, success_order,
+                         failure_order, Val($memid), Val(true))
             expected_box[]
         end
     end
@@ -56,19 +98,50 @@ end
 
 # Float32 atomics are only available on Metal 3.0, and additionally only for
 # device memory, so we just skip them and reinterpret. That should be safe?
-atomic_store_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32) where {AS} =
-    atomic_store_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr), reinterpret(UInt32, desired))
-atomic_load_explicit(ptr::LLVMPtr{Float32,AS}) where {AS} =
-    reinterpret(Float32, atomic_load_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr)))
-atomic_exchange_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32) where {AS} =
+@inline atomic_store_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32) where {AS} =
+    atomic_store_explicit(ptr, desired, Val(memory_order_relaxed))
+@inline atomic_store_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
+                              order::memory_order) where {AS} =
+    atomic_store_explicit(ptr, desired, Val(order))
+@inline atomic_store_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
+                              order::Val) where {AS} =
+    atomic_store_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr),
+                          reinterpret(UInt32, desired), order)
+@inline atomic_load_explicit(ptr::LLVMPtr{Float32,AS}) where {AS} =
+    atomic_load_explicit(ptr, Val(memory_order_relaxed))
+@inline atomic_load_explicit(ptr::LLVMPtr{Float32,AS}, order::memory_order) where {AS} =
+    atomic_load_explicit(ptr, Val(order))
+@inline atomic_load_explicit(ptr::LLVMPtr{Float32,AS}, order::Val) where {AS} =
+    reinterpret(Float32, atomic_load_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr), order))
+@inline atomic_exchange_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32) where {AS} =
+    atomic_exchange_explicit(ptr, desired, Val(memory_order_relaxed))
+@inline atomic_exchange_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
+                                 order::memory_order) where {AS} =
+    atomic_exchange_explicit(ptr, desired, Val(order))
+@inline atomic_exchange_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
+                                 order::Val) where {AS} =
     reinterpret(Float32, atomic_exchange_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr),
-                                                  reinterpret(UInt32, desired)))
+                                                  reinterpret(UInt32, desired), order))
+@inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{Float32,AS}, expected::Float32,
+                                              desired::Float32) where {AS} =
+    atomic_compare_exchange_weak_explicit(ptr, expected, desired,
+                                          Val(memory_order_relaxed),
+                                          Val(memory_order_relaxed))
+@inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{Float32,AS}, expected::Float32,
+                                              desired::Float32,
+                                              success_order::memory_order,
+                                              failure_order::memory_order) where {AS} =
+    atomic_compare_exchange_weak_explicit(ptr, expected, desired,
+                                          Val(success_order), Val(failure_order))
 function atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{Float32,AS}, expected::Float32,
-                                               desired::Float32) where {AS}
+                                               desired::Float32,
+                                               success_order::Val,
+                                               failure_order::Val) where {AS}
     ptr′ = reinterpret(LLVMPtr{UInt32,AS}, ptr)
     expected′ = reinterpret(UInt32, expected)
     desired′ = reinterpret(UInt32, desired)
-    return reinterpret(Float32, atomic_compare_exchange_weak_explicit(ptr′, expected′, desired′))
+    return reinterpret(Float32, atomic_compare_exchange_weak_explicit(ptr′, expected′, desired′,
+                                                                     success_order, failure_order))
 end
 
 const atomic_fetch_and_modify = [
@@ -91,10 +164,15 @@ for (op, types) in atomic_fetch_and_modify, typ in types, as in (AS.Device, AS.T
     memnam, memid = atomic_memory_names[as]
     f = Symbol("atomic_fetch_$(op)_explicit")
     @eval begin
-        function $f(ptr::LLVMPtr{$typ,$as}, desired::$typ)
+        @inline $f(ptr::LLVMPtr{$typ,$as}, desired::$typ) =
+            $f(ptr, desired, Val(memory_order_relaxed))
+        @inline $f(ptr::LLVMPtr{$typ,$as}, desired::$typ, order::memory_order) =
+            $f(ptr, desired, Val(order))
+
+        function $f(ptr::LLVMPtr{$typ,$as}, desired::$typ, order::Val)
             @typed_ccall($"air.atomic.$memnam.$op.$typnam", llvmcall, $typ,
                          (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Bool),
-                         ptr, desired, Val(memory_order_relaxed), Val($memid), Val(true))
+                         ptr, desired, order, Val($memid), Val(true))
         end
     end
 end
@@ -102,12 +180,24 @@ end
 # TODO: non-fetch 64-bit min/max atomics (hardware support?)
 
 # generic atomic support using compare-and-swap
-@inline function atomic_fetch_op_explicit(ptr::LLVMPtr{T}, op::Function, val) where {T}
+@inline atomic_fetch_op_failure_order(order::Val) = order
+@inline atomic_fetch_op_failure_order(::Val{memory_order_release}) = Val(memory_order_relaxed)
+@inline atomic_fetch_op_failure_order(::Val{memory_order_acq_rel}) = Val(memory_order_acquire)
+
+@inline atomic_fetch_op_explicit(ptr::LLVMPtr{T}, op::Function, val) where {T} =
+    atomic_fetch_op_explicit(ptr, op, val, Val(memory_order_relaxed))
+@inline atomic_fetch_op_explicit(ptr::LLVMPtr{T}, op::Function, val,
+                                 order::memory_order) where {T} =
+    atomic_fetch_op_explicit(ptr, op, val, Val(order))
+
+@inline function atomic_fetch_op_explicit(ptr::LLVMPtr{T}, op::Function, val,
+                                          order::Val) where {T}
     old = Base.unsafe_load(ptr)
+    failure_order = atomic_fetch_op_failure_order(order)
     while true
         cmp = old
         new = convert(T, op(old, val))
-        old = atomic_compare_exchange_weak_explicit(ptr, cmp, new)
+        old = atomic_compare_exchange_weak_explicit(ptr, cmp, new, order, failure_order)
         isequal(old, cmp) && return old
     end
 end

--- a/src/device/intrinsics/atomics.jl
+++ b/src/device/intrinsics/atomics.jl
@@ -8,6 +8,30 @@
     memory_order_seq_cst = 5
 end
 
+# Ordered atomics are only available in newer Metal language versions. Keep this
+# check in device code so target constants can propagate and an enclosing
+# `metal_version()` guard can eliminate an otherwise unsupported operation.
+@inline function check_memory_order(::Val{order}) where {order}
+    if order === memory_order_relaxed
+        return
+    elseif order === memory_order_seq_cst
+        @static_assert(metal_version() >= sv"4.0",
+                       "Atomic memory_order_seq_cst requires Metal 4.0 or newer.")
+    elseif order === memory_order_acquire
+        @static_assert(metal_version() >= sv"4.1",
+                       "Atomic memory_order_acquire requires Metal 4.1 or newer.")
+    elseif order === memory_order_release
+        @static_assert(metal_version() >= sv"4.1",
+                       "Atomic memory_order_release requires Metal 4.1 or newer.")
+    elseif order === memory_order_acq_rel
+        @static_assert(metal_version() >= sv"4.1",
+                       "Atomic memory_order_acq_rel requires Metal 4.1 or newer.")
+    else
+        @static_assert(false, "Invalid atomic memory ordering.")
+    end
+    return
+end
+
 # XXX: the integers should come from some enum
 const atomic_memory_names = Dict(
     AS.Device      => ("global", Int32(2)),
@@ -36,7 +60,12 @@ for typ in (:Int32, :UInt32), as in (AS.Device, AS.ThreadGroup)
             atomic_store_explicit(ptr, desired, Val(order))
 
         function atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
-                                       order::Val)
+                                       order::Val{O}) where {O}
+            if !(O in (memory_order_relaxed, memory_order_release, memory_order_seq_cst))
+                @static_assert(false,
+                               "atomic_store_explicit only supports relaxed, release, or sequentially consistent ordering.")
+            end
+            check_memory_order(order)
             @typed_ccall($"air.atomic.$memnam.store.$typnam", llvmcall, Nothing,
                          (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Bool),
                          ptr, desired, order, Val($memid), Val(true))
@@ -47,7 +76,12 @@ for typ in (:Int32, :UInt32), as in (AS.Device, AS.ThreadGroup)
         @inline atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, order::memory_order) =
             atomic_load_explicit(ptr, Val(order))
 
-        function atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, order::Val)
+        function atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, order::Val{O}) where {O}
+            if !(O in (memory_order_relaxed, memory_order_acquire, memory_order_seq_cst))
+                @static_assert(false,
+                               "atomic_load_explicit only supports relaxed, acquire, or sequentially consistent ordering.")
+            end
+            check_memory_order(order)
             @typed_ccall($"air.atomic.$memnam.load.$typnam", llvmcall, $typ,
                          (LLVMPtr{$typ,$as}, Int32, Int32, Bool),
                          ptr, order, Val($memid), Val(true))
@@ -61,6 +95,7 @@ for typ in (:Int32, :UInt32), as in (AS.Device, AS.ThreadGroup)
 
         function atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
                                           order::Val)
+            check_memory_order(order)
             @typed_ccall($"air.atomic.$memnam.xchg.$typnam", llvmcall, $typ,
                          (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Bool),
                          ptr, desired, order, Val($memid), Val(true))
@@ -81,8 +116,18 @@ for typ in (:Int32, :UInt32), as in (AS.Device, AS.ThreadGroup)
 
         function atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
                                                        expected::$typ, desired::$typ,
-                                                       success_order::Val,
-                                                       failure_order::Val)
+                                                       success_order::Val{S},
+                                                       failure_order::Val{F}) where {S,F}
+            if !(F in (memory_order_relaxed, memory_order_acquire, memory_order_seq_cst)) ||
+               (S === memory_order_relaxed && F !== memory_order_relaxed) ||
+               (S === memory_order_acquire && F === memory_order_seq_cst) ||
+               (S === memory_order_release && F !== memory_order_relaxed) ||
+               (S === memory_order_acq_rel && F === memory_order_seq_cst)
+                @static_assert(false,
+                               "atomic_compare_exchange_weak_explicit failure ordering must be relaxed, acquire, or sequentially consistent and no stronger than the success ordering.")
+            end
+            check_memory_order(success_order)
+            check_memory_order(failure_order)
             # NOTE: we deviate slightly from the Metal/C++ API here, not returning the
             #       status boolean, but the contents of the expected value box, which will
             #       have been changed to the current value if the exchange failed.
@@ -170,6 +215,7 @@ for (op, types) in atomic_fetch_and_modify, typ in types, as in (AS.Device, AS.T
             $f(ptr, desired, Val(order))
 
         function $f(ptr::LLVMPtr{$typ,$as}, desired::$typ, order::Val)
+            check_memory_order(order)
             @typed_ccall($"air.atomic.$memnam.$op.$typnam", llvmcall, $typ,
                          (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Bool),
                          ptr, desired, order, Val($memid), Val(true))
@@ -192,8 +238,8 @@ end
 
 @inline function atomic_fetch_op_explicit(ptr::LLVMPtr{T}, op::Function, val,
                                           order::Val) where {T}
-    old = Base.unsafe_load(ptr)
     failure_order = atomic_fetch_op_failure_order(order)
+    old = atomic_load_explicit(ptr, failure_order)
     while true
         cmp = old
         new = convert(T, op(old, val))

--- a/src/device/intrinsics/synchronization.jl
+++ b/src/device/intrinsics/synchronization.jl
@@ -19,6 +19,55 @@ end
     thread_scope_simdgroup = 4
 end
 
+# Keep availability checks in device code so target constants can propagate and
+# enclosing `metal_version()` guards can eliminate unavailable operations.
+@inline function check_atomic_memory_order(::Val{order}) where {order}
+    if order === memory_order_relaxed
+        return
+    elseif order === memory_order_acquire
+        @static_assert(metal_version() >= sv"4.1",
+                       "Atomic memory_order_acquire requires Metal 4.1 or newer.")
+    elseif order === memory_order_release
+        @static_assert(metal_version() >= sv"4.1",
+                       "Atomic memory_order_release requires Metal 4.1 or newer.")
+    elseif order === memory_order_acq_rel
+        @static_assert(metal_version() >= sv"4.1",
+                       "Atomic memory_order_acq_rel requires Metal 4.1 or newer.")
+    elseif order === memory_order_seq_cst
+        @static_assert(metal_version() >= sv"4.1",
+                       "Atomic memory_order_seq_cst requires Metal 4.1 or newer.")
+    else
+        @static_assert(false, "Invalid atomic memory ordering.")
+    end
+    return
+end
+
+@inline function check_atomic_flags()
+    @static_assert(metal_version() >= sv"4.1",
+                   "Atomic memory flags require Metal 4.1 or newer.")
+    return
+end
+
+@inline function check_atomic_thread_fence_order(::Val{order}) where {order}
+    @static_assert(metal_version() >= sv"3.2",
+                   "atomic_thread_fence requires Metal 3.2 or newer.")
+    if order === memory_order_relaxed || order === memory_order_seq_cst
+        return
+    elseif order === memory_order_acquire
+        @static_assert(metal_version() >= sv"4.1",
+                       "atomic_thread_fence memory_order_acquire requires Metal 4.1 or newer.")
+    elseif order === memory_order_release
+        @static_assert(metal_version() >= sv"4.1",
+                       "atomic_thread_fence memory_order_release requires Metal 4.1 or newer.")
+    elseif order === memory_order_acq_rel
+        @static_assert(metal_version() >= sv"4.1",
+                       "atomic_thread_fence memory_order_acq_rel requires Metal 4.1 or newer.")
+    else
+        @static_assert(false, "Invalid atomic memory ordering.")
+    end
+    return
+end
+
 """
     MemoryFlags
 
@@ -62,12 +111,11 @@ end
 
 @device_function @inline function atomic_thread_fence(flags::Val{F}, order::Val{O},
                                                        scope::Val{S}) where {F,O,S}
-    @static_assert(metal_version() >= sv"3.2",
-                   "atomic_thread_fence requires Metal 3.2 or newer.")
-    @static_assert(O isa memory_order, "Invalid atomic memory ordering.")
-    @static_assert(O === memory_order_relaxed || O === memory_order_seq_cst || metal_version() >= sv"4.1",
-                   "Acquire, release, and acquire-release atomic_thread_fence orderings require Metal 4.1 or newer.")
-    @static_assert(S isa thread_scope, "Invalid atomic thread scope.")
+    check_atomic_thread_fence_order(order)
+    if !(S in (thread_scope_thread, thread_scope_threadgroup,
+               thread_scope_device, thread_scope_simdgroup))
+        @static_assert(false, "Invalid atomic thread scope.")
+    end
     @typed_ccall("air.atomic.fence", llvmcall, Nothing, (Int32, Int32, Int32),
                  flags, order, scope)
 end

--- a/src/device/intrinsics/synchronization.jl
+++ b/src/device/intrinsics/synchronization.jl
@@ -112,10 +112,7 @@ end
 @device_function @inline function atomic_thread_fence(flags::Val{F}, order::Val{O},
                                                        scope::Val{S}) where {F,O,S}
     check_atomic_thread_fence_order(order)
-    if !(S in (thread_scope_thread, thread_scope_threadgroup,
-               thread_scope_device, thread_scope_simdgroup))
-        @static_assert(false, "Invalid atomic thread scope.")
-    end
+    @static_assert(S isa thread_scope, "Invalid atomic thread scope.")
     @typed_ccall("air.atomic.fence", llvmcall, Nothing, (Int32, Int32, Int32),
                  flags, order, scope)
 end

--- a/test/device/intrinsics/atomics.jl
+++ b/test/device/intrinsics/atomics.jl
@@ -230,28 +230,39 @@ n = 128 # NOTE: also hard-coded in MtlThreadGroupArray constructors
     end
 
     @testset "explicit ordering arguments" begin
-        function ordered_kernel(a)
-            ptr = pointer(a, 1)
-            Metal.atomic_store_explicit(ptr, Int32(1), Metal.memory_order_release)
-            loaded = Metal.atomic_load_explicit(ptr, Metal.memory_order_acquire)
-            exchanged = Metal.atomic_exchange_explicit(ptr, loaded + Int32(1),
-                                                       Metal.memory_order_acq_rel)
-            added = Metal.atomic_fetch_add_explicit(ptr, exchanged,
-                                                    Metal.memory_order_seq_cst)
-            old = Metal.atomic_compare_exchange_weak_explicit(
-                ptr,
-                added + Int32(1),
-                Int32(42),
-                Metal.memory_order_acq_rel,
-                Metal.memory_order_acquire,
-            )
-            a[2] = old
+        function ordered_fetch_kernel(a, ::Val{ORDER}) where {ORDER}
+            Metal.atomic_fetch_add_explicit(pointer(a, 1), Int32(1), ORDER)
             return
         end
 
-        a = Metal.zeros(Int32, 2)
-        @metal ordered_kernel(a)
-        @test Array(a) == Int32[42, 3]
+        # The enum value is in the kernel signature, so the public enum overload
+        # specializes it to a Val before lowering to AIR.
+        for (order, minimum, message) in (
+            (Metal.memory_order_relaxed, v"3.0", nothing),
+            (Metal.memory_order_seq_cst, v"4.0",
+             "Atomic memory_order_seq_cst requires Metal 4.0 or newer."),
+            (Metal.memory_order_acquire, v"4.1",
+             "Atomic memory_order_acquire requires Metal 4.1 or newer."),
+            (Metal.memory_order_release, v"4.1",
+             "Atomic memory_order_release requires Metal 4.1 or newer."),
+            (Metal.memory_order_acq_rel, v"4.1",
+             "Atomic memory_order_acq_rel requires Metal 4.1 or newer."),
+        )
+            a = Metal.zeros(Int32, 1)
+            if Metal.metal_target() >= minimum
+                @metal ordered_fetch_kernel(a, Val(order))
+                @test Array(a) == Int32[1]
+            else
+                err = try
+                    @metal launch=false ordered_fetch_kernel(a, Val(order))
+                    nothing
+                catch err
+                    err
+                end
+                @test err isa Metal.InvalidIRError
+                @test occursin(message, sprint(showerror, err))
+            end
+        end
     end
 end
 
@@ -356,13 +367,26 @@ end
     mt_child1 = MtlArray(child1)
     mt_parent = MtlArray(parent)
 
-    @metal threads=256 groups=cld(n_leaves, 256) refit_kernel!(
-        values,
-        flags,
-        mt_child0,
-        mt_child1,
-        mt_parent,
-        Int32(n_leaves),
-    )
-    @test Array(values)[1] == UInt32(n_leaves)
+    if Metal.metal_target() >= v"4.1"
+        @metal threads=256 groups=cld(n_leaves, 256) refit_kernel!(
+            values,
+            flags,
+            mt_child0,
+            mt_child1,
+            mt_parent,
+            Int32(n_leaves),
+        )
+        @test Array(values)[1] == UInt32(n_leaves)
+    else
+        err = try
+            @metal launch=false refit_kernel!(values, flags, mt_child0, mt_child1, mt_parent,
+                                              Int32(n_leaves))
+            nothing
+        catch err
+            err
+        end
+        @test err isa Metal.InvalidIRError
+        @test occursin("Atomic memory_order_acq_rel requires Metal 4.1 or newer.",
+                       sprint(showerror, err))
+    end
 end

--- a/test/device/intrinsics/atomics.jl
+++ b/test/device/intrinsics/atomics.jl
@@ -302,11 +302,14 @@ n = 128 # NOTE: also hard-coded in MtlThreadGroupArray constructors
         legacy_ir = sprint(io -> Metal.code_llvm(io, legacy_abi,
                                                   Tuple{Core.LLVMPtr{Int32,Metal.AS.Device}};
                                                   kernel=true, metal=v"4.0", dump_module=true))
-        @test occursin("@air.atomic.global.add.s.i32(ptr addrspace(1), i32, i32, i32, i32, i1)",
-                       ordered_ir)
+        atomic_ptr = raw"(?:ptr addrspace\(1\)|i32 addrspace\(1\)\*)"
+        ordered_abi_pattern = Regex(raw"@air\.atomic\.global\.add\.s\.i32\(" * atomic_ptr *
+                                    raw", i32, i32, i32, i32, i1\)")
+        legacy_abi_pattern = Regex(raw"@air\.atomic\.global\.add\.s\.i32\(" * atomic_ptr *
+                                   raw", i32, i32, i32, i1\)")
+        @test occursin(ordered_abi_pattern, ordered_ir)
         @test occursin("i32 4, i32 2, i32 3, i1 false", ordered_ir)
-        @test occursin("@air.atomic.global.add.s.i32(ptr addrspace(1), i32, i32, i32, i1)",
-                       legacy_ir)
+        @test occursin(legacy_abi_pattern, legacy_ir)
         @test occursin("i32 0, i32 2, i1 true", legacy_ir)
 
         function guarded_ordered_fetch_kernel(a)

--- a/test/device/intrinsics/atomics.jl
+++ b/test/device/intrinsics/atomics.jl
@@ -239,8 +239,8 @@ n = 128 # NOTE: also hard-coded in MtlThreadGroupArray constructors
         # specializes it to a Val before lowering to AIR.
         for (order, minimum, message) in (
             (Metal.memory_order_relaxed, v"3.0", nothing),
-            (Metal.memory_order_seq_cst, v"4.0",
-             "Atomic memory_order_seq_cst requires Metal 4.0 or newer."),
+            (Metal.memory_order_seq_cst, v"4.1",
+             "Atomic memory_order_seq_cst requires Metal 4.1 or newer."),
             (Metal.memory_order_acquire, v"4.1",
              "Atomic memory_order_acquire requires Metal 4.1 or newer."),
             (Metal.memory_order_release, v"4.1",
@@ -263,6 +263,64 @@ n = 128 # NOTE: also hard-coded in MtlThreadGroupArray constructors
                 @test occursin(message, sprint(showerror, err))
             end
         end
+
+        function flagged_fetch_kernel(a, ::Val{ORDER}, ::Val{FLAGS}) where {ORDER,FLAGS}
+            Metal.atomic_fetch_add_explicit(pointer(a, 1), Int32(1), ORDER, FLAGS)
+            return
+        end
+
+        a = Metal.zeros(Int32, 1)
+        if Metal.metal_target() >= v"4.1"
+            @metal flagged_fetch_kernel(a, Val(Metal.memory_order_relaxed),
+                                        Val(Metal.MemoryFlagDevice | Metal.MemoryFlagThreadGroup))
+            @test Array(a) == Int32[1]
+        else
+            err = try
+                @metal launch=false flagged_fetch_kernel(
+                    a, Val(Metal.memory_order_relaxed), Val(Metal.MemoryFlagDevice))
+                nothing
+            catch err
+                err
+            end
+            @test err isa Metal.InvalidIRError
+            @test occursin("Atomic memory flags require Metal 4.1 or newer.",
+                           sprint(showerror, err))
+        end
+
+        function ordered_flags_abi(ptr::Core.LLVMPtr{Int32,Metal.AS.Device})
+            Metal.atomic_fetch_add_explicit(ptr, Int32(1), Metal.memory_order_acq_rel,
+                                            Metal.MemoryFlagDevice | Metal.MemoryFlagThreadGroup)
+            return
+        end
+        function legacy_abi(ptr::Core.LLVMPtr{Int32,Metal.AS.Device})
+            Metal.atomic_fetch_add_explicit(ptr, Int32(1))
+            return
+        end
+        ordered_ir = sprint(io -> Metal.code_llvm(io, ordered_flags_abi,
+                                                   Tuple{Core.LLVMPtr{Int32,Metal.AS.Device}};
+                                                   kernel=true, metal=v"4.1", dump_module=true))
+        legacy_ir = sprint(io -> Metal.code_llvm(io, legacy_abi,
+                                                  Tuple{Core.LLVMPtr{Int32,Metal.AS.Device}};
+                                                  kernel=true, metal=v"4.0", dump_module=true))
+        @test occursin("@air.atomic.global.add.s.i32(ptr addrspace(1), i32, i32, i32, i32, i1)",
+                       ordered_ir)
+        @test occursin("i32 4, i32 2, i32 3, i1 false", ordered_ir)
+        @test occursin("@air.atomic.global.add.s.i32(ptr addrspace(1), i32, i32, i32, i1)",
+                       legacy_ir)
+        @test occursin("i32 0, i32 2, i1 true", legacy_ir)
+
+        function guarded_ordered_fetch_kernel(a)
+            if Metal.metal_version() >= sv"4.1"
+                Metal.atomic_fetch_add_explicit(pointer(a, 1), Int32(1),
+                                                Metal.memory_order_acq_rel,
+                                                Metal.MemoryFlagDevice)
+            end
+            a[1] += 1
+            return
+        end
+        a = Metal.zeros(Int32, 1)
+        @metal guarded_ordered_fetch_kernel(a)
+        @test Array(a) == Int32[Metal.metal_target() >= v"4.1" ? 2 : 1]
     end
 end
 
@@ -347,7 +405,8 @@ end
             parent_node = parent[leaf_node]
             while parent_node != Int32(0)
                 old = Metal.atomic_fetch_add_explicit(pointer(flags, parent_node), UInt32(1),
-                                                      Metal.memory_order_acq_rel)
+                                                      Metal.memory_order_acq_rel,
+                                                      Metal.MemoryFlagDevice)
                 if old + UInt32(1) == UInt32(2)
                     left = child0[parent_node]
                     right = child1[parent_node]

--- a/test/device/intrinsics/atomics.jl
+++ b/test/device/intrinsics/atomics.jl
@@ -228,6 +228,31 @@ n = 128 # NOTE: also hard-coded in MtlThreadGroupArray constructors
             @test f.(a, val) ≈ Array(b)
         end
     end
+
+    @testset "explicit ordering arguments" begin
+        function ordered_kernel(a)
+            ptr = pointer(a, 1)
+            Metal.atomic_store_explicit(ptr, Int32(1), Metal.memory_order_release)
+            loaded = Metal.atomic_load_explicit(ptr, Metal.memory_order_acquire)
+            exchanged = Metal.atomic_exchange_explicit(ptr, loaded + Int32(1),
+                                                       Metal.memory_order_acq_rel)
+            added = Metal.atomic_fetch_add_explicit(ptr, exchanged,
+                                                    Metal.memory_order_seq_cst)
+            old = Metal.atomic_compare_exchange_weak_explicit(
+                ptr,
+                added + Int32(1),
+                Int32(42),
+                Metal.memory_order_acq_rel,
+                Metal.memory_order_acquire,
+            )
+            a[2] = old
+            return
+        end
+
+        a = Metal.zeros(Int32, 2)
+        @metal ordered_kernel(a)
+        @test Array(a) == Int32[42, 3]
+    end
 end
 
 @testset "high-level" begin
@@ -284,4 +309,60 @@ end
         @metal threads=n kernel(a)
         @test Array(a)[1] == 0
     end
+end
+
+@testset "device-memory publish through fetch_add" begin
+    n_leaves = 2048
+    n_nodes = 2n_leaves - 1
+
+    child0 = zeros(Int32, n_nodes)
+    child1 = zeros(Int32, n_nodes)
+    parent = zeros(Int32, n_nodes)
+    for node in 1:n_leaves-1
+        left = 2node
+        right = 2node + 1
+        child0[node] = left
+        child1[node] = right
+        parent[left] = node
+        parent[right] = node
+    end
+
+    function refit_kernel!(values, flags, child0, child1, parent, n_leaves::Int32)
+        leaf = thread_position_in_grid().x
+        if leaf <= n_leaves
+            leaf_node = n_leaves - Int32(1) + leaf
+            values[leaf_node] = UInt32(1)
+
+            parent_node = parent[leaf_node]
+            while parent_node != Int32(0)
+                old = Metal.atomic_fetch_add_explicit(pointer(flags, parent_node), UInt32(1),
+                                                      Metal.memory_order_acq_rel)
+                if old + UInt32(1) == UInt32(2)
+                    left = child0[parent_node]
+                    right = child1[parent_node]
+                    values[parent_node] = values[left] + values[right]
+                    parent_node = parent[parent_node]
+                else
+                    break
+                end
+            end
+        end
+        return
+    end
+
+    values = Metal.zeros(UInt32, n_nodes)
+    flags = Metal.zeros(UInt32, n_leaves - 1)
+    mt_child0 = MtlArray(child0)
+    mt_child1 = MtlArray(child1)
+    mt_parent = MtlArray(parent)
+
+    @metal threads=256 groups=cld(n_leaves, 256) refit_kernel!(
+        values,
+        flags,
+        mt_child0,
+        mt_child1,
+        mt_parent,
+        Int32(n_leaves),
+    )
+    @test Array(values)[1] == UInt32(n_leaves)
 end

--- a/test/device/intrinsics/synchronization.jl
+++ b/test/device/intrinsics/synchronization.jl
@@ -96,6 +96,48 @@
     end
 
     # TODO: simdgroup barrier test
+
+    @testset "atomic thread fence" begin
+        function fence_kernel(buf, ::Val{ORDER}, ::Val{FLAGS}, ::Val{SCOPE}) where {ORDER,FLAGS,SCOPE}
+            Metal.atomic_thread_fence(FLAGS, ORDER, SCOPE)
+            buf[1] += 1
+            return
+        end
+
+        for order in (Metal.memory_order_relaxed, Metal.memory_order_seq_cst)
+            buf = Metal.zeros(Int32, 1)
+            @metal fence_kernel(buf, Val(order),
+                                Val(Metal.MemoryFlagDevice | Metal.MemoryFlagTexture),
+                                Val(Metal.thread_scope_simdgroup))
+            @test Array(buf) == Int32[1]
+        end
+
+        function fence_abi(::Core.LLVMPtr{Int32,Metal.AS.Device})
+            Metal.atomic_thread_fence(Metal.MemoryFlagDevice | Metal.MemoryFlagTexture,
+                                      Metal.memory_order_seq_cst,
+                                      Metal.thread_scope_simdgroup)
+            return
+        end
+        ir = sprint(io -> Metal.code_llvm(io, fence_abi,
+                                           Tuple{Core.LLVMPtr{Int32,Metal.AS.Device}};
+                                           kernel=true, metal=v"3.2", dump_module=true))
+        @test occursin("@air.atomic.fence(i32, i32, i32)", ir)
+        @test occursin("i32 5, i32 5, i32 4", ir)
+
+        function unavailable_fence(buf)
+            Metal.atomic_thread_fence(Metal.MemoryFlagDevice, Metal.memory_order_relaxed)
+            return
+        end
+        err = try
+            @metal launch=false metal=v"3.1" unavailable_fence(Metal.zeros(Int32, 1))
+            nothing
+        catch err
+            err
+        end
+        @test err isa Metal.InvalidIRError
+        @test occursin("atomic_thread_fence requires Metal 3.2 or newer.",
+                       sprint(showerror, err))
+    end
 end
 
 ############################################################################################

--- a/test/kernelabstractions.jl
+++ b/test/kernelabstractions.jl
@@ -1,5 +1,8 @@
 import KernelAbstractions
 using Metal.MetalKernels
+using Test
+
+@test KernelAbstractions.supports_atomics(MetalBackend())
 
 include(joinpath(dirname(pathof(KernelAbstractions)), "..", "test", "testsuite.jl"))
 

--- a/test/kernelabstractions.jl
+++ b/test/kernelabstractions.jl
@@ -1,8 +1,5 @@
 import KernelAbstractions
 using Metal.MetalKernels
-using Test
-
-@test KernelAbstractions.supports_atomics(MetalBackend())
 
 include(joinpath(dirname(pathof(KernelAbstractions)), "..", "test", "testsuite.jl"))
 


### PR DESCRIPTION
Note: I used Codex with GPT5.5 High to implement this feature. For context, my original issue with this problem was about building a correct TLAS on the GPU with RayCore.jl (which failed): https://github.com/JuliaGeometry/Raycore.jl/pull/19

## Summary

This adds explicit memory-order support to Metal’s low-level atomic intrinsics and enables KernelAbstractions atomic support for `MetalBackend`.

Metal atomic operations previously exposed only relaxed ordering through the Julia API. That is fine for counters and reductions, but it is not enough for synchronization patterns where ordinary device-memory writes are published through an atomic operation and then read by another workitem.

Changes:
- Add Metal `memory_order` enum values for relaxed, acquire, release, acq_rel, and seq_cst.
- Add explicit ordering arguments to low-level atomic load/store/exchange/fetch/CAS functions.
- Preserve relaxed defaults for existing direct Metal atomic call sites.
- Add compare-exchange success/failure ordering support.
- Use `Val`-specialized ordering paths so GPU code receives compile-time ordering constants.
- Enable `KernelAbstractions.supports_atomics(::MetalBackend)`.
- Add a regression test for a cross-workitem publish/consume pattern using device-memory writes plus an ordered atomic `fetch_add`.

## Why

KernelAbstractions and Atomix can express atomic operations with acquire/release or sequentially-consistent semantics. Metal needs to receive those requested orderings for synchronization-sensitive GPU algorithms to be correct.

The new regression test models a common bottom-up refit pattern: each workitem writes ordinary device memory, then increments an atomic counter; the second arriving workitem reads both children’s ordinary writes and publishes the parent. This requires the atomic operation to provide ordering, while still allowing relaxed atomics for cases that do not need synchronization.

## Validation

- Metal atomic tests passed.
- Metal KernelAbstractions integration test passed.
- Downstream RayCore TLAS/BLAS Metal repro passed with Atomix orderings wired through to Metal.
- ArchimedLight-derived static TLAS comparison passed: CPU-built/adapted and direct Metal-built TLAS match for nodes, instances, all BLAS buffers, descriptors, and root AABB.