### PR TITLE
Add ordered atomics and enable KernelAbstractions atomic support

### DIFF
--- a/src/MetalKernels.jl
+++ b/src/MetalKernels.jl
@@ -33,7 +33,7 @@ KA.synchronize(::MetalBackend) = synchronize()
 KA.functional(::MetalBackend) = Metal.functional()
 
 KA.supports_float64(::MetalBackend) = false
-KA.supports_atomics(::MetalBackend) = false
+KA.supports_atomics(::MetalBackend) = metal_support() >= v"4.1"
 KA.supports_unified(::MetalBackend) = true
 
 Adapt.adapt_storage(::MetalBackend, a::Array) = Adapt.adapt(MtlArray, a)

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -242,6 +242,71 @@ function GPUCompiler.finish_ir!(@nospecialize(job::MetalCompilerJob),
                    job, mod, entry)
 
     # downgrade intrinsics when targeting older AIR versions
+    if job.config.target.metal < v"4.1"
+        # Metal 4.1 added memory flags to the atomic ABI and made its atomic pointers
+        # non-volatile. Device code always emits that module-wide ABI; recover the legacy
+        # form for older language targets by dropping flags and restoring volatile=true.
+        for f in collect(functions(mod))
+            fn = LLVM.name(f)
+            match(r"^air\.atomic\.(global|local)\.", fn) === nothing && continue
+
+            calls = [user(u) for u in uses(f)]
+            GPUCompiler.@compiler_assert all(call -> call isa LLVM.CallInst, calls) job
+
+            is_cmpxchg = occursin(".cmpxchg.weak.", fn)
+            compatible = all(calls) do call
+                args = collect(arguments(call))
+                flags = args[end-1]
+                success_order = args[end-(is_cmpxchg ? 4 : 3)]
+                flags isa ConstantInt && convert(UInt32, flags) == 0 &&
+                    success_order isa ConstantInt && convert(Int32, success_order) == 0 &&
+                    (!is_cmpxchg || (args[end-3] isa ConstantInt &&
+                                     convert(Int32, args[end-3]) == 0))
+            end
+            # Leave invalid calls untouched so GPUCompiler's subsequent static-assert
+            # validation can report the user-facing availability or ordering error.
+            compatible || continue
+
+            new_ft = function_type(f)
+            new_params = collect(parameters(new_ft))
+            old_params = [new_params[1:end-2]..., new_params[end]]
+            old_ft = LLVM.FunctionType(LLVM.return_type(new_ft), old_params)
+
+            LLVM.name!(f, fn * ".metal41")
+            old_f = LLVM.Function(mod, fn, old_ft)
+            for attr in collect(function_attributes(f))
+                push!(function_attributes(old_f), attr)
+            end
+
+            for call in calls
+                args = collect(arguments(call))
+                flags = args[end-1]
+                success_order = args[end-(is_cmpxchg ? 4 : 3)]
+                GPUCompiler.@compiler_assert flags isa ConstantInt job
+                GPUCompiler.@compiler_assert convert(UInt32, flags) == 0 job
+                GPUCompiler.@compiler_assert success_order isa ConstantInt job
+                GPUCompiler.@compiler_assert convert(Int32, success_order) == 0 job
+                if is_cmpxchg
+                    failure_order = args[end-3]
+                    GPUCompiler.@compiler_assert failure_order isa ConstantInt job
+                    GPUCompiler.@compiler_assert convert(Int32, failure_order) == 0 job
+                end
+
+                @dispose builder=IRBuilder() begin
+                    position!(builder, call)
+                    debuglocation!(builder, call)
+                    old_args = [args[1:end-2]..., ConstantInt(true)]
+                    new_call = call!(builder, old_ft, old_f, old_args)
+                    replace_uses!(call, new_call)
+                    erase!(call)
+                end
+            end
+
+            GPUCompiler.@compiler_assert isempty(uses(f)) job
+            erase!(f)
+        end
+    end
+
     if job.config.target.air < v"2.8"
         # AIR 2.8 generalized the simdgroup matrix load/store intrinsics, replacing
         # the elements-per-row scalar, matrix origin, and transposition flag with

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -241,20 +241,22 @@ function GPUCompiler.finish_ir!(@nospecialize(job::MetalCompilerJob),
                    Tuple{CompilerJob{MetalCompilerTarget}, LLVM.Module, LLVM.Function},
                    job, mod, entry)
 
-    # downgrade intrinsics when targeting older AIR versions
+    # downgrade intrinsics when targeting older AIR or Metal versions
+    ## atomics
     if job.config.target.metal < v"4.1"
-        # Metal 4.1 added memory flags to the atomic ABI and made its atomic pointers
-        # non-volatile. Device code always emits that module-wide ABI; recover the legacy
-        # form for older language targets by dropping flags and restoring volatile=true.
+        ## atomic ABI: selected by AIR
+        ## volatile bit: selected by MSL
+        ## device code always emits the AIR 2.9 / Metal 4.1 form
         for f in collect(functions(mod))
             fn = LLVM.name(f)
-            match(r"^air\.atomic\.(global|local)\.", fn) === nothing && continue
+            (startswith(fn, "air.atomic.global.") ||
+             startswith(fn, "air.atomic.local.")) || continue
 
             calls = [user(u) for u in uses(f)]
-            GPUCompiler.@compiler_assert all(call -> call isa LLVM.CallInst, calls) job
-
             is_cmpxchg = occursin(".cmpxchg.weak.", fn)
-            compatible = all(calls) do call
+            is_load = occursin(".load.", fn)
+            expected_nargs = is_cmpxchg ? 8 : is_load ? 5 : 6
+            conforming(call) = call isa LLVM.CallInst && length(arguments(call)) == expected_nargs && let
                 args = collect(arguments(call))
                 flags = args[end-1]
                 success_order = args[end-(is_cmpxchg ? 4 : 3)]
@@ -263,9 +265,22 @@ function GPUCompiler.finish_ir!(@nospecialize(job::MetalCompilerJob),
                     (!is_cmpxchg || (args[end-3] isa ConstantInt &&
                                      convert(Int32, args[end-3]) == 0))
             end
-            # Leave invalid calls untouched so GPUCompiler's subsequent static-assert
-            # validation can report the user-facing availability or ordering error.
-            compatible || continue
+
+            if job.config.target.air >= v"2.9"
+                # AIR 2.9 introduced the flags operand, but pre-4.1 MSL still marks
+                # atomic pointers volatile. Leave non-conforming calls for check_ir!
+                # so that device-side static assertions produce the useful diagnostic.
+                for call in calls
+                    conforming(call) || continue
+                    # LLVM models the callee as the final operand, after all arguments.
+                    operands(call)[end-1] = ConstantInt(true)
+                end
+                continue
+            end
+
+            # AIR before 2.9 needs the legacy ABI without flags. We can only rewrite a
+            # declaration when every use conforms; otherwise leave it for check_ir!.
+            all(conforming, calls) || continue
 
             new_ft = function_type(f)
             new_params = collect(parameters(new_ft))
@@ -280,18 +295,6 @@ function GPUCompiler.finish_ir!(@nospecialize(job::MetalCompilerJob),
 
             for call in calls
                 args = collect(arguments(call))
-                flags = args[end-1]
-                success_order = args[end-(is_cmpxchg ? 4 : 3)]
-                GPUCompiler.@compiler_assert flags isa ConstantInt job
-                GPUCompiler.@compiler_assert convert(UInt32, flags) == 0 job
-                GPUCompiler.@compiler_assert success_order isa ConstantInt job
-                GPUCompiler.@compiler_assert convert(Int32, success_order) == 0 job
-                if is_cmpxchg
-                    failure_order = args[end-3]
-                    GPUCompiler.@compiler_assert failure_order isa ConstantInt job
-                    GPUCompiler.@compiler_assert convert(Int32, failure_order) == 0 job
-                end
-
                 @dispose builder=IRBuilder() begin
                     position!(builder, call)
                     debuglocation!(builder, call)
@@ -306,7 +309,7 @@ function GPUCompiler.finish_ir!(@nospecialize(job::MetalCompilerJob),
             erase!(f)
         end
     end
-
+    ## simdgroup
     if job.config.target.air < v"2.8"
         # AIR 2.8 generalized the simdgroup matrix load/store intrinsics, replacing
         # the elements-per-row scalar, matrix origin, and transposition flag with
@@ -459,12 +462,14 @@ end
         metal = metal_target(macos)
     end
     if air === nothing
-        air = air_target(macos)
+        air = max(air_support(macos), air_floor(metal))
         if air < v"2.6"
             error("""Metal.jl requires AIR 2.6 (macOS 14) or newer, but macOS $(macos) only supports AIR $(air_support(macos)).""")
         end
     elseif air < v"2.6"
         error("""Metal.jl requires AIR 2.6 (macOS 14) or newer; cannot target AIR $(air).""")
+    elseif air < air_floor(metal)
+            error("""Metal $(metal) requires AIR $(air_floor(metal)) or newer; cannot target AIR $(air).""")
     end
 
     # create GPUCompiler objects

--- a/src/device/intrinsics/atomics.jl
+++ b/src/device/intrinsics/atomics.jl
@@ -14,41 +14,205 @@ const atomic_type_names = Dict(
     :Float32 => "f32"
 )
 
+# Keep availability checks in device code so target constants can propagate and
+# enclosing `metal_version()` guards can eliminate unavailable operations.
+@inline function check_atomic_memory_order(::Val{order}) where {order}
+    if order === memory_order_relaxed
+        return
+    elseif order === memory_order_acquire
+        @static_assert(metal_version() >= sv"4.1",
+                       "Atomic memory_order_acquire requires Metal 4.1 or newer.")
+    elseif order === memory_order_release
+        @static_assert(metal_version() >= sv"4.1",
+                       "Atomic memory_order_release requires Metal 4.1 or newer.")
+    elseif order === memory_order_acq_rel
+        @static_assert(metal_version() >= sv"4.1",
+                       "Atomic memory_order_acq_rel requires Metal 4.1 or newer.")
+    elseif order === memory_order_seq_cst
+        @static_assert(metal_version() >= sv"4.1",
+                       "Atomic memory_order_seq_cst requires Metal 4.1 or newer.")
+    else
+        @static_assert(false, "Invalid atomic memory ordering.")
+    end
+    return
+end
+
+@inline function check_atomic_flags()
+    @static_assert(metal_version() >= sv"4.1",
+                   "Atomic memory flags require Metal 4.1 or newer.")
+    return
+end
+
 
 ## low-level functions
 for typ in (:Int32, :UInt32), as in (AS.Device, AS.ThreadGroup)
     typnam = atomic_type_names[typ]
     memnam, memid = atomic_memory_names[as]
+    default_flags = as === AS.Device ? MemoryFlagDevice : MemoryFlagThreadGroup
 
     @eval begin
-        function atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ)
+        @inline atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ) =
+            atomic_store_explicit(ptr, desired, Val(memory_order_relaxed))
+        @inline atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                                      order::memory_order) =
+            atomic_store_explicit(ptr, desired, Val(order))
+        @inline atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                                      order::Val{memory_order_relaxed}) =
+            atomic_store_relaxed(ptr, desired)
+        @inline atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                                      order::Val) =
+            atomic_store_explicit(ptr, desired, order, Val($default_flags))
+        @inline atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                                      order::memory_order,
+                                      flags::Union{MemoryFlags,UInt32}) =
+            atomic_store_explicit(ptr, desired, Val(order), Val(flags))
+
+        function atomic_store_relaxed(ptr::LLVMPtr{$typ,$as}, desired::$typ)
             @typed_ccall($"air.atomic.$memnam.store.$typnam", llvmcall, Nothing,
                          (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Bool),
                          ptr, desired, Val(memory_order_relaxed), Val($memid), Val(true))
         end
 
