### PR TITLE
Native gemm: support view destinations and refactor

### DIFF
--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -230,6 +230,14 @@ end
 
 ## scalar path: per-element shared-memory tiled kernel (any eltype / transpose / offset)
 
+# α/β scaling for the scalar kernel. LinearAlgebra passes `Bool` α/β (`MulAddMul`'s
+# strong-zero flags), and `Bool * AbstractFloat` lowers through `copysign` — which the
+# Metal backend cannot compile for `BFloat16` — so handle `Bool` with a select instead.
+# (The false cases never execute: α = 0 returns early in `gemm!` and β = 0 takes the
+# `iszero` branch below; they just have to compile.)
+@inline bscale(a, x) = a * x
+@inline bscale(a::Bool, x) = a ? x : zero(x)
+
 function gemm_scalar_kernel!(C, A, B, alpha, beta,
                               M, N, K, ::Val{TA}, ::Val{TB}, ::Val{TILE}) where {TA, TB, TILE}
     TAT = eltype(A); TBT = eltype(B); R = eltype(C)
@@ -267,9 +275,9 @@ function gemm_scalar_kernel!(C, A, B, alpha, beta,
         # `setindex!` converts to `R` for us; an explicit `R(...)` would additionally
         # demand a constructor, which element types like `SVector` don't provide
         if iszero(beta)
-            @inbounds C[gi, gj] = alpha * acc
+            @inbounds C[gi, gj] = bscale(alpha, acc)
         else
-            @inbounds C[gi, gj] = alpha * acc + beta * C[gi, gj]
+            @inbounds C[gi, gj] = bscale(alpha, acc) + bscale(beta, C[gi, gj])
         end
     end
     return
@@ -472,11 +480,12 @@ function gemm!(C::MtlMatrixOperand, tA::Char, tB::Char,
     # nothing to compute
     (M == 0 || N == 0) && return C
 
-    # empty contraction: C = β·C
-    if K == 0
+    # no contribution from A·B (empty contraction, or α = 0 which LinearAlgebra
+    # defines as never reading A·B): C = β·C
+    if K == 0 || iszero(alpha)
         if iszero(beta)
             fill!(C, zero(eltype(C)))
-        else
+        elseif !isone(beta)
             C .*= beta
         end
         return C

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -125,10 +125,9 @@ end
 # scratch and written elementwise with bounds checks.
 # DIRECT=false (view destinations and eltypes `simdgroup_store` can't assemble, see
 # `gemm_simd!`): every fragment takes the scratch path, which accesses C elementwise.
-@inline function epilogue!(C, scratch, acc, bm0, sm0, bn0, sn0, M, N,
+@inline function epilogue!(C::AbstractArray{R}, scratch, acc, bm0, sm0, bn0, sn0, M, N,
                             alpha, beta, lane, sc0, ::Val{TM}, ::Val{TN},
-                            ::Val{EDGE}, ::Val{SIMPLE}, ::Val{DIRECT}) where {TM, TN, EDGE, SIMPLE, DIRECT}
-    R = eltype(C)
+                            ::Val{EDGE}, ::Val{SIMPLE}, ::Val{DIRECT}) where {R, TM, TN, EDGE, SIMPLE, DIRECT}
     ntuple(Val(TM * TN)) do idx
         ti = (idx - 1) % TM; tj = (idx - 1) ÷ TM
         gr = bm0 + sm0 + ti * 8; gc = bn0 + sn0 + tj * 8

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -120,16 +120,19 @@ end
 end
 
 # epilogue, kept top-level so the unrolled ntuple doesn't capture the reassigned acc.
-# EDGE=false: every fragment is fully in-bounds -> direct stores, no scratch needed.
-# EDGE=true: boundary fragments are staged through a small per-simdgroup 8x8 scratch
-# and written elementwise with bounds checks.
-@inline function epilogue!(C::MtlDeviceArray{R}, scratch, acc, bm0, sm0, bn0, sn0, M, N,
+# DIRECT=true, EDGE=false: every fragment is fully in-bounds -> direct stores, no scratch.
+# DIRECT=true, EDGE=true: boundary fragments are staged through a small per-simdgroup 8x8
+# scratch and written elementwise with bounds checks.
+# DIRECT=false (view destinations and eltypes `simdgroup_store` can't assemble, see
+# `gemm_simd!`): every fragment takes the scratch path, which accesses C elementwise.
+@inline function epilogue!(C, scratch, acc, bm0, sm0, bn0, sn0, M, N,
                             alpha, beta, lane, sc0, ::Val{TM}, ::Val{TN},
-                            ::Val{EDGE}, ::Val{SIMPLE}) where {R, TM, TN, EDGE, SIMPLE}
+                            ::Val{EDGE}, ::Val{SIMPLE}, ::Val{DIRECT}) where {TM, TN, EDGE, SIMPLE, DIRECT}
+    R = eltype(C)
     ntuple(Val(TM * TN)) do idx
         ti = (idx - 1) % TM; tj = (idx - 1) ÷ TM
         gr = bm0 + sm0 + ti * 8; gc = bn0 + sn0 + tj * 8
-        if (!EDGE || (gr + 8 <= M && gc + 8 <= N)) && simd_direct_store(R)
+        if DIRECT && (!EDGE || (gr + 8 <= M && gc + 8 <= N))
             store_frag!(C, acc[idx], gr, gc, alpha, beta, Val(SIMPLE))
         else
             simdgroup_store(acc[idx], scratch, (1, sc0 + 1))
@@ -163,7 +166,7 @@ end
 function gemm_simd_kernel!(C, A, B, alpha::Float32, beta::Float32,
                             M, N, K, ::Val{TA}, ::Val{TB},
                             ::Val{WM}, ::Val{WN}, ::Val{TM}, ::Val{TN},
-                            ::Val{KB}, ::Val{EDGE}, ::Val{SIMPLE}) where {TA, TB, WM, WN, TM, TN, KB, EDGE, SIMPLE}
+                            ::Val{KB}, ::Val{EDGE}, ::Val{SIMPLE}, ::Val{DIRECT}) where {TA, TB, WM, WN, TM, TN, KB, EDGE, SIMPLE, DIRECT}
     SGM = 8 * TM; SGN = 8 * TN                         # output region per simdgroup
     BM = WM * SGM; BN = WN * SGN; BK = 8 * KB
     nthreads = WM * WN * 32
@@ -222,7 +225,7 @@ function gemm_simd_kernel!(C, A, B, alpha::Float32, beta::Float32,
 
     lane = Int(thread_index_in_simdgroup()) - 1
     epilogue!(C, scratch, acc, bm0, sm0, bn0, sn0, M, N, alpha, beta, lane, s0 * 8,
-               Val(TM), Val(TN), Val(EDGE), Val(SIMPLE))
+               Val(TM), Val(TN), Val(EDGE), Val(SIMPLE), Val(DIRECT))
     return
 end
 
@@ -421,12 +424,16 @@ function gemm_simd!(C, A, B, alpha, beta, cA::Char, cB::Char)
     threads = WM * WN * 32
     groups = (cld(M, BM), cld(N, BN))
     # aligned tiles skip the bounds-checked edge path; α=1,β=0 skips the α/β arithmetic.
-    # `BFloat16` outputs always need the edge path's f32 scratch (see `simd_direct_store`).
-    edge = !(M % BM == 0 && N % BN == 0) || !simd_direct_store(eltype(C))
+    # `simdgroup_store` addresses C by its leading dimension, so view destinations — like
+    # `BFloat16` outputs (see `simd_direct_store`) — always take the edge path's f32
+    # scratch, which accesses C elementwise.
+    direct = C isa MtlMatrix && simd_direct_store(eltype(C))
+    edge = !(M % BM == 0 && N % BN == 0) || !direct
     simple = isone(alpha) && iszero(beta)
     @metal threads=threads groups=groups gemm_simd_kernel!(
         C, A, B, Float32(alpha), Float32(beta), Int(M), Int(N), Int(K),
-        Val(cA), Val(cB), Val(WM), Val(WN), Val(TM), Val(TN), Val(KB), Val(edge), Val(simple))
+        Val(cA), Val(cB), Val(WM), Val(WN), Val(TM), Val(TN), Val(KB), Val(edge), Val(simple),
+        Val(direct))
     return C
 end
 
