### PR TITLE
Fix reduce under mixed types

### DIFF
--- a/src/compiler/reflection.jl
+++ b/src/compiler/reflection.jl
@@ -78,5 +78,6 @@ function return_type(@nospecialize(func), @nospecialize(tt))
     job = CompilerJob(source, config)
     interp = GPUCompiler.get_interpreter(job)
     sig = Base.signature_type(func, tt)
-    Core.Compiler._return_type(interp, sig)
+    # required in 1.11, otherwise this always returns `Union{}` during precompilation
+    return Base.invoke_in_world(Base.tls_world_age(), Core.Compiler._return_type, interp, sig)
 end

--- a/src/compiler/reflection.jl
+++ b/src/compiler/reflection.jl
@@ -77,11 +77,10 @@ function return_type(@nospecialize(func), @nospecialize(tt))
     config = compiler_config(device())
     job = CompilerJob(source, config)
     interp = GPUCompiler.get_interpreter(job)
-    sig = Base.signature_type(func, tt)
-    @static if v"1.11-" <= VERSION < v"1.12-"
-        # required in 1.11, otherwise this always returns `Union{}` during precompilation
-        return Base.invoke_in_world(Base.tls_world_age(), Core.Compiler._return_type, interp, sig)
+    @static if VERSION >= v"1.11"
+        return Base.infer_return_type(func, tt; interp)
     else
+        sig = Base.signature_type(func, tt)
         return Core.Compiler._return_type(interp, sig)
     end
 end

--- a/src/compiler/reflection.jl
+++ b/src/compiler/reflection.jl
@@ -78,6 +78,10 @@ function return_type(@nospecialize(func), @nospecialize(tt))
     job = CompilerJob(source, config)
     interp = GPUCompiler.get_interpreter(job)
     sig = Base.signature_type(func, tt)
-    # required in 1.11, otherwise this always returns `Union{}` during precompilation
-    return Base.invoke_in_world(Base.tls_world_age(), Core.Compiler._return_type, interp, sig)
+    @static if v"1.11-" <= VERSION < v"1.12-"
+        # required in 1.11, otherwise this always returns `Union{}` during precompilation
+        return Base.invoke_in_world(Base.tls_world_age(), Core.Compiler._return_type, interp, sig)
+    else
+        return Core.Compiler._return_type(interp, sig)
+    end
 end

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -243,7 +243,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::WrappedMtlArray{T},
     dev = device()
 
     # be conservative about using shuffle instructions
-    shuffle = T <: Union{Float32, Float16, Int32, UInt32, Int16, UInt16, Int8, UInt8}
+    shuffle = return_type(op, Tuple{T, T}) <: Union{Float32, Float16, Int32, UInt32, Int16, UInt16, Int8, UInt8}
 
     R_old = R
     # add singleton dimensions to the output container, if needed

--- a/test/array.jl
+++ b/test/array.jl
@@ -833,4 +833,9 @@ end
     R = transpose(Metal.zeros(Float32, 2, 3))
     A = MtlArray(rand(Float32, 3, 2, 10))
     @test @inferred(Metal.GPUArrays.mapreducedim!(identity, +, R, A)) === R
+
+    R = transpose(Metal.zeros(Int16, 2, 3))
+    A = MtlArray(rand(Int16.(0:10), 3, 2, 10))
+    @test @inferred(sum!(abs2, R, A)) === R
+    @test Array(R) ≈ dropdims(sum(abs2, Array(A); dims=3); dims = 3)
 end


### PR DESCRIPTION
`Base.add_sum` widens the result to `Int`, which causes errors because the result can not use shuffle instructions anymore. Arguably, the intermediate result should not be overpromoted to a type wider than the result container, but that's a more complex issue and this seems more correct according to the `mapreducedim!` implementation either way.

fixes #907
