### PR TITLE
Handle transposed triangular operands in in-place left division.

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -471,6 +471,17 @@ for (triangle, upper, unit) in ((:UpperTriangular, true, false),
             return MPS.solve_triangular(parent(A), B; upper=$upper, unit=$unit)
         end
 
+        # the generic `ldiv!` picks a direction using `istriu`, which scalar-indexes the
+        # wrapper until JuliaLang/LinearAlgebra.jl#1265 (1.13) unwraps it to the parent
+        @static if VERSION < v"1.13.0-"
+        function LinearAlgebra.ldiv!(A::$triangle{T,<:Union{Transpose{T,<:MtlMatrix{T}},
+                                                            Adjoint{T,<:MtlMatrix{T}}}},
+                                     B::MtlVecOrMat{T}) where {T<:MtlFloat}
+            return MPS.solve_triangular(parent(parent(A)), B; upper=$(!upper),
+                                        unit=$unit, transpose=true)
+        end
+        end
+
         function Base.:\(A::$triangle{T,<:MtlMatrix{T}},
                          B::MtlVecOrMat{T}) where {T<:MtlFloat}
             return ldiv!(A, copy(B))

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -421,6 +421,9 @@ end
         y = copy(db)
         ldiv!(dT, y)
         @test Array(y) ≈ cT \ b rtol=1f-4
+        yt = copy(db)
+        ldiv!(transpose(dT), yt)
+        @test Array(yt) ≈ transpose(cT) \ b rtol=1f-4
         Y = copy(dBR)
         rdiv!(Y, dT)
         @test Array(Y) ≈ BR / cT rtol=1f-4


### PR DESCRIPTION
`ldiv!` lacked the transposed-operand method its `rdiv!` sibling already has, so `transpose(UpperTriangular(::MtlMatrix)) \ x` fell back to the generic `ldiv!`, whose `istriu` direction check scalar-indexes the wrapper. Latent until 1.12.7, where LinearAlgebra.jl#1561 routed `\` through the in-place `ldiv!`; 1.13 avoids it via LinearAlgebra.jl#1265.