### PR TITLE
Uniformly catch all command-buffer errors

### DIFF
--- a/lib/mps/command_buf.jl
+++ b/lib/mps/command_buf.jl
@@ -35,9 +35,13 @@ end
 export commitAndContinue!
 
 function commitAndContinue!(cmdbuf::MPSCommandBuffer)
+    # `commitAndContinue` replaces `commandBuffer` with a fresh underlying buffer,
+    # so retain and record the submitted one before asking MPS to continue.
+    submitted = cmdbuf.commandBuffer
     hook = MTL.submit_hook[]
-    hook === nothing || hook(cmdbuf.commandBuffer)
+    hook === nothing || hook(submitted)
     @objc [cmdbuf::id{MPSCommandBuffer} commitAndContinue]::Nothing
+    MTL.record_committed!(submitted, pointer(submitted.commandQueue))
 end
 
 function commitAndContinue!(f::Base.Callable, cmdbuf::MPSCommandBuffer)

--- a/lib/mtl/command_buf.jl
+++ b/lib/mtl/command_buf.jl
@@ -95,11 +95,10 @@ end
 
 mutable struct QueueSubmissionState
     pending::Vector{MTLCommandBufferLike}
-    errors::Vector{CommandBufferErrorInfo}
+    errors::Union{Nothing,Vector{CommandBufferErrorInfo}}
 end
 
-QueueSubmissionState() = QueueSubmissionState(MTLCommandBufferLike[],
-                                              CommandBufferErrorInfo[])
+QueueSubmissionState() = QueueSubmissionState(MTLCommandBufferLike[], nothing)
 
 const submission_state_per_queue = Dict{id{MTLCommandQueue},QueueSubmissionState}()
 
