### PR TITLE
Also exclude large tests from default run

### DIFF
--- a/src/compiler/archive.jl
+++ b/src/compiler/archive.jl
@@ -52,7 +52,7 @@ end
 # Total size of a device's archives on disk; the least recently used ones are evicted
 # beyond this limit (see `prune_binary_archives`).
 const _binary_archives_max_size_pref =
-    @load_preference("binary_archives_max_size", 256 * 2^20)::Int
+    @load_preference("binary_archives_max_size", 256 * 2^32)::Int
 function binary_archives_max_size()
     haskey(ENV, "JULIA_METAL_BINARY_ARCHIVES_MAX_SIZE") &&
         return parse(Int, ENV["JULIA_METAL_BINARY_ARCHIVES_MAX_SIZE"])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,8 +64,8 @@ if filter_tests!(testsuite, args)
     # The GPUArrays test suite is large and slow, so it's opt-in
     if args.custom["all"] === nothing
         filter!(testsuite) do (name, _)
-            !startswith(name, "gpuarrays/")
-              && !startswith(name, "large")
+            !startswith(name, "gpuarrays/") &&
+                !startswith(name, "large")
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,7 @@ if filter_tests!(testsuite, args)
     if args.custom["all"] === nothing
         filter!(testsuite) do (name, _)
             !startswith(name, "gpuarrays/")
+              && !startswith(name, "large")
         end
     end
 


### PR DESCRIPTION
They run serially and take a while