@@ -446,7 +453,8 @@ end
 """
     Metal.gemm!(C, tA, tB, A, B, α, β; kernel=:auto)
 
-Native GEMM computing `C = α·op_tA(A)·op_tB(B) + β·C` for `MtlMatrix` operands.
+Native GEMM computing `C = α·op_tA(A)·op_tB(B) + β·C` for `MtlMatrix` operands, or
+range-based `view`s of them (including the destination).
 `tA`/`tB ∈ {'N','T','C'}`, or one of the LinearAlgebra wrapper chars `{'S','s','H','h'}`
 applying a Symmetric/Hermitian view of the operand (upper/lowercase selects the stored
 triangle). Backs the `:native`/`:auto` matmul paths (`kernel=:auto`, picking
@@ -456,7 +464,7 @@ caller's responsibility (see `supports_simd_matmul`/`supports_tensor_matmul`); t
 kernel never handles wrapper chars (it requires plain `'N'`/`'N'` operands), while the simd
 and scalar kernels gather elementwise through `opA`/`opB` and handle all of them.
 """
-function gemm!(C::MtlMatrix, tA::Char, tB::Char,
+function gemm!(C::MtlMatrixOperand, tA::Char, tB::Char,
                A::MtlMatrixOperand, B::MtlMatrixOperand,
                alpha::Number, beta::Number; kernel::Symbol = :auto)
     M = size(C, 1); N = size(C, 2)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -214,7 +214,7 @@ LinearAlgebra.generic_matvecmul!(C::MtlVector, tA::AbstractChar, A::MtlMatrix, B
     elseif alg === :GPUArrays
         GPUArrays.generic_matmatmul!(C, wrap(A, tA), B, alpha, beta)
     else
-        error(":$alg is not a valid matmul algorithm. Options are: `:auto`, `:MPS`, `:MPSGraph`, `:GPUArrays`, `:native`, `:simd`, `:scalar`")
+        error(":$alg is not a valid matvecmul algorithm. Options are: `:auto`, `:MPS`, `:MPSGraph`, `:GPUArrays`, `:native`, `:simd`, `:scalar`")
     end
 end
 

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -39,8 +39,25 @@ matmul_alg_error(alg, inT, outT, vec) = error("Matrix-$(vec ? "Vector" : "Matrix
 # paths only the former); gemm_char normalizes an AbstractChar (e.g. a
 # LinearAlgebra.WrapperChar) to the plain Char the kernels specialize on.
 @inline is_ntc(t) = (t == 'N') || (t == 'T') || (t == 'C')
-@inline gemm_char(t) = t == 'N' ? 'N' : t == 'T' ? 'T' : t == 'C' ? 'C' :
-                       t == 'S' ? 'S' : t == 's' ? 's' : t == 'H' ? 'H' : 'h'
+@inline gemm_char(t) = Char(t)
+
+matmul_alg_invalid(alg, vec) =
+    error(":$alg is not a valid $(vec ? "matvecmul" : "matmul") algorithm. Options are: `:auto`, `:MPS`, `:MPSGraph`, `:GPUArrays`, `:native`, `:simd`, `:scalar`$(vec ? "" : ", `:tensor`")")
+
+# shared native-kernel path: a forced :simd/:tensor kernel must support the operands
+# (the scalar kernel handles anything); :native/:auto let gemm! pick the kernel
+@inline function native_matmul!(C, tA, tB, A, B, alpha, beta, alg)
+    cA = gemm_char(tA); cB = gemm_char(tB)
+    if alg === :simd
+        supports_simd_matmul(C, A, B, cA, cB, alpha, beta) ||
+            matmul_alg_error(alg, eltype(A), eltype(C), false)
+    elseif alg === :tensor
+        supports_tensor_matmul(C, A, B, cA, cB, alpha, beta) ||
+            matmul_alg_error(alg, eltype(A), eltype(C), false)
+    end
+    kernel = (alg === :native || alg === :auto) ? :auto : alg
+    gemm!(C, cA, cB, A, B, alpha, beta; kernel)
+end
 
 LinearAlgebra.generic_matmatmul!(C::MtlMatrix, tA, tB, A::MtlMatrix, B::MtlMatrix, _add::MulAddMul) =
     LinearAlgebra.generic_matmatmul!(C, tA, tB, A, B, _add.alpha, _add.beta)
@@ -65,27 +82,17 @@ LinearAlgebra.generic_matmatmul!(C::MtlMatrix, tA, tB, A::MtlMatrix, B::MtlMatri
     end
 
     alg = matmul_alg[]
-    # the MPS paths only handle plain transpose/adjoint operands
+    # the MPS paths only handle plain transpose/adjoint operands; only probe MPSGraph
+    # support when a branch below can actually use it
     ntc = is_ntc(tA) && is_ntc(tB)
-    mpsgraph_supported = ntc && supports_mpsgraph_matmul(A, B, C, MPSGRAPH_VALID_MATMUL_TYPES)
+    mpsgraph_supported = (alg === :MPSGraph || alg === :auto) && ntc &&
+                         supports_mpsgraph_matmul(A, B, C, MPSGRAPH_VALID_MATMUL_TYPES)
     # If possible, dispatch to MPSGraphs, then performance shaders
     if alg === :MPSGraph || (alg === :auto && mpsgraph_supported)
         mpsgraph_supported || matmul_alg_error(alg, eltype(A), eltype(C), false)
         graph_matmul!(C, A, B, alpha, beta, tA, tB)
-    elseif alg === :simd || alg === :scalar || alg === :tensor
-        # explicit native kernel: check it supports these operands, then force it. The scalar
-        # kernel handles any eltype, so only :simd and :tensor have an extra constraint.
-        cA = gemm_char(tA); cB = gemm_char(tB)
-        if alg === :simd
-            supports_simd_matmul(C, A, B, cA, cB, alpha, beta) ||
-                matmul_alg_error(alg, eltype(A), eltype(C), false)
-        elseif alg === :tensor
-            supports_tensor_matmul(C, A, B, cA, cB, alpha, beta) ||
-                matmul_alg_error(alg, eltype(A), eltype(C), false)
-        end
-        gemm!(C, cA, cB, A, B, alpha, beta; kernel=alg)
-    elseif alg === :native || alg === :auto
-        gemm!(C, gemm_char(tA), gemm_char(tB), A, B, alpha, beta)
+    elseif alg === :native || alg === :auto || alg === :simd || alg === :scalar || alg === :tensor
+        native_matmul!(C, tA, tB, A, B, alpha, beta, alg)
     elseif alg === :MPS
         (ntc && supports_mps_matmul(A, B, C, MPS_VALID_MATMUL_TYPES)) || matmul_alg_error(alg, eltype(A), eltype(C), false)
         transA = tA == 'T' || tA == 'C'
@@ -94,7 +101,7 @@ LinearAlgebra.generic_matmatmul!(C::MtlMatrix, tA, tB, A::MtlMatrix, B::MtlMatri
     elseif alg === :GPUArrays
         GPUArrays.generic_matmatmul!(C, wrap(A, tA), wrap(B, tB), alpha, beta)
     else
-        error(":$alg is not a valid matmul algorithm. Options are: `:auto`, `:MPS`, `:MPSGraph`, `:GPUArrays`, `:native`, `:simd`, `:scalar`, `:tensor`")
+        matmul_alg_invalid(alg, false)
     end
 end
 
@@ -125,22 +132,13 @@ LinearAlgebra.generic_matmatmul!(C::MtlMatrix, tA, tB,
 
     alg = matmul_alg[]
     if alg === :native || alg === :auto || alg === :simd || alg === :scalar || alg === :tensor
-        cA = gemm_char(tA); cB = gemm_char(tB)
-        if alg === :simd
-            supports_simd_matmul(C, A, B, cA, cB, alpha, beta) ||
-                matmul_alg_error(alg, eltype(A), eltype(C), false)
-        elseif alg === :tensor
-            supports_tensor_matmul(C, A, B, cA, cB, alpha, beta) ||
-                matmul_alg_error(alg, eltype(A), eltype(C), false)
-        end
-        kernel = (alg === :simd || alg === :scalar || alg === :tensor) ? alg : :auto
-        gemm!(C, cA, cB, A, B, alpha, beta; kernel)
+        native_matmul!(C, tA, tB, A, B, alpha, beta, alg)
     elseif alg === :GPUArrays
         GPUArrays.generic_matmatmul!(C, wrap(A, tA), wrap(B, tB), alpha, beta)
     elseif alg === :MPS || alg === :MPSGraph
         matmul_alg_error(alg, eltype(A), eltype(C), false)
     else
-        error(":$alg is not a valid matmul algorithm. Options are: `:auto`, `:MPS`, `:MPSGraph`, `:GPUArrays`, `:native`, `:simd`, `:scalar`, `:tensor`")
+        matmul_alg_invalid(alg, false)
     end
 end
 
@@ -179,9 +177,11 @@ LinearAlgebra.generic_matvecmul!(C::MtlVector, tA::AbstractChar, A::MtlMatrix, B
     end
 
     alg = matmul_alg[]
-    # the MPS paths only handle plain transpose/adjoint operands
+    # the MPS paths only handle plain transpose/adjoint operands; only probe MPSGraph
+    # support when a branch below can actually use it
     ntc = is_ntc(tA)
-    mpsgraph_supported = ntc && supports_mpsgraph_matmul(A, B, C, MPSGRAPH_VALID_MATVECMUL_TYPES)
+    mpsgraph_supported = (alg === :MPSGraph || alg === :auto) && ntc &&
+                         supports_mpsgraph_matmul(A, B, C, MPSGRAPH_VALID_MATVECMUL_TYPES)
     # If possible, dispatch to MPSGraphs, then performance shaders
     if alg === :MPSGraph || (alg === :auto && mpsgraph_supported)
         mpsgraph_supported || matmul_alg_error(alg, eltype(A), eltype(C), true)
@@ -190,10 +190,11 @@ LinearAlgebra.generic_matvecmul!(C::MtlVector, tA::AbstractChar, A::MtlMatrix, B
         # matrix-vector products go through the native gemv; `:simd`/`:scalar` force the
         # kernel. The tensor kernel is matrix-only, so `:tensor` isn't handled here and
         # falls through to the unsupported-algorithm error below.
+        cA = gemm_char(tA)
         kernel = (alg === :simd || alg === :scalar) ? alg : :auto
-        alg === :simd && !supports_simd_matmul(C, A, B, gemm_char(tA), 'N', alpha, beta) &&
-            matmul_alg_error(alg, eltype(A), eltype(C), true)
-        gemv!(C, gemm_char(tA), A, B, alpha, beta; kernel)
+        alg === :simd && (supports_simd_matmul(C, A, B, cA, 'N', alpha, beta) ||
+            matmul_alg_error(alg, eltype(A), eltype(C), true))
+        gemv!(C, cA, A, B, alpha, beta; kernel)
     elseif alg === :MPS
         (ntc && supports_mps_matmul(A, B, C, MPS_VALID_MATVECMUL_TYPES)) || matmul_alg_error(alg, eltype(A), eltype(C), true)
         transA = tA == 'T' || tA == 'C'
@@ -201,7 +202,7 @@ LinearAlgebra.generic_matvecmul!(C::MtlVector, tA::AbstractChar, A::MtlMatrix, B
     elseif alg === :GPUArrays
         GPUArrays.generic_matmatmul!(C, wrap(A, tA), B, alpha, beta)
     else
-        error(":$alg is not a valid matvecmul algorithm. Options are: `:auto`, `:MPS`, `:MPSGraph`, `:GPUArrays`, `:native`, `:simd`, `:scalar`")
+        matmul_alg_invalid(alg, true)
     end
 end
 

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -34,12 +34,11 @@ end
 const matmul_alg = ScopedValue(:auto)
 matmul_alg_error(alg, inT, outT, vec) = error("Matrix-$(vec ? "Vector" : "Matrix") multiplication algorithm `:$alg` is not supported for input eltype $inT and output eltype $outT.")
 
-# the native GEMM kernels handle 'N'/'T'/'C' as well as the Symmetric/Hermitian wrapper
-# chars 'S'/'s'/'H'/'h' (the MPS paths only the former); gemm_char normalizes an
-# AbstractChar (e.g. a LinearAlgebra.WrapperChar) to the plain Char the kernels
-# specialize on.
+# LinearAlgebra's wrapper_char only ever produces 'N'/'T'/'C' or the Symmetric/Hermitian
+# wrapper chars 'S'/'s'/'H'/'h', all of which the native GEMM kernels handle (the MPS
+# paths only the former); gemm_char normalizes an AbstractChar (e.g. a
+# LinearAlgebra.WrapperChar) to the plain Char the kernels specialize on.
 @inline is_ntc(t) = (t == 'N') || (t == 'T') || (t == 'C')
-@inline is_gemm_char(t) = is_ntc(t) || (t == 'S') || (t == 's') || (t == 'H') || (t == 'h')
 @inline gemm_char(t) = t == 'N' ? 'N' : t == 'T' ? 'T' : t == 'C' ? 'C' :
                        t == 'S' ? 'S' : t == 's' ? 's' : t == 'H' ? 'H' : 'h'
 
@@ -76,7 +75,6 @@ LinearAlgebra.generic_matmatmul!(C::MtlMatrix, tA, tB, A::MtlMatrix, B::MtlMatri
     elseif alg === :simd || alg === :scalar || alg === :tensor
         # explicit native kernel: check it supports these operands, then force it. The scalar
         # kernel handles any eltype, so only :simd and :tensor have an extra constraint.
-        is_gemm_char(tA) && is_gemm_char(tB) || matmul_alg_error(alg, eltype(A), eltype(C), false)
         cA = gemm_char(tA); cB = gemm_char(tB)
         if alg === :simd
             supports_simd_matmul(C, A, B, cA, cB, alpha, beta) ||
@@ -87,12 +85,7 @@ LinearAlgebra.generic_matmatmul!(C::MtlMatrix, tA, tB, A::MtlMatrix, B::MtlMatri
         end
         gemm!(C, cA, cB, A, B, alpha, beta; kernel=alg)
     elseif alg === :native || alg === :auto
-        if is_gemm_char(tA) && is_gemm_char(tB)
-            gemm!(C, gemm_char(tA), gemm_char(tB), A, B, alpha, beta)
-        else
-            # operand chars we don't know: expand through the generic GPUArrays path
-            GPUArrays.generic_matmatmul!(C, wrap(A, tA), wrap(B, tB), alpha, beta)
-        end
+        gemm!(C, gemm_char(tA), gemm_char(tB), A, B, alpha, beta)
     elseif alg === :MPS
         (ntc && supports_mps_matmul(A, B, C, MPS_VALID_MATMUL_TYPES)) || matmul_alg_error(alg, eltype(A), eltype(C), false)
         transA = tA == 'T' || tA == 'C'
@@ -132,7 +125,6 @@ LinearAlgebra.generic_matmatmul!(C::MtlMatrix, tA, tB,
 
     alg = matmul_alg[]
     if alg === :native || alg === :auto || alg === :simd || alg === :scalar || alg === :tensor
-        is_gemm_char(tA) && is_gemm_char(tB) || matmul_alg_error(alg, eltype(A), eltype(C), false)
         cA = gemm_char(tA); cB = gemm_char(tB)
         if alg === :simd
             supports_simd_matmul(C, A, B, cA, cB, alpha, beta) ||
@@ -198,15 +190,10 @@ LinearAlgebra.generic_matvecmul!(C::MtlVector, tA::AbstractChar, A::MtlMatrix, B
         # matrix-vector products go through the native gemv; `:simd`/`:scalar` force the
         # kernel. The tensor kernel is matrix-only, so `:tensor` isn't handled here and
         # falls through to the unsupported-algorithm error below.
-        if is_gemm_char(tA)
-            kernel = (alg === :simd || alg === :scalar) ? alg : :auto
-            alg === :simd && !supports_simd_matmul(C, A, B, gemm_char(tA), 'N', alpha, beta) &&
-                matmul_alg_error(alg, eltype(A), eltype(C), true)
-            gemv!(C, gemm_char(tA), A, B, alpha, beta; kernel)
-        else
-            # operand chars we don't know: expand through the generic GPUArrays path
-            GPUArrays.generic_matmatmul!(C, wrap(A, tA), B, alpha, beta)
-        end
+        kernel = (alg === :simd || alg === :scalar) ? alg : :auto
+        alg === :simd && !supports_simd_matmul(C, A, B, gemm_char(tA), 'N', alpha, beta) &&
+            matmul_alg_error(alg, eltype(A), eltype(C), true)
+        gemv!(C, gemm_char(tA), A, B, alpha, beta; kernel)
     elseif alg === :MPS
         (ntc && supports_mps_matmul(A, B, C, MPS_VALID_MATVECMUL_TYPES)) || matmul_alg_error(alg, eltype(A), eltype(C), true)
         transA = tA == 'T' || tA == 'C'

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -105,11 +105,11 @@ LinearAlgebra.generic_matmatmul!(C::MtlMatrix, tA, tB, A::MtlMatrix, B::MtlMatri
     end
 end
 
-LinearAlgebra.generic_matmatmul!(C::MtlMatrix, tA, tB,
+LinearAlgebra.generic_matmatmul!(C::MtlMatrixOperand, tA, tB,
                                  A::MtlMatrixOperand, B::MtlMatrixOperand,
                                  _add::MulAddMul) =
     LinearAlgebra.generic_matmatmul!(C, tA, tB, A, B, _add.alpha, _add.beta)
-@autoreleasepool function LinearAlgebra.generic_matmatmul!(C::MtlMatrix, tA, tB,
+@autoreleasepool function LinearAlgebra.generic_matmatmul!(C::MtlMatrixOperand, tA, tB,
                                                            A::MtlMatrixOperand,
                                                            B::MtlMatrixOperand,
                                                            alpha::Number, beta::Number)
@@ -143,7 +143,7 @@ LinearAlgebra.generic_matmatmul!(C::MtlMatrix, tA, tB,
 end
 
 if isdefined(LinearAlgebra, :generic_matmatmul_wrapper!)
-    function LinearAlgebra.generic_matmatmul_wrapper!(C::MtlMatrix{T},
+    function LinearAlgebra.generic_matmatmul_wrapper!(C::MtlMatrixOperand{T},
                                                       tA::AbstractChar, tB::AbstractChar,
                                                       A::MtlMatrixOperand{T},
                                                       B::MtlMatrixOperand{T},

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -36,8 +36,8 @@ using LinearAlgebra, ScopedValues
         @test_throws "Matrix-$(vec_b ? "Vector" : "Matrix") multiplication algorithm `:MPSGraph`" test_matmul(Int8, Int16; vec_b, alg=:MPSGraph)
 
         # Invalid algorithm Symbol
-        @test_throws ":bad is not a valid matvecmul algorithm." test_matmul(Int8, Int16; vec_b, alg=:bad)
-        @test_throws ":bad is not a valid matvecmul algorithm." test_matmul(Float16, Float16; vec_b, alg=:bad)
+        @test_throws ":bad is not a valid $(vec_b ? "matvecmul" : "matmul") algorithm." test_matmul(Int8, Int16; vec_b, alg=:bad)
+        @test_throws ":bad is not a valid $(vec_b ? "matvecmul" : "matmul") algorithm." test_matmul(Float16, Float16; vec_b, alg=:bad)
 
         # :auto
         @test test_matmul(Int32, Int32; vec_b)     # fallback to GPUArrays

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -102,79 +102,81 @@ end
 end
 
 @testset "matrix multiplication of range views" begin
-    x = ones(Float32, 2, 2)
-    y = ones(Float32, 4, 2)
-    dx = MtlArray(x)
-    dy = MtlArray(y)
-    @test Array(dx * view(dy, 1:2, :)) ≈ x * view(y, 1:2, :)
+    @testset "$T" for T in [Float32, Float16, BFloat16]
+        x = ones(T, 2, 2)
+        y = ones(T, 4, 2)
+        dx = MtlArray(x)
+        dy = MtlArray(y)
+        @test Array(dx * view(dy, 1:2, :)) ≈ x * view(y, 1:2, :)
 
-    a = rand(Float32, 4, 3)
-    b = rand(Float32, 3, 5)
-    da = MtlArray(a)
-    db = MtlArray(b)
-    av = view(da, 2:3, :)
-    bv = view(db, :, 2:4)
+        a = rand(T, 4, 3)
+        b = rand(T, 3, 5)
+        da = MtlArray(a)
+        db = MtlArray(b)
+        av = view(da, 2:3, :)
+        bv = view(db, :, 2:4)
 
-    # Call `generic_matmatmul!` directly so these exercise the native kernels and honor `matmul_alg`
-    for alg in (:auto, :simd, :scalar)
-        C = MtlArray(zeros(Float32, 2, 5))
-        @with (Metal.matmul_alg => alg) LinearAlgebra.generic_matmatmul!(C, 'N', 'N', av, db, true, false)
-        @test Array(C) ≈ view(a, 2:3, :) * b
+        # Call `generic_matmatmul!` directly so these exercise the native kernels and honor `matmul_alg`
+        for alg in (:auto, :simd, :scalar)
+            C = MtlArray(zeros(T, 2, 5))
+            @with (Metal.matmul_alg => alg) LinearAlgebra.generic_matmatmul!(C, 'N', 'N', av, db, true, false)
+            @test Array(C) ≈ view(a, 2:3, :) * b
 
-        C = MtlArray(zeros(Float32, 4, 3))
-        @with (Metal.matmul_alg => alg) LinearAlgebra.generic_matmatmul!(C, 'N', 'N', da, bv, true, false)
-        @test Array(C) ≈ a * view(b, :, 2:4)
+            C = MtlArray(zeros(T, 4, 3))
+            @with (Metal.matmul_alg => alg) LinearAlgebra.generic_matmatmul!(C, 'N', 'N', da, bv, true, false)
+            @test Array(C) ≈ a * view(b, :, 2:4)
 
-        C = MtlArray(zeros(Float32, 2, 3))
-        @with (Metal.matmul_alg => alg) LinearAlgebra.generic_matmatmul!(C, 'N', 'N', av, bv, true, false)
-        @test Array(C) ≈ view(a, 2:3, :) * view(b, :, 2:4)
-    end
+            C = MtlArray(zeros(T, 2, 3))
+            @with (Metal.matmul_alg => alg) LinearAlgebra.generic_matmatmul!(C, 'N', 'N', av, bv, true, false)
+            @test Array(C) ≈ view(a, 2:3, :) * view(b, :, 2:4)
+        end
 
-    # non-unit strides (step-range views)
-    as = rand(Float32, 8, 6)
-    bs = rand(Float32, 6, 10)
-    xs = rand(Float32, 6)
-    das = MtlArray(as)
-    dbs = MtlArray(bs)
-    dxs = MtlArray(xs)
-    asv = view(das, 1:2:8, :)
-    bsv = view(dbs, :, 1:2:10)
+        # non-unit strides (step-range views)
+        as = rand(T, 8, 6)
+        bs = rand(T, 6, 10)
+        xs = rand(T, 6)
+        das = MtlArray(as)
+        dbs = MtlArray(bs)
+        dxs = MtlArray(xs)
+        asv = view(das, 1:2:8, :)
+        bsv = view(dbs, :, 1:2:10)
 
-    @test Array(asv * bsv) ≈ view(as, 1:2:8, :) * view(bs, :, 1:2:10)
-    @test Array(asv' * asv) ≈ view(as, 1:2:8, :)' * view(as, 1:2:8, :)
-    @test Array(asv * dxs) ≈ view(as, 1:2:8, :) * xs
+        @test Array(asv * bsv) ≈ view(as, 1:2:8, :) * view(bs, :, 1:2:10)
+        @test Array(asv' * asv) ≈ view(as, 1:2:8, :)' * view(as, 1:2:8, :)
+        @test Array(asv * dxs) ≈ view(as, 1:2:8, :) * xs
 
-    for alg in (:auto, :simd, :scalar)
-        C = MtlArray(zeros(Float32, 4, 5))
-        @with (Metal.matmul_alg => alg) LinearAlgebra.generic_matmatmul!(C, 'N', 'N', asv, bsv, true, false)
-        @test Array(C) ≈ view(as, 1:2:8, :) * view(bs, :, 1:2:10)
+        for alg in (:auto, :simd, :scalar)
+            C = MtlArray(zeros(T, 4, 5))
+            @with (Metal.matmul_alg => alg) LinearAlgebra.generic_matmatmul!(C, 'N', 'N', asv, bsv, true, false)
+            @test Array(C) ≈ view(as, 1:2:8, :) * view(bs, :, 1:2:10)
 
-        C = MtlArray(zeros(Float32, 6, 6))
-        @with (Metal.matmul_alg => alg) LinearAlgebra.generic_matmatmul!(C, 'T', 'N', asv, asv, true, false)
-        @test Array(C) ≈ view(as, 1:2:8, :)' * view(as, 1:2:8, :)
-    end
+            C = MtlArray(zeros(T, 6, 6))
+            @with (Metal.matmul_alg => alg) LinearAlgebra.generic_matmatmul!(C, 'T', 'N', asv, asv, true, false)
+            @test Array(C) ≈ view(as, 1:2:8, :)' * view(as, 1:2:8, :)
+        end
 
-    # strided destination
-    for alg in (:auto, :simd, :scalar)
-        cs = rand(Float32, 8, 5)
-        dcs = MtlArray(cs)
-        mul!(view(cs, 1:2:8, :), view(as, 1:2:8, :), view(bs, :, 1:2:10), 2.0f0, 1.0f0)
-        @with (Metal.matmul_alg => alg) LinearAlgebra.generic_matmatmul!(view(dcs, 1:2:8, :), 'N', 'N', asv, bsv, 2.0f0, 1.0f0)
-        @test Array(dcs) ≈ cs
-    end
+        # strided destination
+        for alg in (:auto, :simd, :scalar)
+            cs = rand(T, 8, 5)
+            dcs = MtlArray(cs)
+            mul!(view(cs, 1:2:8, :), view(as, 1:2:8, :), view(bs, :, 1:2:10), 2.0f0, 1.0f0)
+            @with (Metal.matmul_alg => alg) LinearAlgebra.generic_matmatmul!(view(dcs, 1:2:8, :), 'N', 'N', asv, bsv, 2.0f0, 1.0f0)
+            @test Array(dcs) ≈ cs
+        end
 
-    # strided destination with contiguous operands: the view is dense but its leading
-    # dimension differs from its height, which the simd kernel must not direct-store to
-    a2 = rand(Float32, 2, 3)
-    b2 = rand(Float32, 3, 5)
-    da2 = MtlArray(a2)
-    db2 = MtlArray(b2)
-    for alg in (:auto, :simd, :scalar)
-        c2 = rand(Float32, 4, 5)
-        dc2 = MtlArray(c2)
-        mul!(view(c2, 1:2, :), a2, b2)
-        @with (Metal.matmul_alg => alg) LinearAlgebra.generic_matmatmul!(view(dc2, 1:2, :), 'N', 'N', da2, db2, true, false)
-        @test Array(dc2) ≈ c2
+        # strided destination with contiguous operands: the view is dense but its leading
+        # dimension differs from its height, which the simd kernel must not direct-store to
+        a2 = rand(T, 2, 3)
+        b2 = rand(T, 3, 5)
+        da2 = MtlArray(a2)
+        db2 = MtlArray(b2)
+        for alg in (:auto, :simd, :scalar)
+            c2 = rand(T, 4, 5)
+            dc2 = MtlArray(c2)
+            mul!(view(c2, 1:2, :), a2, b2)
+            @with (Metal.matmul_alg => alg) LinearAlgebra.generic_matmatmul!(view(dc2, 1:2, :), 'N', 'N', da2, db2, true, false)
+            @test Array(dc2) ≈ c2
+        end
     end
 end
 

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -123,7 +123,49 @@ end
         C = MtlArray(zeros(Float32, 4, 3))
         @with (Metal.matmul_alg => alg) mul!(C, da, bv)
         @test Array(C) ≈ a * view(b, :, 2:4)
+
+        C = MtlArray(zeros(Float32, 2, 3))
+        @with (Metal.matmul_alg => alg) mul!(C, av, bv)
+        @test Array(C) ≈ view(a, 2:3, :) * view(b, :, 2:4)
     end
+
+    # non-unit strides (step-range views)
+    as = rand(Float32, 8, 6)
+    bs = rand(Float32, 6, 10)
+    xs = rand(Float32, 6)
+    das = MtlArray(as)
+    dbs = MtlArray(bs)
+    dxs = MtlArray(xs)
+    asv = view(das, 1:2:8, :)
+    bsv = view(dbs, :, 1:2:10)
+
+    @test Array(asv * bsv) ≈ view(as, 1:2:8, :) * view(bs, :, 1:2:10)
+    @test Array(asv' * asv) ≈ view(as, 1:2:8, :)' * view(as, 1:2:8, :)
+    @test Array(asv * dxs) ≈ view(as, 1:2:8, :) * xs
+
+    for alg in (:auto, :simd, :scalar)
+        C = MtlArray(zeros(Float32, 4, 5))
+        @with (Metal.matmul_alg => alg) mul!(C, asv, bsv)
+        @test Array(C) ≈ view(as, 1:2:8, :) * view(bs, :, 1:2:10)
+    end
+
+    # strided destination
+    cs = rand(Float32, 8, 5)
+    dcs = MtlArray(cs)
+    mul!(view(cs, 1:2:8, :), view(as, 1:2:8, :), view(bs, :, 1:2:10), 2.0f0, 1.0f0)
+    mul!(view(dcs, 1:2:8, :), asv, bsv, 2.0f0, 1.0f0)
+    @test Array(dcs) ≈ cs
+
+    # strided destination with contiguous operands
+    a2 = rand(Float32, 2, 3)
+    b2 = rand(Float32, 3, 5)
+    c2 = rand(Float32, 4, 5)
+    da2 = MtlArray(a2)
+    db2 = MtlArray(b2)
+    dc2 = MtlArray(c2)
+    mul!(view(c2, 1:2, :), a2, b2)
+    mul!(view(dc2, 1:2, :), da2, db2)
+    @test Array(dc2) ≈ c2
 end
 
 @testset "native GEMM" begin

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -115,17 +115,18 @@ end
     av = view(da, 2:3, :)
     bv = view(db, :, 2:4)
 
+    # Call `generic_matmatmul!` directly so these exercise the native kernels and honor `matmul_alg`
     for alg in (:auto, :simd, :scalar)
         C = MtlArray(zeros(Float32, 2, 5))
-        @with (Metal.matmul_alg => alg) mul!(C, av, db)
+        @with (Metal.matmul_alg => alg) LinearAlgebra.generic_matmatmul!(C, 'N', 'N', av, db, true, false)
         @test Array(C) ≈ view(a, 2:3, :) * b
 
         C = MtlArray(zeros(Float32, 4, 3))
-        @with (Metal.matmul_alg => alg) mul!(C, da, bv)
+        @with (Metal.matmul_alg => alg) LinearAlgebra.generic_matmatmul!(C, 'N', 'N', da, bv, true, false)
         @test Array(C) ≈ a * view(b, :, 2:4)
 
         C = MtlArray(zeros(Float32, 2, 3))
-        @with (Metal.matmul_alg => alg) mul!(C, av, bv)
+        @with (Metal.matmul_alg => alg) LinearAlgebra.generic_matmatmul!(C, 'N', 'N', av, bv, true, false)
         @test Array(C) ≈ view(a, 2:3, :) * view(b, :, 2:4)
     end
 
@@ -145,8 +146,12 @@ end
 
     for alg in (:auto, :simd, :scalar)
         C = MtlArray(zeros(Float32, 4, 5))
-        @with (Metal.matmul_alg => alg) mul!(C, asv, bsv)
+        @with (Metal.matmul_alg => alg) LinearAlgebra.generic_matmatmul!(C, 'N', 'N', asv, bsv, true, false)
         @test Array(C) ≈ view(as, 1:2:8, :) * view(bs, :, 1:2:10)
+
+        C = MtlArray(zeros(Float32, 6, 6))
+        @with (Metal.matmul_alg => alg) LinearAlgebra.generic_matmatmul!(C, 'T', 'N', asv, asv, true, false)
+        @test Array(C) ≈ view(as, 1:2:8, :)' * view(as, 1:2:8, :)
     end
 
     # strided destination

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -155,22 +155,27 @@ end
     end
 
     # strided destination
-    cs = rand(Float32, 8, 5)
-    dcs = MtlArray(cs)
-    mul!(view(cs, 1:2:8, :), view(as, 1:2:8, :), view(bs, :, 1:2:10), 2.0f0, 1.0f0)
-    mul!(view(dcs, 1:2:8, :), asv, bsv, 2.0f0, 1.0f0)
-    @test Array(dcs) ≈ cs
+    for alg in (:auto, :simd, :scalar)
+        cs = rand(Float32, 8, 5)
+        dcs = MtlArray(cs)
+        mul!(view(cs, 1:2:8, :), view(as, 1:2:8, :), view(bs, :, 1:2:10), 2.0f0, 1.0f0)
+        @with (Metal.matmul_alg => alg) LinearAlgebra.generic_matmatmul!(view(dcs, 1:2:8, :), 'N', 'N', asv, bsv, 2.0f0, 1.0f0)
+        @test Array(dcs) ≈ cs
+    end
 
-    # strided destination with contiguous operands
+    # strided destination with contiguous operands: the view is dense but its leading
+    # dimension differs from its height, which the simd kernel must not direct-store to
     a2 = rand(Float32, 2, 3)
     b2 = rand(Float32, 3, 5)
-    c2 = rand(Float32, 4, 5)
     da2 = MtlArray(a2)
     db2 = MtlArray(b2)
-    dc2 = MtlArray(c2)
-    mul!(view(c2, 1:2, :), a2, b2)
-    mul!(view(dc2, 1:2, :), da2, db2)
-    @test Array(dc2) ≈ c2
+    for alg in (:auto, :simd, :scalar)
+        c2 = rand(Float32, 4, 5)
+        dc2 = MtlArray(c2)
+        mul!(view(c2, 1:2, :), a2, b2)
+        @with (Metal.matmul_alg => alg) LinearAlgebra.generic_matmatmul!(view(dc2, 1:2, :), 'N', 'N', da2, db2, true, false)
+        @test Array(dc2) ≈ c2
+    end
 end
 
 @testset "native GEMM" begin

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -36,8 +36,8 @@ using LinearAlgebra, ScopedValues
         @test_throws "Matrix-$(vec_b ? "Vector" : "Matrix") multiplication algorithm `:MPSGraph`" test_matmul(Int8, Int16; vec_b, alg=:MPSGraph)
 
         # Invalid algorithm Symbol
-        @test_throws ":bad is not a valid matmul algorithm." test_matmul(Int8, Int16; vec_b, alg=:bad)
-        @test_throws ":bad is not a valid matmul algorithm." test_matmul(Float16, Float16; vec_b, alg=:bad)
+        @test_throws ":bad is not a valid matvecmul algorithm." test_matmul(Int8, Int16; vec_b, alg=:bad)
+        @test_throws ":bad is not a valid matvecmul algorithm." test_matmul(Float16, Float16; vec_b, alg=:bad)
 
         # :auto
         @test test_matmul(Int32, Int32; vec_b)     # fallback to GPUArrays


### PR DESCRIPTION
This PR:
- Adds support for view destinations in the native matmul path
- Factors out some identical code to be shared
- Routes the tests more directly to ensure that these paths are always tested. That these paths are reached under default conditions should be separate tests (and is currently [broken](https://github.com/JuliaGPU/GPUArrays.jl/pull/760#issuecomment-5412587370))