### PR TITLE
[tests] Set max_test_rss based on number of jobs and available memory

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -167,7 +167,7 @@ init_code = quote
     import ..runtime_validation, ..shader_validation, ..capturing, ..@grab_output, ..@on_device
 end
 
-# 8GB mac minis can struggle in some julia versions
-max_worker_rss = ParallelTestRunner.available_memory() ÷ max(1, something(args.jobs, ParallelTestRunner.default_njobs()))
+# This value is important to avoid test code loading issues when running out of memory
+max_worker_rss = min(ParallelTestRunner.available_memory() ÷ max(1, something(args.jobs, ParallelTestRunner.default_njobs())), 3800 * 2^20)
 
 runtests(Metal, args; testsuite, init_code, init_worker_code, test_worker, max_worker_rss)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -168,6 +168,6 @@ init_code = quote
 end
 
 # 8GB mac minis can struggle in some julia versions
-max_worker_rss = 2^20 * (Sys.total_memory() > 8*2^30 ? 3800 : 2200)
+max_worker_rss = ParallelTestRunner.available_memory() ÷ something(args.jobs, ParallelTestRunner.default_njobs())
 
 runtests(Metal, args; testsuite, init_code, init_worker_code, test_worker, max_worker_rss)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -168,6 +168,6 @@ init_code = quote
 end
 
 # 8GB mac minis can struggle in some julia versions
-max_worker_rss = ParallelTestRunner.available_memory() ÷ something(args.jobs, ParallelTestRunner.default_njobs())
+max_worker_rss = ParallelTestRunner.available_memory() ÷ max(1, something(args.jobs, ParallelTestRunner.default_njobs()))
 
 runtests(Metal, args; testsuite, init_code, init_worker_code, test_worker, max_worker_rss)


### PR DESCRIPTION
This currently uses PTR internals but I think we should potentially legitimize this through the PTR interface