-        function atomic_load_explicit(ptr::LLVMPtr{$typ,$as})
+        function atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                                       order::Val{O}, flags::Val{F}) where {O,F}
+            if !(O in (memory_order_relaxed, memory_order_release, memory_order_seq_cst))
+                @static_assert(false,
+                               "atomic_store_explicit only supports relaxed, release, or sequentially consistent ordering.")
+            end
+            check_atomic_memory_order(order)
+            check_atomic_flags()
+            @typed_ccall($"air.atomic.$memnam.store.$typnam", llvmcall, Nothing,
+                         (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Int32, Bool),
+                         ptr, desired, order, Val($memid), flags, Val(false))
+        end
+
+        @inline atomic_load_explicit(ptr::LLVMPtr{$typ,$as}) =
+            atomic_load_explicit(ptr, Val(memory_order_relaxed))
+        @inline atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, order::memory_order) =
+            atomic_load_explicit(ptr, Val(order))
+        @inline atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, order::Val{memory_order_relaxed}) =
+            atomic_load_relaxed(ptr)
+        @inline atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, order::Val) =
+            atomic_load_explicit(ptr, order, Val($default_flags))
+        @inline atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, order::memory_order,
+                                     flags::Union{MemoryFlags,UInt32}) =
+            atomic_load_explicit(ptr, Val(order), Val(flags))
+
+        function atomic_load_relaxed(ptr::LLVMPtr{$typ,$as})
             @typed_ccall($"air.atomic.$memnam.load.$typnam", llvmcall, $typ,
                          (LLVMPtr{$typ,$as}, Int32, Int32, Bool),
                          ptr, Val(memory_order_relaxed), Val($memid), Val(true))
         end
 
-        function atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ)
+        function atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, order::Val{O},
+                                      flags::Val{F}) where {O,F}
+            if !(O in (memory_order_relaxed, memory_order_acquire, memory_order_seq_cst))
+                @static_assert(false,
+                               "atomic_load_explicit only supports relaxed, acquire, or sequentially consistent ordering.")
+            end
+            check_atomic_memory_order(order)
+            check_atomic_flags()
+            @typed_ccall($"air.atomic.$memnam.load.$typnam", llvmcall, $typ,
+                         (LLVMPtr{$typ,$as}, Int32, Int32, Int32, Bool),
+                         ptr, order, Val($memid), flags, Val(false))
+        end
+
+        @inline atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ) =
+            atomic_exchange_explicit(ptr, desired, Val(memory_order_relaxed))
+        @inline atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                                         order::memory_order) =
+            atomic_exchange_explicit(ptr, desired, Val(order))
+        @inline atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                                         order::Val{memory_order_relaxed}) =
+            atomic_exchange_relaxed(ptr, desired)
+        @inline atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                                         order::Val) =
+            atomic_exchange_explicit(ptr, desired, order, Val($default_flags))
+        @inline atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                                         order::memory_order,
+                                         flags::Union{MemoryFlags,UInt32}) =
+            atomic_exchange_explicit(ptr, desired, Val(order), Val(flags))
+
+        function atomic_exchange_relaxed(ptr::LLVMPtr{$typ,$as}, desired::$typ)
             @typed_ccall($"air.atomic.$memnam.xchg.$typnam", llvmcall, $typ,
                          (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Bool),
                          ptr, desired, Val(memory_order_relaxed), Val($memid), Val(true))
         end
 
-        function atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
+        function atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                                          order::Val{O}, flags::Val{F}) where {O,F}
+            check_atomic_memory_order(order)
+            check_atomic_flags()
+            @typed_ccall($"air.atomic.$memnam.xchg.$typnam", llvmcall, $typ,
+                         (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Int32, Bool),
+                         ptr, desired, order, Val($memid), flags, Val(false))
+        end
+
+        @inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
+                                                      expected::$typ, desired::$typ) =
+            atomic_compare_exchange_weak_explicit(ptr, expected, desired,
+                                                  Val(memory_order_relaxed),
+                                                  Val(memory_order_relaxed))
+        @inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
+                                                      expected::$typ, desired::$typ,
+                                                      success_order::memory_order,
+                                                      failure_order::memory_order) =
+            atomic_compare_exchange_weak_explicit(ptr, expected, desired,
+                                                  Val(success_order),
+                                                  Val(failure_order))
+        @inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
+                                                      expected::$typ, desired::$typ,
+                                                      success_order::Val{memory_order_relaxed},
+                                                      failure_order::Val{memory_order_relaxed}) =
+            atomic_compare_exchange_weak_relaxed(ptr, expected, desired)
+        @inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
+                                                      expected::$typ, desired::$typ,
+                                                      success_order::Val,
+                                                      failure_order::Val) =
+            atomic_compare_exchange_weak_explicit(ptr, expected, desired, success_order,
+                                                  failure_order, Val($default_flags))
+        @inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
+                                                      expected::$typ, desired::$typ,
+                                                      success_order::memory_order,
+                                                      failure_order::memory_order,
+                                                      flags::Union{MemoryFlags,UInt32}) =
+            atomic_compare_exchange_weak_explicit(ptr, expected, desired, Val(success_order),
+                                                  Val(failure_order), Val(flags))
+
+        function atomic_compare_exchange_weak_relaxed(ptr::LLVMPtr{$typ,$as},
                                                        expected::$typ, desired::$typ)
+            expected_box = Ref(expected)
+            @typed_ccall($"air.atomic.$memnam.cmpxchg.weak.$typnam", llvmcall, $typ,
+                         (LLVMPtr{$typ,$as}, Ptr{$typ}, $typ, Int32, Int32, Int32, Bool),
+                         ptr, expected_box, desired, Val(memory_order_relaxed),
+                         Val(memory_order_relaxed),
+                         Val($memid), Val(true))
+            expected_box[]
+        end
+
+        function atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
+                                                       expected::$typ, desired::$typ,
+                                                       success_order::Val{S}, failure_order::Val{F},
+                                                       flags::Val{G}) where {S,F,G}
+            if !(F in (memory_order_relaxed, memory_order_acquire, memory_order_seq_cst)) ||
+               (S === memory_order_relaxed && F !== memory_order_relaxed) ||
+               (S === memory_order_acquire && F === memory_order_seq_cst) ||
+               (S === memory_order_release && F !== memory_order_relaxed) ||
+               (S === memory_order_acq_rel && F === memory_order_seq_cst)
+                @static_assert(false,
+                               "atomic_compare_exchange_weak_explicit failure ordering must be relaxed, acquire, or sequentially consistent and no stronger than the success ordering.")
+            end
+            check_atomic_memory_order(success_order)
+            check_atomic_memory_order(failure_order)
+            check_atomic_flags()
             # NOTE: we deviate slightly from the Metal/C++ API here, not returning the
             #       status boolean, but the contents of the expected value box, which will
             #       have been changed to the current value if the exchange failed.
             expected_box = Ref(expected)
             @typed_ccall($"air.atomic.$memnam.cmpxchg.weak.$typnam", llvmcall, $typ,
-                         (LLVMPtr{$typ,$as}, Ptr{$typ}, $typ, Int32, Int32, Int32, Bool),
-                         ptr, expected_box, desired, Val(memory_order_relaxed),
-                         Val(memory_order_relaxed), Val($memid), Val(true))
+                         (LLVMPtr{$typ,$as}, Ptr{$typ}, $typ, Int32, Int32, Int32, Int32, Bool),
+                         ptr, expected_box, desired, success_order,
+                         failure_order, Val($memid), flags, Val(false))
             expected_box[]
         end
     end
@@ -56,19 +220,91 @@ end
 
 # Float32 atomics are only available on Metal 3.0, and additionally only for
 # device memory, so we just skip them and reinterpret. That should be safe?
-atomic_store_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32) where {AS} =
-    atomic_store_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr), reinterpret(UInt32, desired))
-atomic_load_explicit(ptr::LLVMPtr{Float32,AS}) where {AS} =
-    reinterpret(Float32, atomic_load_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr)))
-atomic_exchange_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32) where {AS} =
+@inline atomic_store_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32) where {AS} =
+    atomic_store_explicit(ptr, desired, Val(memory_order_relaxed))
+@inline atomic_store_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
+                              order::memory_order) where {AS} =
+    atomic_store_explicit(ptr, desired, Val(order))
+@inline atomic_store_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
+                              order::memory_order,
+                              flags::Union{MemoryFlags,UInt32}) where {AS} =
+    atomic_store_explicit(ptr, desired, Val(order), Val(flags))
+@inline atomic_store_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
+                              order::Val) where {AS} =
+    atomic_store_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr),
+                          reinterpret(UInt32, desired), order)
+@inline atomic_store_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
+                              order::Val, flags::Val) where {AS} =
+    atomic_store_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr),
+                          reinterpret(UInt32, desired), order, flags)
+@inline atomic_load_explicit(ptr::LLVMPtr{Float32,AS}) where {AS} =
+    atomic_load_explicit(ptr, Val(memory_order_relaxed))
+@inline atomic_load_explicit(ptr::LLVMPtr{Float32,AS}, order::memory_order) where {AS} =
+    atomic_load_explicit(ptr, Val(order))
+@inline atomic_load_explicit(ptr::LLVMPtr{Float32,AS}, order::memory_order,
+                             flags::Union{MemoryFlags,UInt32}) where {AS} =
+    atomic_load_explicit(ptr, Val(order), Val(flags))
+@inline atomic_load_explicit(ptr::LLVMPtr{Float32,AS}, order::Val) where {AS} =
+    reinterpret(Float32, atomic_load_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr), order))
+@inline atomic_load_explicit(ptr::LLVMPtr{Float32,AS}, order::Val, flags::Val) where {AS} =
+    reinterpret(Float32,
+                atomic_load_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr), order, flags))
+@inline atomic_exchange_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32) where {AS} =
+    atomic_exchange_explicit(ptr, desired, Val(memory_order_relaxed))
+@inline atomic_exchange_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
+                                 order::memory_order) where {AS} =
+    atomic_exchange_explicit(ptr, desired, Val(order))
+@inline atomic_exchange_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
+                                 order::memory_order,
+                                 flags::Union{MemoryFlags,UInt32}) where {AS} =
+    atomic_exchange_explicit(ptr, desired, Val(order), Val(flags))
+@inline atomic_exchange_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
+                                 order::Val) where {AS} =
     reinterpret(Float32, atomic_exchange_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr),
-                                                  reinterpret(UInt32, desired)))
+                                                  reinterpret(UInt32, desired), order))
+@inline atomic_exchange_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
+                                 order::Val, flags::Val) where {AS} =
+    reinterpret(Float32, atomic_exchange_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr),
+                                                  reinterpret(UInt32, desired), order, flags))
+@inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{Float32,AS}, expected::Float32,
+                                              desired::Float32) where {AS} =
+    atomic_compare_exchange_weak_explicit(ptr, expected, desired,
+                                          Val(memory_order_relaxed),
+                                          Val(memory_order_relaxed))
+@inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{Float32,AS}, expected::Float32,
+                                              desired::Float32,
+                                              success_order::memory_order,
+                                              failure_order::memory_order) where {AS} =
+    atomic_compare_exchange_weak_explicit(ptr, expected, desired,
+                                          Val(success_order), Val(failure_order))
+@inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{Float32,AS}, expected::Float32,
+                                              desired::Float32,
+                                              success_order::memory_order,
+                                              failure_order::memory_order,
+                                              flags::Union{MemoryFlags,UInt32}) where {AS} =
+    atomic_compare_exchange_weak_explicit(ptr, expected, desired,
+                                          Val(success_order), Val(failure_order), Val(flags))
 function atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{Float32,AS}, expected::Float32,
-                                               desired::Float32) where {AS}
+                                               desired::Float32,
+                                               success_order::Val,
+                                               failure_order::Val) where {AS}
     ptr′ = reinterpret(LLVMPtr{UInt32,AS}, ptr)
     expected′ = reinterpret(UInt32, expected)
     desired′ = reinterpret(UInt32, desired)
