### PR TITLE
docs: add GetMerged maintainer review scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 *Metal programming in Julia*
 
 [![][doi-img]][doi-url] [![][docs-stable-img]][docs-stable-url] [![][docs-dev-img]][docs-dev-url] [![][buildkite-img]][buildkite-url] [![][codecov-img]][codecov-url] [![][benchmark-img]][benchmark-url]
+[![GetMerged Scorecard](https://getmerged.abhishekco.de/api/badge/JuliaGPU/Metal.jl)](https://getmerged.abhishekco.de/JuliaGPU/Metal.jl)
 
 [doi-img]: https://zenodo.org/badge/262279120.svg
 [doi-url]: https://zenodo.org/badge/latestdoi/262279120


### PR DESCRIPTION
Hey maintainers! 👋

I'm Abhishek, building [GetMerged](https://getmerged.abhishekco.de).

Like many open-source contributors, I've had PRs sit in backlogs for months because star counts don't show how responsive maintainers really are. We built GetMerged to index projects based on actual review turnaround, merge velocity, and welcoming practices.

Your repo scored in the **A-Tier** on our index for rapid review times.

This PR embeds the live GetMerged maintainer review scorecard badge into `README.md` so potential contributors know their pull requests will get reviewed promptly:

[![GetMerged Scorecard](https://getmerged.abhishekco.de/api/badge/JuliaGPU/Metal.jl)](https://getmerged.abhishekco.de/JuliaGPU/Metal.jl)

*(Feel free to adjust the placement or view the full breakdown at https://getmerged.abhishekco.de/JuliaGPU/Metal.jl)*
