### PR TITLE
Remove broken `copy(::MPS.RNG)`

### DIFF
--- a/lib/mps/random.jl
+++ b/lib/mps/random.jl
@@ -28,7 +28,7 @@ RNG(device::MTLDevice) = RNG(device, make_seed())
 
 @autoreleasepool RNG() = RNG(device(), make_seed())
 
-Base.copy(rng::RNG) = RNG(copy(rng.device), copy(rng.uniformInteger), copy(rng.uniformFloat32), copy(rng.normalFloat32))
+Base.copy(rng::RNG) = RNG(rng.device, copy(rng.uniformInteger), copy(rng.uniformFloat32), copy(rng.normalFloat32))
 
 @autoreleasepool function Random.seed!(rng::RNG, seed::Integer)
     rng.uniformInteger = MPSMatrixRandomPhilox(rng.device, UInt32, seed, MPSMatrixRandomDefaultDistributionDescriptor())

--- a/lib/mps/random.jl
+++ b/lib/mps/random.jl
@@ -28,8 +28,6 @@ RNG(device::MTLDevice) = RNG(device, make_seed())
 
 @autoreleasepool RNG() = RNG(device(), make_seed())
 
-Base.copy(rng::RNG) = RNG(rng.device, copy(rng.uniformInteger), copy(rng.uniformFloat32), copy(rng.normalFloat32))
-
 @autoreleasepool function Random.seed!(rng::RNG, seed::Integer)
     rng.uniformInteger = MPSMatrixRandomPhilox(rng.device, UInt32, seed, MPSMatrixRandomDefaultDistributionDescriptor())
     rng.uniformFloat32 = MPSMatrixRandomPhilox(rng.device, Float32, seed, MPSMatrixRandomUniformDistributionDescriptor(0, 1))

--- a/test/mps/rand.jl
+++ b/test/mps/rand.jl
@@ -134,7 +134,7 @@ end
 
 # CPU arrays via MPS.RNG (uses unsafe_wrap + can_alloc_nocopy or shared-storage round-trip)
 @testset "CPU Arrays" begin
-    rng = Metal.MPS.RNG()
+    rng = Metal.MPS.RNG(45)
     @testset "$f with $T" for (f, T) in MPS_INPLACE_TUPLES
         @testset "$d" for d in (2, 3, (3, 3), (3, 3, 3), 16, (16, 16), (16, 16, 16),
                                 (1000,), (1000,1000), 16384, 16385)


### PR DESCRIPTION
This was broken from `MTLDevice` not having a `copy` available to it, but it doesn't copy the underlying random kernel state so it's kind of pointless.