-    return reinterpret(Float32, atomic_compare_exchange_weak_explicit(ptr′, expected′, desired′))
+    return reinterpret(Float32, atomic_compare_exchange_weak_explicit(ptr′, expected′, desired′,
+                                                                     success_order, failure_order))
+end
+function atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{Float32,AS}, expected::Float32,
+                                               desired::Float32,
+                                               success_order::Val,
+                                               failure_order::Val,
+                                               flags::Val) where {AS}
+    ptr′ = reinterpret(LLVMPtr{UInt32,AS}, ptr)
+    expected′ = reinterpret(UInt32, expected)
+    desired′ = reinterpret(UInt32, desired)
+    return reinterpret(Float32, atomic_compare_exchange_weak_explicit(ptr′, expected′, desired′,
+                                                                     success_order, failure_order,
+                                                                     flags))
 end
 
 const atomic_fetch_and_modify = [
@@ -89,12 +325,35 @@ for (op, types) in atomic_fetch_and_modify, typ in types, as in (AS.Device, AS.T
         typnam = "u.$typnam"
     end
     memnam, memid = atomic_memory_names[as]
+    default_flags = as === AS.Device ? MemoryFlagDevice : MemoryFlagThreadGroup
     f = Symbol("atomic_fetch_$(op)_explicit")
+    relaxed_f = Symbol("atomic_fetch_$(op)_relaxed")
     @eval begin
-        function $f(ptr::LLVMPtr{$typ,$as}, desired::$typ)
+        @inline $f(ptr::LLVMPtr{$typ,$as}, desired::$typ) =
+            $f(ptr, desired, Val(memory_order_relaxed))
+        @inline $f(ptr::LLVMPtr{$typ,$as}, desired::$typ, order::memory_order) =
+            $f(ptr, desired, Val(order))
+        @inline $f(ptr::LLVMPtr{$typ,$as}, desired::$typ,
+                   order::Val{memory_order_relaxed}) =
+            $relaxed_f(ptr, desired)
+        @inline $f(ptr::LLVMPtr{$typ,$as}, desired::$typ, order::Val) =
+            $f(ptr, desired, order, Val($default_flags))
+        @inline $f(ptr::LLVMPtr{$typ,$as}, desired::$typ, order::memory_order,
+                   flags::Union{MemoryFlags,UInt32}) =
+            $f(ptr, desired, Val(order), Val(flags))
+
+        function $relaxed_f(ptr::LLVMPtr{$typ,$as}, desired::$typ)
             @typed_ccall($"air.atomic.$memnam.$op.$typnam", llvmcall, $typ,
                          (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Bool),
                          ptr, desired, Val(memory_order_relaxed), Val($memid), Val(true))
+        end
+
+        function $f(ptr::LLVMPtr{$typ,$as}, desired::$typ, order::Val, flags::Val)
+            check_atomic_memory_order(order)
+            check_atomic_flags()
+            @typed_ccall($"air.atomic.$memnam.$op.$typnam", llvmcall, $typ,
+                         (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Int32, Bool),
+                         ptr, desired, order, Val($memid), flags, Val(false))
         end
     end
 end
@@ -102,12 +361,41 @@ end
 # TODO: non-fetch 64-bit min/max atomics (hardware support?)
 
 # generic atomic support using compare-and-swap
-@inline function atomic_fetch_op_explicit(ptr::LLVMPtr{T}, op::Function, val) where {T}
-    old = Base.unsafe_load(ptr)
+@inline atomic_fetch_op_failure_order(order::Val) = order
+@inline atomic_fetch_op_failure_order(::Val{memory_order_release}) = Val(memory_order_relaxed)
+@inline atomic_fetch_op_failure_order(::Val{memory_order_acq_rel}) = Val(memory_order_acquire)
+
+@inline atomic_fetch_op_explicit(ptr::LLVMPtr{T}, op::Function, val) where {T} =
+    atomic_fetch_op_explicit(ptr, op, val, Val(memory_order_relaxed))
+@inline atomic_fetch_op_explicit(ptr::LLVMPtr{T}, op::Function, val,
+                                 order::memory_order) where {T} =
+    atomic_fetch_op_explicit(ptr, op, val, Val(order))
+@inline atomic_fetch_op_explicit(ptr::LLVMPtr{T}, op::Function, val,
+                                 order::memory_order,
+                                 flags::Union{MemoryFlags,UInt32}) where {T} =
+    atomic_fetch_op_explicit(ptr, op, val, Val(order), Val(flags))
+
+@inline function atomic_fetch_op_explicit(ptr::LLVMPtr{T}, op::Function, val,
+                                          order::Val) where {T}
+    failure_order = atomic_fetch_op_failure_order(order)
+    old = atomic_load_explicit(ptr, failure_order)
     while true
         cmp = old
         new = convert(T, op(old, val))
-        old = atomic_compare_exchange_weak_explicit(ptr, cmp, new)
+        old = atomic_compare_exchange_weak_explicit(ptr, cmp, new, order, failure_order)
+        isequal(old, cmp) && return old
+    end
+end
+
+@inline function atomic_fetch_op_explicit(ptr::LLVMPtr{T}, op::Function, val,
+                                          order::Val, flags::Val) where {T}
+    failure_order = atomic_fetch_op_failure_order(order)
+    old = atomic_load_explicit(ptr, failure_order, flags)
+    while true
+        cmp = old
+        new = convert(T, op(old, val))
+        old = atomic_compare_exchange_weak_explicit(ptr, cmp, new, order, failure_order,
+                                                    flags)
         isequal(old, cmp) && return old
     end
 end

--- a/src/device/intrinsics/atomics.jl
+++ b/src/device/intrinsics/atomics.jl
@@ -1,58 +1,15 @@
 # Atomic Functions
 
-# XXX: the integers should come from some enum
-const atomic_memory_names = Dict(
-    AS.Device      => ("global", Int32(2)),
-    AS.ThreadGroup => ("local",  Int32(1))
+const atomic_memory_spaces = (
+    (AS.Device,      "global", thread_scope_device),
+    (AS.ThreadGroup, "local",  thread_scope_threadgroup),
 )
-
-const atomic_type_names = Dict(
-    :Int32   => "i32",
-    :UInt32  => "i32",
-    :Int64   => "i64",
-    :UInt64  => "i64",
-    :Float32 => "f32"
-)
-
-# Keep availability checks in device code so target constants can propagate and
-# enclosing `metal_version()` guards can eliminate unavailable operations.
-@inline function check_atomic_memory_order(::Val{order}) where {order}
-    if order === memory_order_relaxed
-        return
-    elseif order === memory_order_acquire
-        @static_assert(metal_version() >= sv"4.1",
-                       "Atomic memory_order_acquire requires Metal 4.1 or newer.")
-    elseif order === memory_order_release
-        @static_assert(metal_version() >= sv"4.1",
-                       "Atomic memory_order_release requires Metal 4.1 or newer.")
-    elseif order === memory_order_acq_rel
-        @static_assert(metal_version() >= sv"4.1",
-                       "Atomic memory_order_acq_rel requires Metal 4.1 or newer.")
-    elseif order === memory_order_seq_cst
-        @static_assert(metal_version() >= sv"4.1",
-                       "Atomic memory_order_seq_cst requires Metal 4.1 or newer.")
-    else
-        @static_assert(false, "Invalid atomic memory ordering.")
-    end
-    return
-end
-
-@inline function check_atomic_flags()
-    @static_assert(metal_version() >= sv"4.1",
-                   "Atomic memory flags require Metal 4.1 or newer.")
-    return
-end
 
 
 @inline function default_atomic_flags(order::memory_order, ::Val{A}) where {A}
     order === memory_order_relaxed && return MemoryFlagNone
     A === AS.Device ? MemoryFlagDevice : MemoryFlagThreadGroup
 end
-
-@inline valid_atomic_order(order) =
-    order === memory_order_relaxed || order === memory_order_acquire ||
-    order === memory_order_release || order === memory_order_acq_rel ||
-    order === memory_order_seq_cst
 
 # MSL 4.1 requires callers to spell out flags for ordered atomics. We instead default
 # to the memory region addressed by the pointer, while retaining mem_none for relaxed
@@ -61,77 +18,29 @@ end
     (order === memory_order_relaxed && flags == MemoryFlagNone) ||
     metal_version() >= sv"4.1"
 
-# MSL specification section 6.15: failure ordering is restricted to relaxed, acquire,
-# or sequentially consistent, and may not be stronger than the success ordering.
-@inline function valid_atomic_compare_exchange_failure_order(success, failure)
-    (failure === memory_order_relaxed || failure === memory_order_acquire ||
-     failure === memory_order_seq_cst) ||
-        return false
-    success === memory_order_relaxed && return failure === memory_order_relaxed
-    success === memory_order_acquire && return failure !== memory_order_seq_cst
-    success === memory_order_release && return failure === memory_order_relaxed
-    success === memory_order_acq_rel && return failure !== memory_order_seq_cst
-    success === memory_order_seq_cst
+@inline function validate_atomic_arguments(::Val{order}, ::Val{flags}) where {order, flags}
+    @static_assert(order isa memory_order, "Invalid atomic memory ordering.")
+    @static_assert(atomic_order_and_flags_available(order, flags),
+                   "Ordered atomics and memory flags require Metal 4.1 or newer.")
 end
 
 ## low-level functions
-for typ in (:Int32, :UInt32), as in (AS.Device, AS.ThreadGroup)
-    typnam = atomic_type_names[typ]
-    memnam, memid = atomic_memory_names[as]
+for (typ, typnam) in ((:Int32, "i32"), (:UInt32, "i32")),
+    (as, memnam, scope) in atomic_memory_spaces
 
     @eval begin
-        @inline function atomic_store_explicit(
-            ptr::LLVMPtr{$typ,$as}, desired::$typ,
-            order::memory_order=memory_order_relaxed,
-            flags::Union{MemoryFlags,UInt32}=default_atomic_flags(order, Val($as)))
-            atomic_store_explicit(ptr, desired, Val(order), Val(flags))
-        end
-
-        function atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
-                                       ::Val{O}, ::Val{F}) where {O,F}
-            @static_assert(O === memory_order_relaxed || O === memory_order_release ||
-                           O === memory_order_seq_cst,
-                           "atomic_store_explicit only supports relaxed, release, or sequentially consistent ordering.")
-            @static_assert(atomic_order_and_flags_available(O, F),
-                           "Ordered atomics and memory flags require Metal 4.1 or newer.")
-            @typed_ccall($"air.atomic.$memnam.store.$typnam", llvmcall, Nothing,
-                         (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Int32, Bool),
-                         ptr, desired, Val(O), Val($memid), Val(F), Val(false))
-        end
-
         @inline function atomic_load_explicit(
             ptr::LLVMPtr{$typ,$as}, order::memory_order=memory_order_relaxed,
             flags::Union{MemoryFlags,UInt32}=default_atomic_flags(order, Val($as)))
             atomic_load_explicit(ptr, Val(order), Val(flags))
         end
 
-        function atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, ::Val{O},
-                                      ::Val{F}) where {O,F}
-            @static_assert(O === memory_order_relaxed || O === memory_order_acquire ||
-                           O === memory_order_seq_cst,
-                           "atomic_load_explicit only supports relaxed, acquire, or sequentially consistent ordering.")
-            @static_assert(atomic_order_and_flags_available(O, F),
-                           "Ordered atomics and memory flags require Metal 4.1 or newer.")
+        function atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, ::Val{order},
+                                      ::Val{flags}) where {order, flags}
+            validate_atomic_arguments(Val(order), Val(flags))
             @typed_ccall($"air.atomic.$memnam.load.$typnam", llvmcall, $typ,
                          (LLVMPtr{$typ,$as}, Int32, Int32, Int32, Bool),
-                         ptr, Val(O), Val($memid), Val(F), Val(false))
-        end
-
-        @inline function atomic_exchange_explicit(
-            ptr::LLVMPtr{$typ,$as}, desired::$typ,
-            order::memory_order=memory_order_relaxed,
-            flags::Union{MemoryFlags,UInt32}=default_atomic_flags(order, Val($as)))
-            atomic_exchange_explicit(ptr, desired, Val(order), Val(flags))
-        end
-
-        function atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
-                                          ::Val{O}, ::Val{F}) where {O,F}
-            @static_assert(valid_atomic_order(O), "Invalid atomic memory ordering.")
-            @static_assert(atomic_order_and_flags_available(O, F),
-                           "Ordered atomics and memory flags require Metal 4.1 or newer.")
-            @typed_ccall($"air.atomic.$memnam.xchg.$typnam", llvmcall, $typ,
-                         (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Int32, Bool),
-                         ptr, desired, Val(O), Val($memid), Val(F), Val(false))
+                         ptr, Val(order), Val($scope), Val(flags), Val(false))
         end
 
         @inline function atomic_compare_exchange_weak_explicit(
@@ -145,22 +54,62 @@ for typ in (:Int32, :UInt32), as in (AS.Device, AS.ThreadGroup)
 
         function atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
                                                        expected::$typ, desired::$typ,
-                                                       ::Val{S}, ::Val{F},
-                                                       ::Val{G}) where {S,F,G}
-            @static_assert(valid_atomic_order(S), "Invalid atomic memory ordering.")
-            @static_assert(valid_atomic_compare_exchange_failure_order(S, F),
-                           "atomic_compare_exchange_weak_explicit failure ordering must be relaxed, acquire, or sequentially consistent and no stronger than the success ordering.")
-            @static_assert(atomic_order_and_flags_available(S, G),
-                           "Ordered atomics and memory flags require Metal 4.1 or newer.")
+                                                       ::Val{success_order}, ::Val{failure_order},
+                                                       ::Val{flags}) where {success_order, failure_order, flags}
+            validate_atomic_arguments(Val(success_order), Val(flags))
+            @static_assert(failure_order isa memory_order, "Invalid atomic memory ordering.")
             # NOTE: we deviate slightly from the Metal/C++ API here, not returning the
             #       status boolean, but the contents of the expected value box, which will
             #       have been changed to the current value if the exchange failed.
             expected_box = Ref(expected)
             @typed_ccall($"air.atomic.$memnam.cmpxchg.weak.$typnam", llvmcall, $typ,
                          (LLVMPtr{$typ,$as}, Ptr{$typ}, $typ, Int32, Int32, Int32, Int32, Bool),
-                         ptr, expected_box, desired, Val(S),
-                         Val(F), Val($memid), Val(G), Val(false))
+                         ptr, expected_box, desired, Val(success_order),
+                         Val(failure_order), Val($scope), Val(flags), Val(false))
             expected_box[]
