### PR TITLE
Fix tests for macOS 27 Beta 4

### DIFF
--- a/test/mpsgraphs/nn.jl
+++ b/test/mpsgraphs/nn.jl
@@ -203,7 +203,7 @@ end
         dx = Array(dx)
         # MPSGraph's grouped convolution data-gradient kernel drops the first
         # input channel of each group under Metal GPU validation.
-        @test dx ≈ dx_ref broken=(runtime_validation && shader_validation && groups == 2)
+        @test dx ≈ dx_ref broken=(runtime_validation && shader_validation && groups == 2 && macos_version() < v"27.0")
 
         dw_ref = ref_conv2d_filter_grad(x, dy, size(w); stride=(2, 1),
                                         padding=(1, 1, 0, 1), dilation=(1, 1),


### PR DESCRIPTION
Seems like these validation failures have been fixed.

Would like someone else to confirm this this is also fixed for them on Beta 4 before I merge

```julia-repl
julia> using Pkg; Pkg.test("Metal"; test_args=`--verbose mpsgraphs/nn`)
```

Or, fully standalone just launch julia from any directory and paste in the REPL:
```julia-repl
julia> ENV["MTL_SHADER_VALIDATION"]="1"; ENV["MTL_DEBUG_LAYER"]="1"; using Pkg; pkg"activate --temp; add Metal#fixnn"; Pkg.test("Metal"; test_args=`--verbose mpsgraphs/nn`)
```