### PR TITLE
Handle empty operands before dispatching to a matmul backend

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -59,6 +59,14 @@ matmul_alg_invalid(alg, vec) =
     gemm!(C, cA, cB, A, B, alpha, beta; kernel)
 end
 
+# a product with an empty dimension is finished before any backend is chosen: MPS asserts on
+# zero-sized buffers, and the result does not depend on A or B anyway. C is either empty (M or
+# N == 0), or only β applies (K == 0).
+function empty_matmul!(C, beta)
+    isempty(C) && return C
+    iszero(beta) ? fill!(C, zero(eltype(C))) : rmul!(C, beta)
+end
+
 LinearAlgebra.generic_matmatmul!(C::MtlMatrix, tA, tB, A::MtlMatrix, B::MtlMatrix, _add::MulAddMul) =
     LinearAlgebra.generic_matmatmul!(C, tA, tB, A, B, _add.alpha, _add.beta)
 @autoreleasepool function LinearAlgebra.generic_matmatmul!(C::MtlMatrix, tA, tB,
@@ -79,6 +87,7 @@ LinearAlgebra.generic_matmatmul!(C::MtlMatrix, tA, tB, A::MtlMatrix, B::MtlMatri
         if size(C) != (mA, nB)
             throw(DimensionMismatch("C has dimensions $(size(C)), should have ($mA,$nB)"))
         end
+        return empty_matmul!(C, beta)
     end
 
     alg = matmul_alg[]
@@ -128,6 +137,7 @@ LinearAlgebra.generic_matmatmul!(C::MtlMatrixOperand, tA, tB,
         if size(C) != (mA, nB)
             throw(DimensionMismatch("C has dimensions $(size(C)), should have ($mA,$nB)"))
         end
+        return empty_matmul!(C, beta)
     end
 
     alg = matmul_alg[]
@@ -171,9 +181,10 @@ LinearAlgebra.generic_matvecmul!(C::MtlVector, tA::AbstractChar, A::MtlMatrix, B
     end
 
     if mA == 0 || nA == 0 || mB == 0
-        if mC != mB
-            throw(DimensionMismatch("C has length ($mC), should have ($mB)"))
+        if mC != mA
+            throw(DimensionMismatch("C has length ($mC), should have ($mA)"))
         end
+        return empty_matmul!(C, beta)
     end
 
     alg = matmul_alg[]

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -76,6 +76,23 @@ using LinearAlgebra, ScopedValues
     end
 end
 
+@testset "empty dimensions" begin
+    # products with M, K or N == 0 must not reach the backends (MPS asserts on empty buffers):
+    # the result is empty, or β·C when the contraction dimension is empty
+    @testset "$alg $(vec_b ? "gemv" : "gemm") $(M)×$(K)×$(N)" for alg in (:auto, :MPS, :MPSGraph, :native, :GPUArrays),
+                                                                  vec_b in (false, true),
+                                                                  (M, K, N) in ((0, 5, 4), (3, 0, 4), (3, 5, 0))
+        vec_b && N == 0 && continue
+        A = rand(Float32, M, K)
+        B = vec_b ? rand(Float32, K) : rand(Float32, K, N)
+        C = vec_b ? rand(Float32, M) : rand(Float32, M, N)
+        ref = mul!(copy(C), A, B, 2f0, 3f0)
+        dC = MtlArray(C)
+        @with (Metal.matmul_alg => alg) mul!(dC, MtlArray(A), MtlArray(B), 2f0, 3f0)
+        @test Array(dC) ≈ ref
+    end
+end
+
 @testset "test matrix vector multiplication of views" begin
     N = 20
 


### PR DESCRIPTION
mul! with M, K or N == 0 fell through to the selected backend; the MPSGraph path (the default for supported eltypes) then asserts inside MPS on the zero-sized buffers and aborts the process. Finish such products at the generic_matmatmul!/generic_matvecmul! entry points instead: C is either empty, or only β applies when the contraction dimension is empty.

Also fix the empty-shape check in generic_matvecmul!, which compared the output length against the input vector instead of the matrix rows and so rejected every valid empty product with a DimensionMismatch.

Fixes #937, fixes #938.