+        end
+    end
+end
+
+const atomic_value_intrinsics = (
+    (:store,     "store", (:Int32, :UInt32),           false),
+    (:exchange,  "xchg",  (:Int32, :UInt32),           true),
+    (:fetch_add, "add",   (:Int32, :UInt32, :Float32), true),
+    (:fetch_sub, "sub",   (:Int32, :UInt32, :Float32), true),
+    (:fetch_min, "min",   (:Int32, :UInt32),           true),
+    (:fetch_max, "max",   (:Int32, :UInt32),           true),
+    (:fetch_and, "and",   (:Int32, :UInt32),           true),
+    (:fetch_or,  "or",    (:Int32, :UInt32),           true),
+    (:fetch_xor, "xor",   (:Int32, :UInt32),           true),
+)
+
+for (op, air_op, types, returns) in atomic_value_intrinsics, typ in types,
+    (as, memnam, scope) in atomic_memory_spaces
+    typnam = typ === :Float32 ? "f32" : "i32"
+    if op ∉ (:store, :exchange) && typ !== :Float32
+        typnam = "$(typ === :Int32 ? "s" : "u").$typnam"
+    end
+    f = Symbol("atomic_$(op)_explicit")
+    return_type = returns ? typ : :Nothing
+    availability = op ∈ (:fetch_add, :fetch_sub) && typ === :Float32 && as === AS.ThreadGroup ?
+        :(@static_assert(metal_version() >= sv"4.1",
+                          "Float32 threadgroup atomic operations require Metal 4.1 or newer.")) :
+        nothing
+
+    @eval begin
+        @inline function $f(
+            ptr::LLVMPtr{$typ,$as}, desired::$typ,
+            order::memory_order=memory_order_relaxed,
+            flags::Union{MemoryFlags,UInt32}=default_atomic_flags(order, Val($as)))
+            $f(ptr, desired, Val(order), Val(flags))
+        end
+
+        function $f(ptr::LLVMPtr{$typ,$as}, desired::$typ, ::Val{order}, ::Val{flags}) where {order, flags}
+            validate_atomic_arguments(Val(order), Val(flags))
+            $availability
+            @typed_ccall($"air.atomic.$memnam.$air_op.$typnam", llvmcall, $return_type,
+                         (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Int32, Bool),
+                         ptr, desired, Val(order), Val($scope), Val(flags), Val(false))
         end
     end
 end
@@ -212,44 +161,6 @@ function atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{Float32,AS}, expecte
                                                                      flags))
 end
 
-const atomic_fetch_and_modify = [
-    :add => [:Int32, :UInt32, :Float32],
-    :sub => [:Int32, :UInt32, :Float32],
-    :min => [:Int32, :UInt32],
-    :max => [:Int32, :UInt32],
-    :and => [:Int32, :UInt32],
-    :or  => [:Int32, :UInt32],
-    :xor => [:Int32, :UInt32]
-]
-
-for (op, types) in atomic_fetch_and_modify, typ in types, as in (AS.Device, AS.ThreadGroup)
-    typnam = atomic_type_names[typ]
-    if typ in [:Int32, :Int64]
-        typnam = "s.$typnam"
-    elseif typ in [:UInt32, :UInt64]
-        typnam = "u.$typnam"
-    end
-    memnam, memid = atomic_memory_names[as]
-    f = Symbol("atomic_fetch_$(op)_explicit")
-    @eval begin
-        @inline function $f(
-            ptr::LLVMPtr{$typ,$as}, desired::$typ,
-            order::memory_order=memory_order_relaxed,
-            flags::Union{MemoryFlags,UInt32}=default_atomic_flags(order, Val($as)))
-            $f(ptr, desired, Val(order), Val(flags))
-        end
-
-        function $f(ptr::LLVMPtr{$typ,$as}, desired::$typ, ::Val{O}, ::Val{F}) where {O,F}
-            @static_assert(valid_atomic_order(O), "Invalid atomic memory ordering.")
-            @static_assert(atomic_order_and_flags_available(O, F),
-                           "Ordered atomics and memory flags require Metal 4.1 or newer.")
-            @typed_ccall($"air.atomic.$memnam.$op.$typnam", llvmcall, $typ,
-                         (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Int32, Bool),
-                         ptr, desired, Val(O), Val($memid), Val(F), Val(false))
-        end
-    end
-end
-
 # TODO: non-fetch 64-bit min/max atomics (hardware support?)
 
 # generic atomic support using compare-and-swap
@@ -276,7 +187,6 @@ end
         isequal(old, cmp) && return old
     end
 end
-
 
 ## high-level interface
 
@@ -398,14 +308,13 @@ end
 @inline function atomic_arrayset(A::AbstractArray{T}, I::Integer, op::typeof(+),
                                  val::T) where {T <: AbstractFloat}
     ptr = pointer(A, I)
-    # XXX: consider falling back to fetch_op here to support Metal < 3.0 (this also requires
-    #      cmpxchg support for Float32, but we should be able to do that using bitcast)
+    # Float32 add/sub are native for device memory since Metal 3.0, and for threadgroup
+    # memory since Metal 4.1. Earlier threadgroup targets fail in the intrinsic itself.
     atomic_fetch_add_explicit(ptr, val)
 end
 @inline function atomic_arrayset(A::AbstractArray{T}, I::Integer, op::typeof(-),
                                  val::T) where {T <: AbstractFloat}
     ptr = pointer(A, I)
-    # XXX: see above
     atomic_fetch_sub_explicit(ptr, val)
 end
 

--- a/src/device/intrinsics/atomics.jl
+++ b/src/device/intrinsics/atomics.jl
@@ -49,9 +49,10 @@ end
     A === AS.Device ? MemoryFlagDevice : MemoryFlagThreadGroup
 end
 
-const valid_atomic_orders = (memory_order_relaxed, memory_order_acquire,
-                             memory_order_release, memory_order_acq_rel,
-                             memory_order_seq_cst)
+@inline valid_atomic_order(order) =
+    order === memory_order_relaxed || order === memory_order_acquire ||
+    order === memory_order_release || order === memory_order_acq_rel ||
+    order === memory_order_seq_cst
 
 # MSL 4.1 requires callers to spell out flags for ordered atomics. We instead default
 # to the memory region addressed by the pointer, while retaining mem_none for relaxed
@@ -63,7 +64,8 @@ const valid_atomic_orders = (memory_order_relaxed, memory_order_acquire,
 # MSL specification section 6.15: failure ordering is restricted to relaxed, acquire,
 # or sequentially consistent, and may not be stronger than the success ordering.
 @inline function valid_atomic_compare_exchange_failure_order(success, failure)
-    failure in (memory_order_relaxed, memory_order_acquire, memory_order_seq_cst) ||
+    (failure === memory_order_relaxed || failure === memory_order_acquire ||
+     failure === memory_order_seq_cst) ||
         return false
     success === memory_order_relaxed && return failure === memory_order_relaxed
     success === memory_order_acquire && return failure !== memory_order_seq_cst
@@ -87,8 +89,8 @@ for typ in (:Int32, :UInt32), as in (AS.Device, AS.ThreadGroup)
 
         function atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
                                        ::Val{O}, ::Val{F}) where {O,F}
-            @static_assert(O in (memory_order_relaxed, memory_order_release,
-                                 memory_order_seq_cst),
+            @static_assert(O === memory_order_relaxed || O === memory_order_release ||
+                           O === memory_order_seq_cst,
                            "atomic_store_explicit only supports relaxed, release, or sequentially consistent ordering.")
             @static_assert(atomic_order_and_flags_available(O, F),
                            "Ordered atomics and memory flags require Metal 4.1 or newer.")
@@ -105,8 +107,8 @@ for typ in (:Int32, :UInt32), as in (AS.Device, AS.ThreadGroup)
 
         function atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, ::Val{O},
                                       ::Val{F}) where {O,F}
-            @static_assert(O in (memory_order_relaxed, memory_order_acquire,
-                                 memory_order_seq_cst),
+            @static_assert(O === memory_order_relaxed || O === memory_order_acquire ||
+                           O === memory_order_seq_cst,
                            "atomic_load_explicit only supports relaxed, acquire, or sequentially consistent ordering.")
             @static_assert(atomic_order_and_flags_available(O, F),
                            "Ordered atomics and memory flags require Metal 4.1 or newer.")
@@ -124,7 +126,7 @@ for typ in (:Int32, :UInt32), as in (AS.Device, AS.ThreadGroup)
 
         function atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
                                           ::Val{O}, ::Val{F}) where {O,F}
-            @static_assert(O in valid_atomic_orders, "Invalid atomic memory ordering.")
+            @static_assert(valid_atomic_order(O), "Invalid atomic memory ordering.")
             @static_assert(atomic_order_and_flags_available(O, F),
                            "Ordered atomics and memory flags require Metal 4.1 or newer.")
             @typed_ccall($"air.atomic.$memnam.xchg.$typnam", llvmcall, $typ,
@@ -145,7 +147,7 @@ for typ in (:Int32, :UInt32), as in (AS.Device, AS.ThreadGroup)
                                                        expected::$typ, desired::$typ,
                                                        ::Val{S}, ::Val{F},
                                                        ::Val{G}) where {S,F,G}
