### PR TITLE
Fix tensor matmul in macOS 27

### DIFF
--- a/src/device/intrinsics/tensor.jl
+++ b/src/device/intrinsics/tensor.jl
@@ -27,19 +27,37 @@ const TensorDescriptorStorage = Base.RefValue{TensorDescriptor}
     ccall("extern air.get_descriptor_size_tensor", llvmcall,
           Int16, (Int16, Int16), rank, index_size)
 
+# The element-type code stored in a tensor descriptor, as emitted by Apple's Metal frontend
+# for `air.init_strided_private_tensor` (an AIR-internal enum, distinct from both
+# `MTLTensorDataType` and `__tensor_ops_datatype`). The descriptor's own strides/extents are
+# in elements; this code is what address computations that only see the descriptor (notably
+# `air.slice_*` origin folding, as of macOS 27) use to scale to bytes, so passing the wrong
+# code misaddresses any non-4-byte element type.
+tensor_datatype(::Type{Float32})  = Int8(0)
+tensor_datatype(::Type{Float16})  = Int8(1)
+tensor_datatype(::Type{BFloat16}) = Int8(2)
+tensor_datatype(::Type{Int8})     = Int8(3)
+tensor_datatype(::Type{UInt8})    = Int8(4)
+tensor_datatype(::Type{Int16})    = Int8(5)
+tensor_datatype(::Type{UInt16})   = Int8(6)
+tensor_datatype(::Type{Int32})    = Int8(7)
+tensor_datatype(::Type{UInt32})   = Int8(8)
+
 # Build an `i32`-indexed strided tensor view over a device-memory buffer.
+# (macOS 27's frontend appends two more arguments — a null device pointer and an `i32 0`,
+# presumably blockwise-quantization scale data — which the back-end accepts omitted.)
 @device_function @inline init_strided_tensor_device!(
     handle::TensorDescriptorStorage,
     rank::Int16,
     data::LLVMPtr{UInt8, AS.Device},
     extents::NTuple{<:Any, Int32},
     strides::NTuple{<:Any, Int32},
-    contiguous::Int8,
+    datatype::Int8,
 ) = ccall("extern air.init_strided_private_tensor.i32.global", llvmcall,
           Cvoid,
           (Ref{TensorDescriptor}, Int16, LLVMPtr{UInt8, AS.Device},
            Ref{Int32}, Ref{Int32}, Int8),
-          handle, rank, data, extents, strides, contiguous)
+          handle, rank, data, extents, strides, datatype)
 
 @device_function @inline init_strided_tensor_threadgroup!(
     handle::TensorDescriptorStorage,
@@ -47,12 +65,12 @@ const TensorDescriptorStorage = Base.RefValue{TensorDescriptor}
     data::LLVMPtr{UInt8, AS.ThreadGroup},
     extents::NTuple{<:Any, Int32},
     strides::NTuple{<:Any, Int32},
-    contiguous::Int8,
+    datatype::Int8,
 ) = ccall("extern air.init_strided_private_tensor.i32.local", llvmcall,
           Cvoid,
           (Ref{TensorDescriptor}, Int16, LLVMPtr{UInt8, AS.ThreadGroup},
            Ref{Int32}, Ref{Int32}, Int8),
-          handle, rank, data, extents, strides, contiguous)
+          handle, rank, data, extents, strides, datatype)
 
 @device_function @inline get_extent_private_tensor(handle::TensorDescriptor,
                                                    rank::Int16, dim::Int16) =
@@ -110,7 +128,7 @@ end
     storage = Ref{TensorDescriptor}()
     init_strided_tensor_device!(storage, Int16(R),
                                 reinterpret(LLVMPtr{UInt8, AS.Device}, pointer(data)),
-                                e, packed_strides(e), Int8(0))
+                                e, packed_strides(e), tensor_datatype(T))
     return MtlInlineTensor{T, R, AS.Device}(storage[])
 end
 
@@ -121,7 +139,7 @@ end
     storage = Ref{TensorDescriptor}()
     init_strided_tensor_threadgroup!(storage, Int16(R),
                                      reinterpret(LLVMPtr{UInt8, AS.ThreadGroup}, pointer(data)),
-                                     e, packed_strides(e), Int8(0))
+                                     e, packed_strides(e), tensor_datatype(T))
     return MtlInlineTensor{T, R, AS.ThreadGroup}(storage[])
 end
 
@@ -134,7 +152,7 @@ end
     init_strided_tensor_device!(storage, Int16(R),
                                 reinterpret(LLVMPtr{UInt8, AS.Device}, pointer(data)),
                                 unsafe_trunc.(Int32, extents),
-                                unsafe_trunc.(Int32, strides), Int8(0))
+                                unsafe_trunc.(Int32, strides), tensor_datatype(T))
     return MtlInlineTensor{T, R, AS.Device}(storage[])
 end
 
@@ -146,7 +164,7 @@ end
     init_strided_tensor_threadgroup!(storage, Int16(R),
                                      reinterpret(LLVMPtr{UInt8, AS.ThreadGroup}, pointer(data)),
                                      unsafe_trunc.(Int32, extents),
-                                     unsafe_trunc.(Int32, strides), Int8(0))
+                                     unsafe_trunc.(Int32, strides), tensor_datatype(T))
     return MtlInlineTensor{T, R, AS.ThreadGroup}(storage[])
 end
 

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -482,9 +482,7 @@ function gemm!(C::MtlMatrix, tA::Char, tB::Char,
         supports_tensor_matmul(C, A, B, tA, tB, alpha, beta) ||
             error("tensor-ops GEMM is not supported for these operands")
         gemm_tensor!(C, A, B, alpha, beta, tA, tB)
-    # tensor matmul fails in some configurations in macos 27 beta
-    # so disable automatic selection in this version until fixed
-    elseif kernel === :auto && supports_tensor_matmul(C, A, B, tA, tB, alpha, beta) && macos_version() < v"27"
+    elseif kernel === :auto && supports_tensor_matmul(C, A, B, tA, tB, alpha, beta)
         gemm_tensor!(C, A, B, alpha, beta, tA, tB)
     elseif kernel === :simd || (kernel === :auto && supports_simd_matmul(C, A, B, tA, tB, alpha, beta))
         gemm_simd!(C, A, B, alpha, beta, tA, tB)


### PR DESCRIPTION
All Fable.

Before this, the 2-byte eltypes were failing on macOS 27:
```
using Metal, ScopedValues, Test, BFloat16s, LinearAlgebra; @testset "Tensor matmul" begin
    ttol(T) = T === Float32 ? 1.0f-3 : 1.0f-1
    @testset "$T $M×$N×$K" for T in (Float32, Float16, BFloat16),
                                (M, N, K) in ((64, 64, 32), (128, 256, 64), (512, 512, 128))
        A = MtlArray(rand(T, M, K)); B = MtlArray(rand(T, K, N))
        ref = Array(A) * Array(B)
        @test Metal.supports_tensor_matmul(MtlArray(zeros(T, M, N)), A, B, 'N', 'N', true, false)
        Ct = MtlArray(zeros(T, M, N))
        @with (Metal.matmul_alg => :tensor) mul!(Ct, A, B)
        @test isapprox(Array(Ct), ref; rtol=ttol(T))
    end
end
```