### PR TITLE
add override for `Bool` and intercept `throw(InexactError(...))`

### DIFF
--- a/src/device/quirks.jl
+++ b/src/device/quirks.jl
@@ -33,6 +33,19 @@ end
 @device_override @noinline Core.throw_inexacterror(f::Symbol, ::Type{T}, val) where {T} =
     @gputhrow "InexactError" "Inexact conversion"
 
+# bool.jl / float.jl
+# `Bool(::Real)` and `Bool(::Float16)` don't go through `throw_inexacterror` but construct
+# the `InexactError` themselves, through its vararg `@nospecialize` constructor. On the
+# device that means boxing the arguments into a heap-allocated tuple on the throwing branch
+# (an allocation the optimizer can't remove), so route them through `@gputhrow` instead.
+for T in (Real, Float16)
+    @eval @device_override function Base.Bool(x::$T)
+        x == 0 && return false
+        x == 1 && return true
+        @gputhrow "InexactError" "Inexact conversion"
+    end
+end
+
 # abstractarray.jl
 @device_override @noinline Base.throw_boundserror(A, I) =
     @gputhrow "BoundsError" "Out-of-bounds array access"

--- a/test/array.jl
+++ b/test/array.jl
@@ -751,6 +751,15 @@ end
         @test Array(x) == [false, false]
         x .= true
         @test Array(x) == [true, true]
+        x .= Float16(0)
+        @test Array(x) == [false, false]
+
+        # an inexact conversion throws on the device, through the `Bool(::Real)` quirk
+        # rather than by constructing an `InexactError` box
+        @test_throws Metal.KernelException begin
+            x .= 2
+            synchronize()
+        end
     end
 
     # preserving buffer types


### PR DESCRIPTION
Both this PR and https://github.com/JuliaGPU/GPUCompiler.jl/pull/904 fix the issue reported in https://github.com/JuliaGPU/GPUCompiler.jl/pull/899#issuecomment-5372635495 on their own, but both are separate issues that just surfaced together to cause these errors

Adds a device override for `Bool(::Real)` and `Bool(::Float16)` that uses `@gpu_throw` for the error path instead of throwing a regular `InexactError`. We already do this for `Core.throw_inexacterror`, but the `Bool` constructor doesn't call that function