-            @static_assert(S in valid_atomic_orders, "Invalid atomic memory ordering.")
+            @static_assert(valid_atomic_order(S), "Invalid atomic memory ordering.")
             @static_assert(valid_atomic_compare_exchange_failure_order(S, F),
                            "atomic_compare_exchange_weak_explicit failure ordering must be relaxed, acquire, or sequentially consistent and no stronger than the success ordering.")
             @static_assert(atomic_order_and_flags_available(S, G),
@@ -238,7 +240,7 @@ for (op, types) in atomic_fetch_and_modify, typ in types, as in (AS.Device, AS.T
         end
 
         function $f(ptr::LLVMPtr{$typ,$as}, desired::$typ, ::Val{O}, ::Val{F}) where {O,F}
-            @static_assert(O in valid_atomic_orders, "Invalid atomic memory ordering.")
+            @static_assert(valid_atomic_order(O), "Invalid atomic memory ordering.")
             @static_assert(atomic_order_and_flags_available(O, F),
                            "Ordered atomics and memory flags require Metal 4.1 or newer.")
             @typed_ccall($"air.atomic.$memnam.$op.$typnam", llvmcall, $typ,

--- a/src/device/intrinsics/atomics.jl
+++ b/src/device/intrinsics/atomics.jl
@@ -44,261 +44,164 @@ end
 end
 
 
+@inline function default_atomic_flags(order::memory_order, ::Val{A}) where {A}
+    order === memory_order_relaxed && return MemoryFlagNone
+    A === AS.Device ? MemoryFlagDevice : MemoryFlagThreadGroup
+end
+
+const valid_atomic_orders = (memory_order_relaxed, memory_order_acquire,
+                             memory_order_release, memory_order_acq_rel,
+                             memory_order_seq_cst)
+
+# MSL 4.1 requires callers to spell out flags for ordered atomics. We instead default
+# to the memory region addressed by the pointer, while retaining mem_none for relaxed
+# operations to match the no-flags MSL overload.
+@inline atomic_order_and_flags_available(order, flags) =
+    (order === memory_order_relaxed && flags == MemoryFlagNone) ||
+    metal_version() >= sv"4.1"
+
+# MSL specification section 6.15: failure ordering is restricted to relaxed, acquire,
+# or sequentially consistent, and may not be stronger than the success ordering.
+@inline function valid_atomic_compare_exchange_failure_order(success, failure)
+    failure in (memory_order_relaxed, memory_order_acquire, memory_order_seq_cst) ||
+        return false
+    success === memory_order_relaxed && return failure === memory_order_relaxed
+    success === memory_order_acquire && return failure !== memory_order_seq_cst
+    success === memory_order_release && return failure === memory_order_relaxed
+    success === memory_order_acq_rel && return failure !== memory_order_seq_cst
+    success === memory_order_seq_cst
+end
+
 ## low-level functions
 for typ in (:Int32, :UInt32), as in (AS.Device, AS.ThreadGroup)
     typnam = atomic_type_names[typ]
     memnam, memid = atomic_memory_names[as]
-    default_flags = as === AS.Device ? MemoryFlagDevice : MemoryFlagThreadGroup
 
     @eval begin
-        @inline atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ) =
-            atomic_store_explicit(ptr, desired, Val(memory_order_relaxed))
-        @inline atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
-                                      order::memory_order) =
-            atomic_store_explicit(ptr, desired, Val(order))
-        @inline atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
-                                      order::Val{memory_order_relaxed}) =
-            atomic_store_relaxed(ptr, desired)
-        @inline atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
-                                      order::Val) =
-            atomic_store_explicit(ptr, desired, order, Val($default_flags))
-        @inline atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
-                                      order::memory_order,
-                                      flags::Union{MemoryFlags,UInt32}) =
+        @inline function atomic_store_explicit(
+            ptr::LLVMPtr{$typ,$as}, desired::$typ,
+            order::memory_order=memory_order_relaxed,
+            flags::Union{MemoryFlags,UInt32}=default_atomic_flags(order, Val($as)))
             atomic_store_explicit(ptr, desired, Val(order), Val(flags))
-
-        function atomic_store_relaxed(ptr::LLVMPtr{$typ,$as}, desired::$typ)
-            @typed_ccall($"air.atomic.$memnam.store.$typnam", llvmcall, Nothing,
-                         (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Bool),
-                         ptr, desired, Val(memory_order_relaxed), Val($memid), Val(true))
         end
 
         function atomic_store_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
-                                       order::Val{O}, flags::Val{F}) where {O,F}
-            if !(O in (memory_order_relaxed, memory_order_release, memory_order_seq_cst))
-                @static_assert(false,
-                               "atomic_store_explicit only supports relaxed, release, or sequentially consistent ordering.")
-            end
-            check_atomic_memory_order(order)
-            check_atomic_flags()
+                                       ::Val{O}, ::Val{F}) where {O,F}
+            @static_assert(O in (memory_order_relaxed, memory_order_release,
+                                 memory_order_seq_cst),
+                           "atomic_store_explicit only supports relaxed, release, or sequentially consistent ordering.")
+            @static_assert(atomic_order_and_flags_available(O, F),
+                           "Ordered atomics and memory flags require Metal 4.1 or newer.")
             @typed_ccall($"air.atomic.$memnam.store.$typnam", llvmcall, Nothing,
                          (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Int32, Bool),
-                         ptr, desired, order, Val($memid), flags, Val(false))
+                         ptr, desired, Val(O), Val($memid), Val(F), Val(false))
         end
 
-        @inline atomic_load_explicit(ptr::LLVMPtr{$typ,$as}) =
-            atomic_load_explicit(ptr, Val(memory_order_relaxed))
-        @inline atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, order::memory_order) =
-            atomic_load_explicit(ptr, Val(order))
-        @inline atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, order::Val{memory_order_relaxed}) =
-            atomic_load_relaxed(ptr)
-        @inline atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, order::Val) =
-            atomic_load_explicit(ptr, order, Val($default_flags))
-        @inline atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, order::memory_order,
-                                     flags::Union{MemoryFlags,UInt32}) =
+        @inline function atomic_load_explicit(
+            ptr::LLVMPtr{$typ,$as}, order::memory_order=memory_order_relaxed,
+            flags::Union{MemoryFlags,UInt32}=default_atomic_flags(order, Val($as)))
             atomic_load_explicit(ptr, Val(order), Val(flags))
-
-        function atomic_load_relaxed(ptr::LLVMPtr{$typ,$as})
-            @typed_ccall($"air.atomic.$memnam.load.$typnam", llvmcall, $typ,
-                         (LLVMPtr{$typ,$as}, Int32, Int32, Bool),
-                         ptr, Val(memory_order_relaxed), Val($memid), Val(true))
         end
 
-        function atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, order::Val{O},
-                                      flags::Val{F}) where {O,F}
-            if !(O in (memory_order_relaxed, memory_order_acquire, memory_order_seq_cst))
-                @static_assert(false,
-                               "atomic_load_explicit only supports relaxed, acquire, or sequentially consistent ordering.")
-            end
-            check_atomic_memory_order(order)
-            check_atomic_flags()
+        function atomic_load_explicit(ptr::LLVMPtr{$typ,$as}, ::Val{O},
+                                      ::Val{F}) where {O,F}
+            @static_assert(O in (memory_order_relaxed, memory_order_acquire,
+                                 memory_order_seq_cst),
+                           "atomic_load_explicit only supports relaxed, acquire, or sequentially consistent ordering.")
+            @static_assert(atomic_order_and_flags_available(O, F),
+                           "Ordered atomics and memory flags require Metal 4.1 or newer.")
             @typed_ccall($"air.atomic.$memnam.load.$typnam", llvmcall, $typ,
                          (LLVMPtr{$typ,$as}, Int32, Int32, Int32, Bool),
-                         ptr, order, Val($memid), flags, Val(false))
+                         ptr, Val(O), Val($memid), Val(F), Val(false))
         end
 
-        @inline atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ) =
-            atomic_exchange_explicit(ptr, desired, Val(memory_order_relaxed))
-        @inline atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
-                                         order::memory_order) =
-            atomic_exchange_explicit(ptr, desired, Val(order))
-        @inline atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
-                                         order::Val{memory_order_relaxed}) =
-            atomic_exchange_relaxed(ptr, desired)
-        @inline atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
-                                         order::Val) =
-            atomic_exchange_explicit(ptr, desired, order, Val($default_flags))
-        @inline atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
-                                         order::memory_order,
-                                         flags::Union{MemoryFlags,UInt32}) =
+        @inline function atomic_exchange_explicit(
+            ptr::LLVMPtr{$typ,$as}, desired::$typ,
+            order::memory_order=memory_order_relaxed,
+            flags::Union{MemoryFlags,UInt32}=default_atomic_flags(order, Val($as)))
             atomic_exchange_explicit(ptr, desired, Val(order), Val(flags))
-
-        function atomic_exchange_relaxed(ptr::LLVMPtr{$typ,$as}, desired::$typ)
-            @typed_ccall($"air.atomic.$memnam.xchg.$typnam", llvmcall, $typ,
-                         (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Bool),
-                         ptr, desired, Val(memory_order_relaxed), Val($memid), Val(true))
         end
 
         function atomic_exchange_explicit(ptr::LLVMPtr{$typ,$as}, desired::$typ,
-                                          order::Val{O}, flags::Val{F}) where {O,F}
-            check_atomic_memory_order(order)
-            check_atomic_flags()
+                                          ::Val{O}, ::Val{F}) where {O,F}
+            @static_assert(O in valid_atomic_orders, "Invalid atomic memory ordering.")
+            @static_assert(atomic_order_and_flags_available(O, F),
+                           "Ordered atomics and memory flags require Metal 4.1 or newer.")
             @typed_ccall($"air.atomic.$memnam.xchg.$typnam", llvmcall, $typ,
                          (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Int32, Bool),
-                         ptr, desired, order, Val($memid), flags, Val(false))
+                         ptr, desired, Val(O), Val($memid), Val(F), Val(false))
         end
 
-        @inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
-                                                      expected::$typ, desired::$typ) =
-            atomic_compare_exchange_weak_explicit(ptr, expected, desired,
-                                                  Val(memory_order_relaxed),
-                                                  Val(memory_order_relaxed))
-        @inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
-                                                      expected::$typ, desired::$typ,
-                                                      success_order::memory_order,
-                                                      failure_order::memory_order) =
-            atomic_compare_exchange_weak_explicit(ptr, expected, desired,
-                                                  Val(success_order),
-                                                  Val(failure_order))
-        @inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
-                                                      expected::$typ, desired::$typ,
-                                                      success_order::Val{memory_order_relaxed},
-                                                      failure_order::Val{memory_order_relaxed}) =
-            atomic_compare_exchange_weak_relaxed(ptr, expected, desired)
-        @inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
-                                                      expected::$typ, desired::$typ,
-                                                      success_order::Val,
-                                                      failure_order::Val) =
-            atomic_compare_exchange_weak_explicit(ptr, expected, desired, success_order,
-                                                  failure_order, Val($default_flags))
-        @inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
-                                                      expected::$typ, desired::$typ,
-                                                      success_order::memory_order,
-                                                      failure_order::memory_order,
-                                                      flags::Union{MemoryFlags,UInt32}) =
+        @inline function atomic_compare_exchange_weak_explicit(
+            ptr::LLVMPtr{$typ,$as}, expected::$typ, desired::$typ,
+            success_order::memory_order=memory_order_relaxed,
+            failure_order::memory_order=memory_order_relaxed,
+            flags::Union{MemoryFlags,UInt32}=default_atomic_flags(success_order, Val($as)))
             atomic_compare_exchange_weak_explicit(ptr, expected, desired, Val(success_order),
                                                   Val(failure_order), Val(flags))
-
-        function atomic_compare_exchange_weak_relaxed(ptr::LLVMPtr{$typ,$as},
-                                                       expected::$typ, desired::$typ)
-            expected_box = Ref(expected)
-            @typed_ccall($"air.atomic.$memnam.cmpxchg.weak.$typnam", llvmcall, $typ,
-                         (LLVMPtr{$typ,$as}, Ptr{$typ}, $typ, Int32, Int32, Int32, Bool),
-                         ptr, expected_box, desired, Val(memory_order_relaxed),
-                         Val(memory_order_relaxed),
-                         Val($memid), Val(true))
-            expected_box[]
         end
 
         function atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{$typ,$as},
                                                        expected::$typ, desired::$typ,
-                                                       success_order::Val{S}, failure_order::Val{F},
-                                                       flags::Val{G}) where {S,F,G}
-            if !(F in (memory_order_relaxed, memory_order_acquire, memory_order_seq_cst)) ||
-               (S === memory_order_relaxed && F !== memory_order_relaxed) ||
-               (S === memory_order_acquire && F === memory_order_seq_cst) ||
-               (S === memory_order_release && F !== memory_order_relaxed) ||
-               (S === memory_order_acq_rel && F === memory_order_seq_cst)
-                @static_assert(false,
-                               "atomic_compare_exchange_weak_explicit failure ordering must be relaxed, acquire, or sequentially consistent and no stronger than the success ordering.")
-            end
-            check_atomic_memory_order(success_order)
-            check_atomic_memory_order(failure_order)
-            check_atomic_flags()
+                                                       ::Val{S}, ::Val{F},
+                                                       ::Val{G}) where {S,F,G}
+            @static_assert(S in valid_atomic_orders, "Invalid atomic memory ordering.")
+            @static_assert(valid_atomic_compare_exchange_failure_order(S, F),
+                           "atomic_compare_exchange_weak_explicit failure ordering must be relaxed, acquire, or sequentially consistent and no stronger than the success ordering.")
+            @static_assert(atomic_order_and_flags_available(S, G),
+                           "Ordered atomics and memory flags require Metal 4.1 or newer.")
             # NOTE: we deviate slightly from the Metal/C++ API here, not returning the
             #       status boolean, but the contents of the expected value box, which will
             #       have been changed to the current value if the exchange failed.
             expected_box = Ref(expected)
             @typed_ccall($"air.atomic.$memnam.cmpxchg.weak.$typnam", llvmcall, $typ,
                          (LLVMPtr{$typ,$as}, Ptr{$typ}, $typ, Int32, Int32, Int32, Int32, Bool),
-                         ptr, expected_box, desired, success_order,
-                         failure_order, Val($memid), flags, Val(false))
+                         ptr, expected_box, desired, Val(S),
+                         Val(F), Val($memid), Val(G), Val(false))
             expected_box[]
         end
     end
 end
 
