### PR TITLE
Use SIMD shuffles for native scans

### DIFF
--- a/src/accumulate.jl
+++ b/src/accumulate.jl
@@ -75,6 +75,96 @@ function partial_scan(op::Function, output::AbstractArray{T}, input::AbstractArr
     return
 end
 
+function partial_scan_simd(op::Function, output::AbstractArray{T}, input::AbstractArray,
+                           Rdim, Rpre, Rpost, Rother, neutral, init,
+                           ::Val{single_simdgroup}) where {T, single_simdgroup}
+    threads = Int(threads_per_threadgroup_3d().x)
+    thread = Int(thread_position_in_threadgroup_3d().x)
+    lane = Int(thread_index_in_simdgroup())
+    simdgroup = Int(simdgroup_index_in_threadgroup())
+    assume(threads_per_simdgroup() == 32)
+
+    i = (Int(threadgroup_position_in_grid_3d().x) - 1) * threads + thread
+    j = (Int(threadgroup_position_in_grid_3d().z) - 1) *
+        Int(threadgroups_per_grid_3d().y) + Int(threadgroup_position_in_grid_3d().y)
+
+    if j > length(Rother)
+        return
+    end
+
+    @inbounds begin
+        I = Rother[j]
+        Ipre = Rpre[I[1]]
+        Ipost = Rpost[I[2]]
+    end
+
+    val = @inbounds if i <= length(Rdim)
+        op(neutral, input[Ipre, i, Ipost])
+    else
+        op(neutral, neutral)
+    end
+
+    # Inclusive scan within each SIMD group.
+    offset = 1
+    while offset < 32
+        previous = simd_shuffle_up(val, offset)
+        if lane > offset
+            val = op(previous, val)
+        end
+        offset <<= 1
+    end
+
+    if single_simdgroup
+        @inbounds if i <= length(Rdim)
+            if init !== nothing
+                val = op(something(init), val)
+            end
+            output[Ipre, i, Ipost] = val
+        end
+        return
+    end
+
+    # Scan the per-SIMD-group totals using the first SIMD group, then add the total of
+    # all preceding groups. This needs only two threadgroup barriers instead of the
+    # up-sweep/down-sweep tree used by the generic kernel.
+    totals = MtlThreadGroupArray(T, 32)
+    last_lane = min(32, threads - (simdgroup - 1) * 32)
+    if lane == last_lane
+        @inbounds totals[simdgroup] = val
+    end
+    threadgroup_barrier(MemoryFlagThreadGroup)
+
+    simdgroups = cld(threads, 32)
+    if simdgroup == 1
+        group_val = lane <= simdgroups ? @inbounds(totals[lane]) : neutral
+        offset = 1
+        while offset < 32
+            previous = simd_shuffle_up(group_val, offset)
+            if lane > offset
+                group_val = op(previous, group_val)
+            end
+            offset <<= 1
+        end
+        if lane <= simdgroups
+            @inbounds totals[lane] = group_val
+        end
+    end
+    threadgroup_barrier(MemoryFlagThreadGroup)
+
+    if simdgroup > 1
+        @inbounds val = op(totals[simdgroup - 1], val)
+    end
+
+    @inbounds if i <= length(Rdim)
+        if init !== nothing
+            val = op(something(init), val)
+        end
+        output[Ipre, i, Ipost] = val
+    end
+
+    return
+end
+
 function aggregate_partial_scan(op::Function, output::AbstractArray, aggregates::AbstractArray, Rdim, Rpre, Rpost, Rother, init)
     block = threadgroup_position_in_grid_3d().x
 
@@ -119,30 +209,56 @@ function scan!(f::Function, output::WrappedMtlArray{T}, input::WrappedMtlArray;
     Rpost = CartesianIndices(size(input)[dims+1:end])
     Rother = CartesianIndices((length(Rpre), length(Rpost)))
 
+    full = nextpow(2, length(Rdim))
+    simd_type = T <: Union{Float32, Float16, Int32, UInt32, Int16, UInt16, Int8, UInt8}
+    # A single SIMD group needs no barriers, and the hierarchical SIMD scan wins for
+    # 512+ threads. Keep the shared-memory tree for the measured 64-256-thread crossover.
+    simd = simd_type && (full <= 32 || full >= 512)
+
     # the maximum number of threads is limited by the hardware
     dev = device()
     threadgroup_threads, threadgroup_memory = MTL.threadgroup_limits(dev)
     maxthreads = min(threadgroup_threads, threadgroup_memory ÷ sizeof(T) ÷ 2)
 
     # determine how many threads we can launch for the scan kernel
-    kernel = @metal launch=false partial_scan(f, output, input, Rdim, Rpre, Rpost, Rother, neutral, init, Val(maxthreads), Val(true))
+    kernel = if simd
+        @metal launch=false partial_scan_simd(f, output, input, Rdim, Rpre, Rpost,
+                                              Rother, neutral, init, Val(false))
+    else
+        @metal launch=false partial_scan(f, output, input, Rdim, Rpre, Rpost,
+                                         Rother, neutral, init, Val(maxthreads),
+                                         Val(true))
+    end
     threads = Int(kernel.pipeline.maxTotalThreadsPerThreadgroup)
 
     # determine the grid layout to cover the other dimensions
     blocks_other = (length(Rother), 1)
 
     # does that suffice to scan the array in one go?
-    full = nextpow(2, length(Rdim))
     if full <= threads
-        @metal(threads=full, groups=(1, blocks_other...),
-               partial_scan(f, output, input, Rdim, Rpre, Rpost, Rother, neutral, init, Val(full), Val(true)))
+        if simd
+            @metal(threads=full, groups=(1, blocks_other...),
+                   partial_scan_simd(f, output, input, Rdim, Rpre, Rpost, Rother,
+                                     neutral, init, Val(full <= 32)))
+        else
+            @metal(threads=full, groups=(1, blocks_other...),
+                   partial_scan(f, output, input, Rdim, Rpre, Rpost, Rother,
+                                neutral, init, Val(full), Val(true)))
+        end
     else
         # perform partial scans across the scanning dimension
         # NOTE: don't set init here to avoid applying the value multiple times
         partial = prevpow(2, threads)
         blocks_dim = cld(length(Rdim), partial)
-        @metal(threads=partial, groups=(blocks_dim, blocks_other...),
-              partial_scan(f, output, input, Rdim, Rpre, Rpost, Rother, neutral, nothing, Val(partial), Val(true)))
+        if simd
+            @metal(threads=partial, groups=(blocks_dim, blocks_other...),
+                   partial_scan_simd(f, output, input, Rdim, Rpre, Rpost, Rother,
+                                     neutral, nothing, Val(false)))
+        else
+            @metal(threads=partial, groups=(blocks_dim, blocks_other...),
+                   partial_scan(f, output, input, Rdim, Rpre, Rpost, Rother,
+                                neutral, nothing, Val(partial), Val(true)))
+        end
 
         # get the total of each thread block (except the first) of the partial scans
         aggregates = fill(neutral, Base.setindex(size(input), blocks_dim, dims))

--- a/test/array.jl
+++ b/test/array.jl
@@ -632,6 +632,18 @@ end
     @test testf(cumsum, rand(Float32, 2))
     @test testf(cumprod, rand(Float32, 2))
 
+    @testset "SIMD scan" begin
+        @with (Metal.scan_alg => :native) begin
+            input = reshape(Float32.(mod.(0:(3 * 1025 - 1), 11) .- 5), 1025, 3)
+            @test Array(accumulate(+, MtlArray(input); dims=1)) ≈
+                accumulate(+, input; dims=1)
+
+            input = reshape(Int32.(mod.(0:(3 * 513 - 1), 7)), 513, 3)
+            @test Array(accumulate(max, MtlArray(input'); dims=2)) ==
+                accumulate(max, input'; dims=2)
+        end
+    end
+
     scan_input = reshape(Float32[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37], 3, 4)
     product_input = scan_input ./ 10
     for alg in (:native, :MPSGraph), dims in 1:2


### PR DESCRIPTION
## Summary

Use SIMD shuffles to reduce synchronization overhead in the native scan implementation.

The existing partial scan uses a Blelloch tree in threadgroup memory. For a 1024-thread block, this requires roughly 21 threadgroup barriers. The new path:

- scans values within each 32-lane SIMD group using `simd_shuffle_up`
- stores one total per SIMD group
- scans those group totals with the first SIMD group
- adds the preceding-group total to each local prefix

This requires no barriers for scans of up to 32 elements and two barriers for the hierarchical scan.

The SIMD path is limited to types supported by the existing shuffle intrinsics. Based on the measured crossover, 64–256-thread scans retain the existing Blelloch implementation, while 512-thread and larger scans use the hierarchical SIMD implementation. Unsupported types also continue to use the existing implementation.

The multi-block scan logic and algorithm selection between native kernels and MPSGraph are unchanged. Floating-point `accumulate(max/min, ...)` uses the native path automatically because MPSGraph does not preserve Julia's NaN propagation semantics.

## Performance

Benchmarked on an Apple M4 with Julia 1.12.5. Each case scans 4,194,304 total elements, with 40 alternating before/after samples. Reported values are medians.

Native addition:

| Type | Elements per scan | Before | After | Speedup |
|---|---:|---:|---:|---:|
| `Float32` | 32 | 3.54 ms | 2.33 ms | 1.52x |
| `Float32` | 512 | 5.06 ms | 2.44 ms | 2.07x |
| `Float32` | 1024 | 5.44 ms | 2.43 ms | 2.24x |
| `Int32` | 32 | 3.91 ms | 2.28 ms | 1.72x |
| `Int32` | 512 | 5.26 ms | 2.72 ms | 1.94x |
| `Int32` | 1024 | 5.50 ms | 2.45 ms | 2.25x |

Floating-point max/min scans, which automatically use the native implementation:

| Operation | Elements per scan | Before | After | Speedup |
|---|---:|---:|---:|---:|
| `accumulate(max)` | 32 | 1.45 ms | 0.90 ms | 1.62x |
| `accumulate(max)` | 512 | 1.33 ms | 0.92 ms | 1.45x |
| `accumulate(max)` | 1024 | 2.21 ms | 1.19 ms | 1.85x |
| `accumulate(min)` | 32 | 1.27 ms | 0.81 ms | 1.58x |
| `accumulate(min)` | 512 | 1.50 ms | 1.02 ms | 1.47x |
| `accumulate(min)` | 1024 | 1.73 ms | 0.92 ms | 1.89x |

The 256-thread case continues to dispatch to the existing implementation because the SIMD implementation did not consistently win at that crossover.

## Correctness

The operand order and handling of padded lanes and initial values are preserved. Floating-point association can differ, as it already can with the existing parallel Blelloch scan.

The added tests cover a non-power-of-two multi-block addition scan and a non-additive scan along a non-leading dimension. Existing tests cover small scans, initializers, supported operations, and NaN propagation.

Validation:

- array test suite: 605/605 passed
- SIMD intrinsic test suite: 196/196 passed

AI Use:
This PR was made with the assistance of GPT 5.6 Sol Extra High. I reviewed all the code and benchmark results myself.