@@ -126,15 +125,21 @@ function _prune_completed_submissions!(pending, errors, is_completed, error_info
     for submission in pending
         is_completed(submission) || break
         info = error_info(submission)
-        info === nothing || push!(errors, info)
+        if info !== nothing
+            if errors === nothing
+                errors = [info]
+            else
+                push!(errors, info)
+            end
+        end
         n += 1
     end
     n == 0 || deleteat!(pending, 1:n)
-    return
+    return errors
 end
 
 function prune_completed_submissions!(state::QueueSubmissionState)
-    _prune_completed_submissions!(
+    state.errors = _prune_completed_submissions!(
         state.pending, state.errors,
         cmdbuf -> cmdbuf.status >= MTLCommandBufferStatusCompleted,
         cmdbuf -> cmdbuf.status == MTLCommandBufferStatusError ?
@@ -161,7 +166,7 @@ function take_queue_submissions(queue::MTLCommandQueue)
     key = pointer(queue)
     @lock last_committed_lock begin
         last = get(last_committed_per_queue, key, nothing)
-        state = pop!(submission_state_per_queue, key, QueueSubmissionState())
+        state = pop!(submission_state_per_queue, key, nothing)
         return last, state
     end
 end
@@ -169,7 +174,8 @@ end
 function take_all_submissions()
     @lock last_committed_lock begin
         last = collect(values(last_committed_per_queue))
-        states = collect(values(submission_state_per_queue))
+        states = isempty(submission_state_per_queue) ? nothing :
+                 collect(values(submission_state_per_queue))
         empty!(submission_state_per_queue)
         return last, states
     end

--- a/lib/mtl/command_buf.jl
+++ b/lib/mtl/command_buf.jl
@@ -17,7 +17,7 @@ end
 #
 
 export MTLCommandBuffer, enqueue!, wait_scheduled, wait_completed, encode_signal!,
-       encode_wait!, commit!, on_scheduled, on_completed
+       encode_wait!, commit!, on_scheduled, on_completed, CommandBufferError
 
 # @objcwrapper MTLCommandBuffer <: NSObject
 
@@ -58,6 +58,137 @@ end
 
 const last_committed_lock = ReentrantLock()
 const last_committed_per_queue = Dict{id{MTLCommandQueue}, MTLCommandBufferLike}()
+
+struct CommandBufferErrorInfo
+    domain::String
+    code::Int
+    description::String
+    command_buffer_label::Union{Nothing,String}
+    queue_label::Union{Nothing,String}
+end
+
+"""
+    CommandBufferError
+
+An error reported by one or more Metal command buffers at a synchronization boundary.
+The `errors` field contains the original `NSError` domain, code, and description, plus
+the command-buffer and queue labels when available.
+"""
+struct CommandBufferError <: Exception
+    errors::Vector{CommandBufferErrorInfo}
+end
+
+function Base.showerror(io::IO, exc::CommandBufferError)
+    n = length(exc.errors)
+    print(io, "CommandBufferError: ", n == 1 ? "Metal command buffer failed" :
+                                           "$n Metal command buffers failed")
+    for info in exc.errors
+        print(io, "\nNSError: ", info.description, " (", info.domain,
+              ", code ", info.code, ")")
+        labels = String[]
+        info.command_buffer_label === nothing ||
+            push!(labels, "command buffer $(repr(info.command_buffer_label))")
+        info.queue_label === nothing || push!(labels, "queue $(repr(info.queue_label))")
+        isempty(labels) || print(io, " [", join(labels, ", "), "]")
+    end
+end
+
+mutable struct QueueSubmissionState
+    pending::Vector{MTLCommandBufferLike}
+    errors::Vector{CommandBufferErrorInfo}
+end
+
+QueueSubmissionState() = QueueSubmissionState(MTLCommandBufferLike[],
+                                              CommandBufferErrorInfo[])
+
+const submission_state_per_queue = Dict{id{MTLCommandQueue},QueueSubmissionState}()
+
+function command_buffer_error_info(cmdbuf::MTLCommandBufferLike)
+    err = cmdbuf.error
+    err === nothing && return CommandBufferErrorInfo(
+        "MTLCommandBufferErrorDomain", 0, "Metal did not provide an NSError",
+        _object_label(cmdbuf), _object_label(cmdbuf.commandQueue))
+    return CommandBufferErrorInfo(String(err.domain), Int(err.code),
+                                  String(err.localizedDescription),
+                                  _object_label(cmdbuf),
+                                  _object_label(cmdbuf.commandQueue))
+end
+
+function _object_label(obj)
+    label = obj.label
+    return label === nothing ? nothing : String(label)
+end
+
+# Keep this state-accounting primitive independent from Objective-C objects so its
+# ordering and pruning semantics can be tested deterministically.
+function _prune_completed_submissions!(pending, errors, is_completed, error_info)
+    n = 0
+    for submission in pending
+        is_completed(submission) || break
+        info = error_info(submission)
+        info === nothing || push!(errors, info)
+        n += 1
+    end
+    n == 0 || deleteat!(pending, 1:n)
+    return
+end
+
+function prune_completed_submissions!(state::QueueSubmissionState)
+    _prune_completed_submissions!(
+        state.pending, state.errors,
+        cmdbuf -> cmdbuf.status >= MTLCommandBufferStatusCompleted,
+        cmdbuf -> cmdbuf.status == MTLCommandBufferStatusError ?
+                  command_buffer_error_info(cmdbuf) : nothing)
+    return
+end
+
+function record_committed!(cmdbuf::MTLCommandBufferLike, key::id{MTLCommandQueue})
+    @lock last_committed_lock begin
+        state = get!(submission_state_per_queue, key) do
+            QueueSubmissionState()
+        end
+        # Completed successes can be forgotten immediately. Completed failures are
+        # reduced to diagnostics, so command-buffer retention stays bounded during
+        # long-running submission workloads without explicit synchronization.
+        prune_completed_submissions!(state)
+        push!(state.pending, cmdbuf)
+        last_committed_per_queue[key] = cmdbuf
+    end
+    return
+end
+
+function take_queue_submissions(queue::MTLCommandQueue)
+    key = pointer(queue)
+    @lock last_committed_lock begin
+        last = get(last_committed_per_queue, key, nothing)
+        state = pop!(submission_state_per_queue, key, QueueSubmissionState())
+        return last, state
+    end
+end
+
+function take_all_submissions()
+    @lock last_committed_lock begin
+        last = collect(values(last_committed_per_queue))
+        states = collect(values(submission_state_per_queue))
+        empty!(submission_state_per_queue)
+        return last, states
+    end
+end
+
+function finish_submissions!(state::QueueSubmissionState)
+    prune_completed_submissions!(state)
+    isempty(state.pending) ||
+        error("Command buffer did not reach a terminal state after queue synchronization")
+    return state.errors
+end
+
+function pending_submission_count(queue::MTLCommandQueue)
+    key = pointer(queue)
+    @lock last_committed_lock begin
+        state = get(submission_state_per_queue, key, nothing)
+        state === nothing ? 0 : length(state.pending)
+    end
+end
 
 # optional profiling hook. when set, it is invoked for every committed command buffer.
 const profile_hook = Ref{Any}(nothing)
@@ -119,12 +250,10 @@ function commit_with_queue_key!(cmdbuf::MTLCommandBufferLike, key::id{MTLCommand
     cmdbuf.status in [MTLCommandBufferStatusCompleted, MTLCommandBufferStatusCommitted] &&
         error("Cannot commit an already committed/completed command buffer")
     @objc [cmdbuf::id{MTLCommandBuffer} commit]::Nothing
-    # Record the commit so synchronize(queue) can wait on this cmdbuf instead
-    # of allocating a fresh sentinel. The slot is overwritten on every commit,
-    # so the dict stays bounded at one cmdbuf per queue.
-    @lock last_committed_lock begin
-        last_committed_per_queue[key] = cmdbuf
-    end
+    # Record every submission for error accounting. The most recent buffer remains
+    # the queue tail used by synchronization, while older completed buffers are
+    # pruned or summarized by `record_committed!`.
+    record_committed!(cmdbuf, key)
     hook = profile_hook[]
     hook === nothing || hook(cmdbuf)
     return

--- a/src/command_batching.jl
+++ b/src/command_batching.jl
@@ -315,9 +315,6 @@ function drain_cleanups!(bq::BatchedCommandQueue; force::Bool=false)
     deleteat!(bq.cleanups, 1:n)
 
     for cleanup in completed
-        if cleanup.cmdbuf.status == MTL.MTLCommandBufferStatusError
-            @error "Command buffer failed" reason=cleanup.cmdbuf.error.localizedDescription
-        end
         empty!(cleanup.roots)
     end
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -55,5 +55,6 @@ Sys.isapple() && @setup_workload begin
     Base.@lock memory_pressure_stats_lock empty!(_memory_pressure_stats)
     empty!(device_malloc_bufs)
     empty!(MTL.last_committed_per_queue)
+    empty!(MTL.submission_state_per_queue)
     empty!(device_exception_info)
 end

--- a/src/synchronization.jl
+++ b/src/synchronization.jl
@@ -1,4 +1,4 @@
-export synchronize, device_synchronize
+export synchronize, device_synchronize, CommandBufferError
 
 # whether to wait on the Julia scheduler instead of parking the calling thread
 # inside Metal's blocking `waitUntilCompleted`. opt-out via Preferences for
@@ -75,6 +75,30 @@ function wait_cmdbuf!(cmdbuf::MTL.MTLCommandBufferLike)
     return
 end
 
+function check_synchronization_errors(states)
+    errors = MTL.CommandBufferErrorInfo[]
+    for state in states
+        append!(errors, MTL.finish_submissions!(state))
+    end
+
+    kernel_error = try
+        check_exceptions()
+        nothing
+    catch err
+        err
+    end
+
+    command_buffer_error = isempty(errors) ? nothing : CommandBufferError(errors)
+    if command_buffer_error !== nothing && kernel_error !== nothing
+        throw(CompositeException(Any[command_buffer_error, kernel_error]))
+    elseif command_buffer_error !== nothing
+        throw(command_buffer_error)
+    elseif kernel_error !== nothing
+        throw(kernel_error)
+    end
+    return
+end
+
 
 #
 # public API
@@ -96,16 +120,16 @@ Wait for currently committed GPU work on `queue` to finish.
     # is what processes its `addLogHandler:` blocks)
     drain_logging_cmdbufs!(queue)
 
-    last = MTL.last_committed(queue)
-    last === nothing && return
+    last, submissions = MTL.take_queue_submissions(queue)
 
     # Handles the already-completed fast path internally.
-    wait_cmdbuf!(last)
+    last === nothing || wait_cmdbuf!(last)
 
     drain_cleanups!(bq; force=true)
 
-    # surface any device-side exception thrown by the work we just waited on
-    check_exceptions()
+    # Surface Metal runtime failures and device-side Julia exceptions together,
+    # after cleanup has released all Julia roots held by completed work.
+    check_synchronization_errors((submissions,))
     return
 end
 
@@ -133,9 +157,7 @@ function device_synchronize()
         drain_logging_cmdbufs!(bq.queue)
     end
 
-    cmdbufs = Base.@lock MTL.last_committed_lock begin
-        collect(values(MTL.last_committed_per_queue))
-    end
+    cmdbufs, submissions = MTL.take_all_submissions()
 
     for cmdbuf in cmdbufs
         if !is_completed(cmdbuf)
@@ -151,6 +173,6 @@ function device_synchronize()
         drain_cleanups!(bq; force=true)
     end
 
-    check_exceptions()
+    check_synchronization_errors(submissions)
     return
 end

--- a/src/synchronization.jl
+++ b/src/synchronization.jl
@@ -75,11 +75,27 @@ function wait_cmdbuf!(cmdbuf::MTL.MTLCommandBufferLike)
     return
 end
 
-function check_synchronization_errors(states)
-    errors = MTL.CommandBufferErrorInfo[]
+function command_buffer_errors(state::Union{Nothing,MTL.QueueSubmissionState})
+    state === nothing && return nothing
+    return MTL.finish_submissions!(state)
+end
+
+function command_buffer_errors(states::AbstractVector{MTL.QueueSubmissionState})
+    errors = nothing
     for state in states
-        append!(errors, MTL.finish_submissions!(state))
+        state_errors = MTL.finish_submissions!(state)
+        state_errors === nothing && continue
+        if errors === nothing
+            errors = state_errors
+        else
+            append!(errors, state_errors)
+        end
     end
+    return errors
+end
+
+function check_synchronization_errors(states)
+    errors = command_buffer_errors(states)
 
     kernel_error = try
         check_exceptions()
@@ -88,7 +104,7 @@ function check_synchronization_errors(states)
         err
     end
 
-    command_buffer_error = isempty(errors) ? nothing : CommandBufferError(errors)
+    command_buffer_error = errors === nothing ? nothing : CommandBufferError(errors)
     if command_buffer_error !== nothing && kernel_error !== nothing
         throw(CompositeException(Any[command_buffer_error, kernel_error]))
     elseif command_buffer_error !== nothing
@@ -129,7 +145,7 @@ Wait for currently committed GPU work on `queue` to finish.
 
     # Surface Metal runtime failures and device-side Julia exceptions together,
     # after cleanup has released all Julia roots held by completed work.
-    check_synchronization_errors((submissions,))
+    check_synchronization_errors(submissions)
     return
 end
 

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -269,7 +269,11 @@ function inject_command_buffer_error!(queue, info)
         state = get!(MTL.submission_state_per_queue, key) do
             MTL.QueueSubmissionState()
         end
-        push!(state.errors, info)
+        if state.errors === nothing
+            state.errors = [info]
+        else
+            push!(state.errors, info)
+        end
     end
     return
 end
@@ -283,6 +287,13 @@ end
                                           x -> iseven(x) ? "failure $x" : nothing)
         @test pending == [5]
         @test errors == ["failure 2", "failure 4"]
+
+        pending = collect(1:3)
+        errors = MTL._prune_completed_submissions!(pending, nothing,
+                                                   x -> x <= 2,
+                                                   _ -> nothing)
+        @test pending == [3]
+        @test errors === nothing
     end
 
     @testset "successful direct submissions and bounded retention" begin

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -263,6 +263,88 @@ end
     @test Array(D) == UInt8[3]
 end
 
+function inject_command_buffer_error!(queue, info)
+    key = pointer(queue)
+    Base.@lock MTL.last_committed_lock begin
+        state = get!(MTL.submission_state_per_queue, key) do
+            MTL.QueueSubmissionState()
+        end
+        push!(state.errors, info)
+    end
+    return
+end
+
+@testset "command buffer error accounting" begin
+    @testset "deterministic pruning" begin
+        pending = collect(1:5)
+        errors = String[]
+        MTL._prune_completed_submissions!(pending, errors,
+                                          x -> x <= 4,
+                                          x -> iseven(x) ? "failure $x" : nothing)
+        @test pending == [5]
+        @test errors == ["failure 2", "failure 4"]
+    end
+
+    @testset "successful direct submissions and bounded retention" begin
+        queue = MTL.MTLCommandQueue(device())
+        for _ in 1:64
+            cmdbuf = MTL.MTLCommandBuffer(queue)
+            MTL.commit!(cmdbuf)
+            MTL.wait_completed(cmdbuf)
+            @test MTL.pending_submission_count(queue) <= 1
+        end
+        @test synchronize(queue) === nothing
+        @test MTL.pending_submission_count(queue) == 0
+    end
+
+    @testset "earlier failure and duplicate suppression" begin
+        queue = MTL.MTLCommandQueue(device())
+        queue.label = "error accounting queue"
+
+        earlier = MTL.MTLCommandBuffer(queue)
+        earlier.label = "failed earlier command buffer"
+        MTL.commit!(earlier)
+        MTL.wait_completed(earlier)
+
+        info = MTL.CommandBufferErrorInfo("MTLCommandBufferErrorDomain", 2,
+                                          "The GPU operation timed out",
+                                          String(earlier.label), String(queue.label))
+        inject_command_buffer_error!(queue, info)
+
+        later = MTL.MTLCommandBuffer(queue)
+        MTL.commit!(later)
+        err = try
+            synchronize(queue)
+            nothing
+        catch exc
+            exc
+        end
+        @test err isa Metal.CommandBufferError
+        @test only(err.errors) == info
+        message = sprint(showerror, err)
+        @test occursin("MTLCommandBufferErrorDomain", message)
+        @test occursin("code 2", message)
+        @test occursin("The GPU operation timed out", message)
+        @test occursin("failed earlier command buffer", message)
+        @test occursin("error accounting queue", message)
+
+        # The synchronization boundary claims the failure before reporting it.
+        @test synchronize(queue) === nothing
+    end
+
+    @testset "device synchronization" begin
+        queue = MTL.MTLCommandQueue(device())
+        cmdbuf = MTL.MTLCommandBuffer(queue)
+        MTL.commit!(cmdbuf)
+        info = MTL.CommandBufferErrorInfo("MTLCommandBufferErrorDomain", 8,
+                                          "Out of memory", nothing, nothing)
+        inject_command_buffer_error!(queue, info)
+        @test_throws Metal.CommandBufferError device_synchronize()
+        @test device_synchronize() === nothing
+    end
+
+end
+
 @testset "command batching tunables" begin
     env = "JULIA_METAL_TEST_BATCHING_TUNABLE"
     withenv(env => nothing) do

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -343,6 +343,16 @@ end
         @test device_synchronize() === nothing
     end
 
+    @testset "MPS intermediate submissions" begin
+        queue = MTL.MTLCommandQueue(device())
+        mpsbuf = MPS.MPSCommandBuffer(queue)
+        submitted = mpsbuf.commandBuffer
+        MPS.commitAndContinue!(mpsbuf)
+        @test MTL.last_committed(queue) == submitted
+
+        MTL.commit!(mpsbuf)
+        @test synchronize(queue) === nothing
+    end
 end
 
 @testset "command batching tunables" begin


### PR DESCRIPTION
Both regular and MPS, via a single hook.