-# Float32 atomics are only available on Metal 3.0, and additionally only for
-# device memory, so we just skip them and reinterpret. That should be safe?
-@inline atomic_store_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32) where {AS} =
-    atomic_store_explicit(ptr, desired, Val(memory_order_relaxed))
-@inline atomic_store_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
-                              order::memory_order) where {AS} =
-    atomic_store_explicit(ptr, desired, Val(order))
-@inline atomic_store_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
-                              order::memory_order,
-                              flags::Union{MemoryFlags,UInt32}) where {AS} =
-    atomic_store_explicit(ptr, desired, Val(order), Val(flags))
-@inline atomic_store_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
-                              order::Val) where {AS} =
-    atomic_store_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr),
-                          reinterpret(UInt32, desired), order)
-@inline atomic_store_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
-                              order::Val, flags::Val) where {AS} =
-    atomic_store_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr),
-                          reinterpret(UInt32, desired), order, flags)
-@inline atomic_load_explicit(ptr::LLVMPtr{Float32,AS}) where {AS} =
-    atomic_load_explicit(ptr, Val(memory_order_relaxed))
-@inline atomic_load_explicit(ptr::LLVMPtr{Float32,AS}, order::memory_order) where {AS} =
-    atomic_load_explicit(ptr, Val(order))
-@inline atomic_load_explicit(ptr::LLVMPtr{Float32,AS}, order::memory_order,
-                             flags::Union{MemoryFlags,UInt32}) where {AS} =
+# Float32 atomics are implemented by reinterpreting through UInt32.
+for op in (:store, :exchange)
+    f = Symbol("atomic_$(op)_explicit")
+    @eval begin
+        @inline function $f(
+            ptr::LLVMPtr{Float32,AS}, desired::Float32,
+            order::memory_order=memory_order_relaxed,
+            flags::Union{MemoryFlags,UInt32}=default_atomic_flags(order, Val(AS))) where {AS}
+            $f(ptr, desired, Val(order), Val(flags))
+        end
+        @inline function $f(ptr::LLVMPtr{Float32,AS}, desired::Float32,
+                            order::Val, flags::Val) where {AS}
+            result = $f(reinterpret(LLVMPtr{UInt32,AS}, ptr),
+                        reinterpret(UInt32, desired), order, flags)
+            $(op === :store ? :(return result) : :(return reinterpret(Float32, result)))
+        end
+    end
+end
+
+@inline function atomic_load_explicit(
+    ptr::LLVMPtr{Float32,AS}, order::memory_order=memory_order_relaxed,
+    flags::Union{MemoryFlags,UInt32}=default_atomic_flags(order, Val(AS))) where {AS}
     atomic_load_explicit(ptr, Val(order), Val(flags))
-@inline atomic_load_explicit(ptr::LLVMPtr{Float32,AS}, order::Val) where {AS} =
-    reinterpret(Float32, atomic_load_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr), order))
+end
 @inline atomic_load_explicit(ptr::LLVMPtr{Float32,AS}, order::Val, flags::Val) where {AS} =
     reinterpret(Float32,
                 atomic_load_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr), order, flags))
-@inline atomic_exchange_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32) where {AS} =
-    atomic_exchange_explicit(ptr, desired, Val(memory_order_relaxed))
-@inline atomic_exchange_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
-                                 order::memory_order) where {AS} =
-    atomic_exchange_explicit(ptr, desired, Val(order))
-@inline atomic_exchange_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
-                                 order::memory_order,
-                                 flags::Union{MemoryFlags,UInt32}) where {AS} =
-    atomic_exchange_explicit(ptr, desired, Val(order), Val(flags))
-@inline atomic_exchange_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
-                                 order::Val) where {AS} =
-    reinterpret(Float32, atomic_exchange_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr),
-                                                  reinterpret(UInt32, desired), order))
-@inline atomic_exchange_explicit(ptr::LLVMPtr{Float32,AS}, desired::Float32,
-                                 order::Val, flags::Val) where {AS} =
-    reinterpret(Float32, atomic_exchange_explicit(reinterpret(LLVMPtr{UInt32,AS}, ptr),
-                                                  reinterpret(UInt32, desired), order, flags))
-@inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{Float32,AS}, expected::Float32,
-                                              desired::Float32) where {AS} =
-    atomic_compare_exchange_weak_explicit(ptr, expected, desired,
-                                          Val(memory_order_relaxed),
-                                          Val(memory_order_relaxed))
-@inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{Float32,AS}, expected::Float32,
-                                              desired::Float32,
-                                              success_order::memory_order,
-                                              failure_order::memory_order) where {AS} =
-    atomic_compare_exchange_weak_explicit(ptr, expected, desired,
-                                          Val(success_order), Val(failure_order))
-@inline atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{Float32,AS}, expected::Float32,
-                                              desired::Float32,
-                                              success_order::memory_order,
-                                              failure_order::memory_order,
-                                              flags::Union{MemoryFlags,UInt32}) where {AS} =
-    atomic_compare_exchange_weak_explicit(ptr, expected, desired,
-                                          Val(success_order), Val(failure_order), Val(flags))
-function atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{Float32,AS}, expected::Float32,
-                                               desired::Float32,
-                                               success_order::Val,
-                                               failure_order::Val) where {AS}
-    ptr′ = reinterpret(LLVMPtr{UInt32,AS}, ptr)
-    expected′ = reinterpret(UInt32, expected)
-    desired′ = reinterpret(UInt32, desired)
-    return reinterpret(Float32, atomic_compare_exchange_weak_explicit(ptr′, expected′, desired′,
-                                                                     success_order, failure_order))
+
+@inline function atomic_compare_exchange_weak_explicit(
+    ptr::LLVMPtr{Float32,AS}, expected::Float32, desired::Float32,
+    success_order::memory_order=memory_order_relaxed,
+    failure_order::memory_order=memory_order_relaxed,
+    flags::Union{MemoryFlags,UInt32}=default_atomic_flags(success_order, Val(AS))) where {AS}
+    atomic_compare_exchange_weak_explicit(ptr, expected, desired, Val(success_order),
+                                          Val(failure_order), Val(flags))
 end
 function atomic_compare_exchange_weak_explicit(ptr::LLVMPtr{Float32,AS}, expected::Float32,
-                                               desired::Float32,
-                                               success_order::Val,
-                                               failure_order::Val,
-                                               flags::Val) where {AS}
+                                               desired::Float32, success_order::Val,
+                                               failure_order::Val, flags::Val) where {AS}
     ptr′ = reinterpret(LLVMPtr{UInt32,AS}, ptr)
     expected′ = reinterpret(UInt32, expected)
     desired′ = reinterpret(UInt32, desired)
@@ -325,35 +228,22 @@ for (op, types) in atomic_fetch_and_modify, typ in types, as in (AS.Device, AS.T
         typnam = "u.$typnam"
     end
     memnam, memid = atomic_memory_names[as]
-    default_flags = as === AS.Device ? MemoryFlagDevice : MemoryFlagThreadGroup
     f = Symbol("atomic_fetch_$(op)_explicit")
-    relaxed_f = Symbol("atomic_fetch_$(op)_relaxed")
     @eval begin
-        @inline $f(ptr::LLVMPtr{$typ,$as}, desired::$typ) =
-            $f(ptr, desired, Val(memory_order_relaxed))
-        @inline $f(ptr::LLVMPtr{$typ,$as}, desired::$typ, order::memory_order) =
-            $f(ptr, desired, Val(order))
-        @inline $f(ptr::LLVMPtr{$typ,$as}, desired::$typ,
-                   order::Val{memory_order_relaxed}) =
-            $relaxed_f(ptr, desired)
-        @inline $f(ptr::LLVMPtr{$typ,$as}, desired::$typ, order::Val) =
-            $f(ptr, desired, order, Val($default_flags))
-        @inline $f(ptr::LLVMPtr{$typ,$as}, desired::$typ, order::memory_order,
-                   flags::Union{MemoryFlags,UInt32}) =
+        @inline function $f(
+            ptr::LLVMPtr{$typ,$as}, desired::$typ,
+            order::memory_order=memory_order_relaxed,
+            flags::Union{MemoryFlags,UInt32}=default_atomic_flags(order, Val($as)))
             $f(ptr, desired, Val(order), Val(flags))
-
-        function $relaxed_f(ptr::LLVMPtr{$typ,$as}, desired::$typ)
-            @typed_ccall($"air.atomic.$memnam.$op.$typnam", llvmcall, $typ,
-                         (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Bool),
-                         ptr, desired, Val(memory_order_relaxed), Val($memid), Val(true))
         end
 
-        function $f(ptr::LLVMPtr{$typ,$as}, desired::$typ, order::Val, flags::Val)
-            check_atomic_memory_order(order)
-            check_atomic_flags()
+        function $f(ptr::LLVMPtr{$typ,$as}, desired::$typ, ::Val{O}, ::Val{F}) where {O,F}
+            @static_assert(O in valid_atomic_orders, "Invalid atomic memory ordering.")
+            @static_assert(atomic_order_and_flags_available(O, F),
+                           "Ordered atomics and memory flags require Metal 4.1 or newer.")
             @typed_ccall($"air.atomic.$memnam.$op.$typnam", llvmcall, $typ,
                          (LLVMPtr{$typ,$as}, $typ, Int32, Int32, Int32, Bool),
-                         ptr, desired, order, Val($memid), flags, Val(false))
+                         ptr, desired, Val(O), Val($memid), Val(F), Val(false))
         end
     end
 end
@@ -365,26 +255,11 @@ end
 @inline atomic_fetch_op_failure_order(::Val{memory_order_release}) = Val(memory_order_relaxed)
 @inline atomic_fetch_op_failure_order(::Val{memory_order_acq_rel}) = Val(memory_order_acquire)
 
-@inline atomic_fetch_op_explicit(ptr::LLVMPtr{T}, op::Function, val) where {T} =
-    atomic_fetch_op_explicit(ptr, op, val, Val(memory_order_relaxed))
-@inline atomic_fetch_op_explicit(ptr::LLVMPtr{T}, op::Function, val,
-                                 order::memory_order) where {T} =
-    atomic_fetch_op_explicit(ptr, op, val, Val(order))
-@inline atomic_fetch_op_explicit(ptr::LLVMPtr{T}, op::Function, val,
-                                 order::memory_order,
-                                 flags::Union{MemoryFlags,UInt32}) where {T} =
+@inline function atomic_fetch_op_explicit(
+    ptr::LLVMPtr{T,AS}, op::Function, val,
+    order::memory_order=memory_order_relaxed,
+    flags::Union{MemoryFlags,UInt32}=default_atomic_flags(order, Val(AS))) where {T,AS}
     atomic_fetch_op_explicit(ptr, op, val, Val(order), Val(flags))
