### PR TITLE
Revert "[tests] Set max_test_rss based on number of jobs and available memory"

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -167,7 +167,7 @@ init_code = quote
     import ..runtime_validation, ..shader_validation, ..capturing, ..@grab_output, ..@on_device
 end
 
-# This value is important to avoid test code loading issues when running out of memory
-max_worker_rss = min(ParallelTestRunner.available_memory() ÷ max(1, something(args.jobs, ParallelTestRunner.default_njobs())), 3800 * 2^20)
+# 8GB mac minis can struggle in some julia versions
+max_worker_rss = 2^20 * (Sys.total_memory() > 8*2^30 ? 3800 : 2200)
 
 runtests(Metal, args; testsuite, init_code, init_worker_code, test_worker, max_worker_rss)


### PR DESCRIPTION
Reverts JuliaGPU/Metal.jl#895. I was hoping this would be a good way to reduce worker restarts unnecessarily but it's not a good heuristic as shown by https://buildkite.com/julialang/metal-dot-jl/builds/3197/table?jid=019faf05-a25b-49f8-a7df-49a134e113ff&tab=output