-
-@inline function atomic_fetch_op_explicit(ptr::LLVMPtr{T}, op::Function, val,
-                                          order::Val) where {T}
-    failure_order = atomic_fetch_op_failure_order(order)
-    old = atomic_load_explicit(ptr, failure_order)
-    while true
-        cmp = old
-        new = convert(T, op(old, val))
-        old = atomic_compare_exchange_weak_explicit(ptr, cmp, new, order, failure_order)
-        isequal(old, cmp) && return old
-    end
 end
 
 @inline function atomic_fetch_op_explicit(ptr::LLVMPtr{T}, op::Function, val,

--- a/src/version.jl
+++ b/src/version.jl
@@ -103,6 +103,26 @@ function metal_support(macos::VersionNumber = macos_version())
     end
 end
 
+"""
+    air_floor(metal)::VersionNumber
+Return the minimum AIR version required by `metal`. The offline compiler raises
+the emitted AIR version to this floor even when the deployment target supports
+an older AIR version.
+"""
+function air_floor(metal::VersionNumber)
+    if metal >= v"4.1"
+        v"2.9"
+    elseif metal >= v"4.0"
+        v"2.8"
+    elseif metal >= v"3.2"
+        v"2.7"
+    elseif metal >= v"3.1"
+        v"2.6"
+    else
+        v"2.5"
+    end
+end
+
 # The versions Metal.jl emits by default. These track the `*_support` ceilings, which is
 # also what the offline `metal` compiler does: compiling with `-mmacosx-version-min=N`
 # yields the AIR, MSL and metallib versions that `N` supports. Since we compile for the

--- a/test/device/intrinsics/atomics.jl
+++ b/test/device/intrinsics/atomics.jl
@@ -228,6 +228,103 @@ n = 128 # NOTE: also hard-coded in MtlThreadGroupArray constructors
             @test f.(a, val) ≈ Array(b)
         end
     end
+
+    @testset "explicit ordering arguments" begin
+        function ordered_fetch_kernel(a, ::Val{ORDER}) where {ORDER}
+            Metal.atomic_fetch_add_explicit(pointer(a, 1), Int32(1), ORDER)
+            return
+        end
+
+        # The enum value is in the kernel signature, so the public enum overload
+        # specializes it to a Val before lowering to AIR.
+        for (order, minimum, message) in (
+            (Metal.memory_order_relaxed, v"3.0", nothing),
+            (Metal.memory_order_seq_cst, v"4.1",
+             "Atomic memory_order_seq_cst requires Metal 4.1 or newer."),
+            (Metal.memory_order_acquire, v"4.1",
+             "Atomic memory_order_acquire requires Metal 4.1 or newer."),
+            (Metal.memory_order_release, v"4.1",
+             "Atomic memory_order_release requires Metal 4.1 or newer."),
+            (Metal.memory_order_acq_rel, v"4.1",
+             "Atomic memory_order_acq_rel requires Metal 4.1 or newer."),
+        )
+            a = Metal.zeros(Int32, 1)
+            if Metal.metal_target() >= minimum
+                @metal ordered_fetch_kernel(a, Val(order))
+                @test Array(a) == Int32[1]
+            else
+                err = try
+                    @metal launch=false ordered_fetch_kernel(a, Val(order))
+                    nothing
+                catch err
+                    err
+                end
+                @test err isa Metal.InvalidIRError
+                @test occursin(message, sprint(showerror, err))
+            end
+        end
+
+        function flagged_fetch_kernel(a, ::Val{ORDER}, ::Val{FLAGS}) where {ORDER,FLAGS}
+            Metal.atomic_fetch_add_explicit(pointer(a, 1), Int32(1), ORDER, FLAGS)
+            return
+        end
+
+        a = Metal.zeros(Int32, 1)
+        if Metal.metal_target() >= v"4.1"
+            @metal flagged_fetch_kernel(a, Val(Metal.memory_order_relaxed),
+                                        Val(Metal.MemoryFlagDevice | Metal.MemoryFlagThreadGroup))
+            @test Array(a) == Int32[1]
+        else
+            err = try
+                @metal launch=false flagged_fetch_kernel(
+                    a, Val(Metal.memory_order_relaxed), Val(Metal.MemoryFlagDevice))
+                nothing
+            catch err
+                err
+            end
+            @test err isa Metal.InvalidIRError
+            @test occursin("Atomic memory flags require Metal 4.1 or newer.",
+                           sprint(showerror, err))
+        end
+
+        function ordered_flags_abi(ptr::Core.LLVMPtr{Int32,Metal.AS.Device})
+            Metal.atomic_fetch_add_explicit(ptr, Int32(1), Metal.memory_order_acq_rel,
+                                            Metal.MemoryFlagDevice | Metal.MemoryFlagThreadGroup)
+            return
+        end
+        function legacy_abi(ptr::Core.LLVMPtr{Int32,Metal.AS.Device})
+            Metal.atomic_fetch_add_explicit(ptr, Int32(1))
+            return
+        end
+        ordered_ir = sprint(io -> Metal.code_llvm(io, ordered_flags_abi,
+                                                   Tuple{Core.LLVMPtr{Int32,Metal.AS.Device}};
+                                                   kernel=true, metal=v"4.1", dump_module=true))
+        legacy_ir = sprint(io -> Metal.code_llvm(io, legacy_abi,
+                                                  Tuple{Core.LLVMPtr{Int32,Metal.AS.Device}};
+                                                  kernel=true, metal=v"4.0", dump_module=true))
+        atomic_ptr = raw"(?:ptr addrspace\(1\)|i32 addrspace\(1\)\*)"
+        ordered_abi_pattern = Regex(raw"@air\.atomic\.global\.add\.s\.i32\(" * atomic_ptr *
+                                    raw", i32, i32, i32, i32, i1\)")
+        legacy_abi_pattern = Regex(raw"@air\.atomic\.global\.add\.s\.i32\(" * atomic_ptr *
+                                   raw", i32, i32, i32, i1\)")
+        @test occursin(ordered_abi_pattern, ordered_ir)
+        @test occursin("i32 4, i32 2, i32 3, i1 false", ordered_ir)
+        @test occursin(legacy_abi_pattern, legacy_ir)
+        @test occursin("i32 0, i32 2, i1 true", legacy_ir)
+
+        function guarded_ordered_fetch_kernel(a)
+            if Metal.metal_version() >= sv"4.1"
+                Metal.atomic_fetch_add_explicit(pointer(a, 1), Int32(1),
+                                                Metal.memory_order_acq_rel,
+                                                Metal.MemoryFlagDevice)
+            end
+            a[1] += 1
+            return
+        end
+        a = Metal.zeros(Int32, 1)
+        @metal guarded_ordered_fetch_kernel(a)
+        @test Array(a) == Int32[Metal.metal_target() >= v"4.1" ? 2 : 1]
+    end
 end
 
 @testset "high-level" begin
@@ -283,5 +380,75 @@ end
         a = MtlArray(T[2n])
         @metal threads=n kernel(a)
         @test Array(a)[1] == 0
+    end
+end
+
+@testset "device-memory publish through fetch_add" begin
+    n_leaves = 2048
+    n_nodes = 2n_leaves - 1
+
+    child0 = zeros(Int32, n_nodes)
+    child1 = zeros(Int32, n_nodes)
+    parent = zeros(Int32, n_nodes)
+    for node in 1:n_leaves-1
+        left = 2node
+        right = 2node + 1
+        child0[node] = left
+        child1[node] = right
+        parent[left] = node
+        parent[right] = node
+    end
+
+    function refit_kernel!(values, flags, child0, child1, parent, n_leaves::Int32)
+        leaf = thread_position_in_grid().x
+        if leaf <= n_leaves
+            leaf_node = n_leaves - Int32(1) + leaf
+            values[leaf_node] = UInt32(1)
+
+            parent_node = parent[leaf_node]
+            while parent_node != Int32(0)
+                old = Metal.atomic_fetch_add_explicit(pointer(flags, parent_node), UInt32(1),
+                                                      Metal.memory_order_acq_rel,
+                                                      Metal.MemoryFlagDevice)
+                if old + UInt32(1) == UInt32(2)
+                    left = child0[parent_node]
+                    right = child1[parent_node]
+                    values[parent_node] = values[left] + values[right]
+                    parent_node = parent[parent_node]
+                else
+                    break
+                end
+            end
+        end
+        return
+    end
+
+    values = Metal.zeros(UInt32, n_nodes)
+    flags = Metal.zeros(UInt32, n_leaves - 1)
+    mt_child0 = MtlArray(child0)
+    mt_child1 = MtlArray(child1)
+    mt_parent = MtlArray(parent)
+
+    if Metal.metal_target() >= v"4.1"
+        @metal threads=256 groups=cld(n_leaves, 256) refit_kernel!(
+            values,
+            flags,
+            mt_child0,
+            mt_child1,
+            mt_parent,
+            Int32(n_leaves),
+        )
+        @test Array(values)[1] == UInt32(n_leaves)
+    else
+        err = try
+            @metal launch=false refit_kernel!(values, flags, mt_child0, mt_child1, mt_parent,
+                                              Int32(n_leaves))
+            nothing
+        catch err
+            err
+        end
+        @test err isa Metal.InvalidIRError
+        @test occursin("Atomic memory_order_acq_rel requires Metal 4.1 or newer.",
+                       sprint(showerror, err))
     end
 end

--- a/test/device/intrinsics/atomics.jl
+++ b/test/device/intrinsics/atomics.jl
@@ -237,16 +237,12 @@ n = 128 # NOTE: also hard-coded in MtlThreadGroupArray constructors
 
         # The enum value is in the kernel signature, so the public enum overload
         # specializes it to a Val before lowering to AIR.
-        for (order, minimum, message) in (
-            (Metal.memory_order_relaxed, v"3.0", nothing),
-            (Metal.memory_order_seq_cst, v"4.1",
-             "Atomic memory_order_seq_cst requires Metal 4.1 or newer."),
-            (Metal.memory_order_acquire, v"4.1",
-             "Atomic memory_order_acquire requires Metal 4.1 or newer."),
-            (Metal.memory_order_release, v"4.1",
-             "Atomic memory_order_release requires Metal 4.1 or newer."),
-            (Metal.memory_order_acq_rel, v"4.1",
-             "Atomic memory_order_acq_rel requires Metal 4.1 or newer."),
+        for (order, minimum) in (
+            (Metal.memory_order_relaxed, v"3.0"),
+            (Metal.memory_order_seq_cst, v"4.1"),
+            (Metal.memory_order_acquire, v"4.1"),
+            (Metal.memory_order_release, v"4.1"),
+            (Metal.memory_order_acq_rel, v"4.1"),
         )
             a = Metal.zeros(Int32, 1)
             if Metal.metal_target() >= minimum
@@ -260,7 +256,8 @@ n = 128 # NOTE: also hard-coded in MtlThreadGroupArray constructors
                     err
                 end
                 @test err isa Metal.InvalidIRError
-                @test occursin(message, sprint(showerror, err))
+                @test occursin("Ordered atomics and memory flags require Metal 4.1 or newer.",
+                               sprint(showerror, err))
             end
         end
 
@@ -283,7 +280,7 @@ n = 128 # NOTE: also hard-coded in MtlThreadGroupArray constructors
                 err
             end
             @test err isa Metal.InvalidIRError
-            @test occursin("Atomic memory flags require Metal 4.1 or newer.",
+            @test occursin("Ordered atomics and memory flags require Metal 4.1 or newer.",
                            sprint(showerror, err))
         end
 
@@ -292,14 +289,17 @@ n = 128 # NOTE: also hard-coded in MtlThreadGroupArray constructors
                                             Metal.MemoryFlagDevice | Metal.MemoryFlagThreadGroup)
             return
         end
-        function legacy_abi(ptr::Core.LLVMPtr{Int32,Metal.AS.Device})
+        function default_abi(ptr::Core.LLVMPtr{Int32,Metal.AS.Device})
             Metal.atomic_fetch_add_explicit(ptr, Int32(1))
             return
         end
         ordered_ir = sprint(io -> Metal.code_llvm(io, ordered_flags_abi,
                                                    Tuple{Core.LLVMPtr{Int32,Metal.AS.Device}};
                                                    kernel=true, metal=v"4.1", dump_module=true))
-        legacy_ir = sprint(io -> Metal.code_llvm(io, legacy_abi,
+        relaxed_ir = sprint(io -> Metal.code_llvm(io, default_abi,
+                                                   Tuple{Core.LLVMPtr{Int32,Metal.AS.Device}};
+                                                   kernel=true, metal=v"4.1", dump_module=true))
+        legacy_ir = sprint(io -> Metal.code_llvm(io, default_abi,
                                                   Tuple{Core.LLVMPtr{Int32,Metal.AS.Device}};
                                                   kernel=true, metal=v"4.0", dump_module=true))
         atomic_ptr = raw"(?:ptr addrspace\(1\)|i32 addrspace\(1\)\*)"
@@ -309,8 +309,92 @@ n = 128 # NOTE: also hard-coded in MtlThreadGroupArray constructors
                                    raw", i32, i32, i32, i1\)")
         @test occursin(ordered_abi_pattern, ordered_ir)
         @test occursin("i32 4, i32 2, i32 3, i1 false", ordered_ir)
+        @test occursin(ordered_abi_pattern, relaxed_ir)
+        @test occursin("i32 0, i32 2, i32 0, i1 false", relaxed_ir)
         @test occursin(legacy_abi_pattern, legacy_ir)
         @test occursin("i32 0, i32 2, i1 true", legacy_ir)
+
+        function unavailable_order(a)
+            Metal.atomic_fetch_add_explicit(pointer(a, 1), Int32(1),
+                                            Metal.memory_order_acquire)
+            return
+        end
+        function unavailable_flags(a)
+            Metal.atomic_fetch_add_explicit(pointer(a, 1), Int32(1), Metal.memory_order_relaxed,
+                                            Metal.MemoryFlagDevice)
+            return
+        end
+        a = Metal.zeros(Int32, 1)
+        for f in (unavailable_order, unavailable_flags)
+            err = try
+                @metal launch=false metal=v"4.0" f(a)
+                nothing
+            catch err
+                err
+            end
+            @test err isa Metal.InvalidIRError
+            @test occursin("Ordered atomics and memory flags require Metal 4.1 or newer.",
+                           sprint(showerror, err))
+        end
+
+        function invalid_load_order(a, b)
+            b[1] = Metal.atomic_load_explicit(pointer(a, 1), Metal.memory_order_release)
+            return
+        end
+        function invalid_store_order(a, b)
+            Metal.atomic_store_explicit(pointer(a, 1), b[1], Metal.memory_order_acquire)
+            return
+        end
+        function invalid_failure_order(a, b)
+            b[1] = Metal.atomic_compare_exchange_weak_explicit(
+                pointer(a, 1), Int32(0), Int32(1), Metal.memory_order_relaxed,
+                Metal.memory_order_acquire)
+            return
+        end
+        b = Metal.zeros(Int32, 1)
+        for (f, message) in (
+            (invalid_load_order, "atomic_load_explicit only supports"),
+            (invalid_store_order, "atomic_store_explicit only supports"),
+            (invalid_failure_order,
+             "failure ordering must be relaxed, acquire, or sequentially consistent and no stronger"),
+        )
+            err = try
+                @metal launch=false metal=v"4.1" f(a, b)
+                nothing
+            catch err
+                err
+            end
+            @test err isa Metal.InvalidIRError
+            @test occursin(message, sprint(showerror, err))
+        end
+
+        function mixed_abi(ptr::Core.LLVMPtr{Int32,Metal.AS.Device})
+            Metal.atomic_load_explicit(ptr)
+            Metal.atomic_load_explicit(ptr + 1, Metal.memory_order_acquire)
+            return
+        end
+        mixed_ir = sprint(io -> Metal.code_llvm(
+            io, mixed_abi, Tuple{Core.LLVMPtr{Int32,Metal.AS.Device}};
+            kernel=true, metal=v"4.1", dump_module=true))
+        ordered_load_pattern = Regex(raw"@air\.atomic\.global\.load\.i32\(" * atomic_ptr *
+                                     raw", i32, i32, i32, i1\)")
+        legacy_load_pattern = Regex(raw"@air\.atomic\.global\.load\.i32\(" * atomic_ptr *
+                                    raw", i32, i32, i1\)")
+        @test occursin(ordered_load_pattern, mixed_ir)
+        @test !occursin(legacy_load_pattern, mixed_ir)
+
+        function mixed_kernel(a, b)
+            x = Metal.atomic_load_explicit(pointer(a, 1))
+            y = Metal.atomic_load_explicit(pointer(a, 2), Metal.memory_order_acquire)
+            b[1] = x + y
+            return
+        end
+        if Metal.metal_target() >= v"4.1"
+            a = MtlArray(Int32[1, 2])
+            b = Metal.zeros(Int32, 1)
+            @metal mixed_kernel(a, b)
+            @test Array(b) == Int32[3]
+        end
 
         function guarded_ordered_fetch_kernel(a)
             if Metal.metal_version() >= sv"4.1"
@@ -448,7 +532,7 @@ end
             err
         end
         @test err isa Metal.InvalidIRError
-        @test occursin("Atomic memory_order_acq_rel requires Metal 4.1 or newer.",
+        @test occursin("Ordered atomics and memory flags require Metal 4.1 or newer.",
                        sprint(showerror, err))
     end
 end

--- a/test/device/intrinsics/atomics.jl
+++ b/test/device/intrinsics/atomics.jl
@@ -178,7 +178,8 @@ n = 128 # NOTE: also hard-coded in MtlThreadGroupArray constructors
                     @test jlfun.(a, val) ≈ Array(b)
                 end
 
-                @testset "threadgroup $T" for T in setdiff(types, [Float32])
+                threadgroup_types = Metal.metal_target() >= v"4.1" ? types : setdiff(types, [Float32])
+                @testset "threadgroup $T" for T in threadgroup_types
                     a = rand(T, n)
                     b = MtlArray(a)
                     val = rand(T)
@@ -295,13 +296,20 @@ n = 128 # NOTE: also hard-coded in MtlThreadGroupArray constructors
         end
         ordered_ir = sprint(io -> Metal.code_llvm(io, ordered_flags_abi,
                                                    Tuple{Core.LLVMPtr{Int32,Metal.AS.Device}};
-                                                   kernel=true, metal=v"4.1", dump_module=true))
+                                                   kernel=true, metal=v"4.1", air=v"2.9",
+                                                   dump_module=true))
         relaxed_ir = sprint(io -> Metal.code_llvm(io, default_abi,
                                                    Tuple{Core.LLVMPtr{Int32,Metal.AS.Device}};
-                                                   kernel=true, metal=v"4.1", dump_module=true))
+                                                   kernel=true, metal=v"4.1", air=v"2.9",
+                                                   dump_module=true))
+        volatile_ir = sprint(io -> Metal.code_llvm(io, default_abi,
+                                                    Tuple{Core.LLVMPtr{Int32,Metal.AS.Device}};
+                                                    kernel=true, metal=v"4.0", air=v"2.9",
+                                                    dump_module=true))
         legacy_ir = sprint(io -> Metal.code_llvm(io, default_abi,
                                                   Tuple{Core.LLVMPtr{Int32,Metal.AS.Device}};
-                                                  kernel=true, metal=v"4.0", dump_module=true))
+                                                  kernel=true, metal=v"4.0", air=v"2.8",
+                                                  dump_module=true))
         atomic_ptr = raw"(?:ptr addrspace\(1\)|i32 addrspace\(1\)\*)"
         ordered_abi_pattern = Regex(raw"@air\.atomic\.global\.add\.s\.i32\(" * atomic_ptr *
                                     raw", i32, i32, i32, i32, i1\)")
@@ -311,6 +319,8 @@ n = 128 # NOTE: also hard-coded in MtlThreadGroupArray constructors
         @test occursin("i32 4, i32 2, i32 3, i1 false", ordered_ir)
         @test occursin(ordered_abi_pattern, relaxed_ir)
         @test occursin("i32 0, i32 2, i32 0, i1 false", relaxed_ir)
+        @test occursin(ordered_abi_pattern, volatile_ir)
+        @test occursin("i32 0, i32 2, i32 0, i1 true", volatile_ir)
         @test occursin(legacy_abi_pattern, legacy_ir)
         @test occursin("i32 0, i32 2, i1 true", legacy_ir)
 
@@ -337,36 +347,34 @@ n = 128 # NOTE: also hard-coded in MtlThreadGroupArray constructors
                            sprint(showerror, err))
         end
 
-        function invalid_load_order(a, b)
-            b[1] = Metal.atomic_load_explicit(pointer(a, 1), Metal.memory_order_release)
+        function invalid_order(a)
+            Metal.atomic_fetch_add_explicit(pointer(a, 1), Int32(1), Val(Int32(42)),
+                                            Val(Metal.MemoryFlagNone))
             return
         end
-        function invalid_store_order(a, b)
-            Metal.atomic_store_explicit(pointer(a, 1), b[1], Metal.memory_order_acquire)
+        err = try
+            @metal launch=false metal=v"4.1" air=v"2.9" invalid_order(a)
+            nothing
+        catch err
+            err
+        end
+        @test err isa Metal.InvalidIRError
+        @test occursin("Invalid atomic memory ordering.", sprint(showerror, err))
+
+        function threadgroup_float32_add(a)
+            Metal.atomic_fetch_add_explicit(pointer(MtlThreadGroupArray(Float32, 1), 1), 1f0)
+            a[1] = 1
             return
         end
-        function invalid_failure_order(a, b)
-            b[1] = Metal.atomic_compare_exchange_weak_explicit(
-                pointer(a, 1), Int32(0), Int32(1), Metal.memory_order_relaxed,
-                Metal.memory_order_acquire)
-            return
+        err = try
+            @metal launch=false metal=v"4.0" air=v"2.8" threadgroup_float32_add(a)
+            nothing
+        catch err
+            err
         end
-        b = Metal.zeros(Int32, 1)
-        for (f, message) in (
-            (invalid_load_order, "atomic_load_explicit only supports"),
-            (invalid_store_order, "atomic_store_explicit only supports"),
-            (invalid_failure_order,
-             "failure ordering must be relaxed, acquire, or sequentially consistent and no stronger"),
-        )
-            err = try
-                @metal launch=false metal=v"4.1" f(a, b)
-                nothing
-            catch err
-                err
-            end
-            @test err isa Metal.InvalidIRError
-            @test occursin(message, sprint(showerror, err))
-        end
+        @test err isa Metal.InvalidIRError
+        @test occursin("Float32 threadgroup atomic operations require Metal 4.1 or newer.",
+                       sprint(showerror, err))
 
         function mixed_abi(ptr::Core.LLVMPtr{Int32,Metal.AS.Device})
             Metal.atomic_load_explicit(ptr)
@@ -375,7 +383,7 @@ n = 128 # NOTE: also hard-coded in MtlThreadGroupArray constructors
         end
         mixed_ir = sprint(io -> Metal.code_llvm(
             io, mixed_abi, Tuple{Core.LLVMPtr{Int32,Metal.AS.Device}};
-            kernel=true, metal=v"4.1", dump_module=true))
+            kernel=true, metal=v"4.1", air=v"2.9", dump_module=true))
         ordered_load_pattern = Regex(raw"@air\.atomic\.global\.load\.i32\(" * atomic_ptr *
                                      raw", i32, i32, i32, i1\)")
         legacy_load_pattern = Regex(raw"@air\.atomic\.global\.load\.i32\(" * atomic_ptr *

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -162,6 +162,14 @@ end
         @test_throws "Metal.jl requires AIR 2.6" begin
             Metal.code_llvm(devnull, dummy, Tuple{}; air=v"2.5")
         end
+
+        # The offline compiler raises AIR to the floor required by the selected MSL
+        # language version, even when the deployment target supports an older AIR.
+        @test Metal.compiler_config(device(); macos=v"14", metal=v"4.0").target.air == v"2.8"
+        @test Metal.compiler_config(device(); macos=v"14", metal=v"4.1").target.air == v"2.9"
+        @test_throws "Metal 4.1.0 requires AIR 2.9.0" begin
+            Metal.code_llvm(devnull, dummy, Tuple{}; metal=v"4.1", air=v"2.8")
+        end
     end
 
     @test Metal.return_type(identity, Tuple{Int}) === Int


### PR DESCRIPTION
Metal's low-level atomic intrinsics previously exposed only relaxed ordering. That is fine for counters and reductions, but not for synchronization patterns where ordinary device-memory writes are published through an atomic and then observed by another workitem.

Thread explicit memory orderings through the low-level atomic API and light up KernelAbstractions/Atomix atomics on the Metal backend:

- Add explicit `order` (and `flags`/`scope`) arguments to the low-level atomic store/load/exchange/fetch/compare-exchange intrinsics, using `Val`-specialized paths so orderings reach GPU code as compile-time constants.
- Keep the existing direct call sites on relaxed ordering, so code that only needs relaxed atomics keeps emitting the same `air.atomic.*` forms and does not change behaviour.
- Support independent success/failure orderings on compare-exchange.
- Gate the acquire/release/acq_rel/seq_cst orderings and the memory flags on Metal 4.1 with device-side `@static_assert`s (`check_atomic_memory_order` / `check_atomic_flags`), so unavailable operations fail to compile with a clear message and enclosing `metal_version()` guards can eliminate them.
- Enable `KA.supports_atomics(::MetalBackend)` when the device supports Metal 4.1, so Atomix-based kernels (e.g. KernelAbstractions' `@atomic`) work on Metal.