### PR TITLE
Support `cbrt(::Float32)`

### DIFF
--- a/docs/src/faq/faq.md
+++ b/docs/src/faq/faq.md
@@ -5,3 +5,16 @@
 Most likely. Any help on designing or implementing high-level wrappers for MSL's low-level functionality
 is greatly appreciated, so please consider [contributing](contributing.md) your uses of these APIs on the
 respective repositories.
+
+## Why do Float32 subnormals become zero on the GPU?
+
+On Apple GPUs, `Float32` arithmetic flushes subnormal operands and results to zero.
+Comparisons also treat subnormal operands as zero, so `iszero(x)` and `x == 0` can be true
+for a nonzero value stored in memory. Multiplying a subnormal input by a power of two
+therefore does not recover its value.
+
+The [Metal Shading Language specification](https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf)
+(section 8.1) permits flushing subnormals to zero, including for `Float16`; code should not
+assume that disabling fast math preserves them. Algorithms that need to handle subnormal
+inputs, such as `cbrt`, can normalize their bit patterns using integer operations before
+performing floating-point arithmetic.

--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -456,3 +456,56 @@ end
 
     return r
 end
+
+### Cube root
+
+# Base refines cbrt(::Float32) in Float64, which Metal does not support.
+# Reduce the argument to [1, 8), approximate with a polynomial, then apply a
+# compensated Newton step. Integer reduction preserves subnormal inputs despite FTZ.
+# Exhaustive testing of positive finite Float32 inputs on an M3 Pro measured a
+# maximum error of 0.50003 ulp; this is not a correctly rounded implementation.
+@device_override function Base.cbrt(x::Float32)
+    u = reinterpret(UInt32, x) & 0x7fffffff
+    if u == 0 || u >= 0x7f800000
+        # Preserve ±0, ±Inf and NaN. Floating-point comparisons would also treat
+        # subnormal inputs as zero.
+        return x
+    end
+
+    # argument reduction
+    e = (u >> 23) % Int32
+    m = u & 0x007fffff
+    if e == 0
+        # subnormal: normalize the significand
+        sh = (leading_zeros(m) - 8) % Int32
+        m = (m << sh) & 0x007fffff
+        e = Int32(1) - sh
+    end
+    # Add 150 = 3*50 to the unbiased exponent (e - 127) so division rounds
+    # down even for subnormals. Remove the extra factor of 2^50 when scaling.
+    e += Int32(23)
+    q = e ÷ Int32(3)
+    r = e - Int32(3) * q
+    y  = reinterpret(Float32, (((Int32(127) + r) % UInt32) << 23) | m) # in [1, 8)
+    ym = reinterpret(Float32, 0x3f800000 | m)                       # in [1, 2)
+
+    # Degree-5 relative minimax fit of cbrt on [1, 2], computed with Remez
+    # in 256-bit arithmetic and rounded to Float32. Scale by cbrt(2)^r.
+    t = fma(0.005348548f0, ym, -0.05038654f0)
+    t = fma(t, ym, 0.20277724f0)
+    t = fma(t, ym, -0.4692287f0)
+    t = fma(t, ym, 0.83816004f0)
+    t = fma(t, ym, 0.47333068f0)
+    t *= r == 0 ? 1f0 : (r == 1 ? 1.2599211f0 : 1.587401f0)
+
+    # Compensate for the rounding of t*t when computing the Newton residual.
+    s = t * t
+    sl = fma(t, t, -s)          # rounding error in s
+    res = fma(s, t, -y)
+    res = fma(sl, t, res)       # approximates t^3 - y
+    t -= res / (3f0 * s)
+
+    # Scale by 2^(q-50) and restore the sign. Every nonzero result is normal.
+    t = reinterpret(Float32, reinterpret(UInt32, t) + (((q - Int32(50)) % UInt32) << 23))
+    return copysign(t, x)
+end

--- a/test/device/intrinsics/math.jl
+++ b/test/device/intrinsics/math.jl
@@ -457,6 +457,40 @@ end
         @test Array(vec) ≈ acosh.(arr)
     end
 
+    let # cbrt
+        specials = T[0, -0.0, Inf, -Inf, NaN, 1, -1, 8, -27, 1000,
+                     floatmax(T), -floatmax(T), floatmin(T), nextfloat(zero(T)), -nextfloat(zero(T))]
+        # Exercise every exponent and each subnormal normalization shift, including
+        # values on either side of the boundaries.
+        powers = T[ldexp(one(T), e) for e in
+                   exponent(nextfloat(zero(T))):exponent(floatmax(T))]
+        boundaries = vcat(prevfloat.(powers), powers, nextfloat.(powers))
+        arr = vcat(specials, boundaries, -boundaries,
+                   reinterpret.(T, rand(Base.uinttype(T), 1024)))
+        if T === Float32
+            # The input with the largest measured error and its neighbors.
+            hard = reinterpret(Float32, UInt32[0x000db5b0, 0x000db5b1, 0x000db5b2])
+            append!(arr, hard)
+            append!(arr, -hard)
+        end
+        got = Array(cbrt.(MtlArray(arr)))
+        expected = cbrt.(arr)
+        @test all(got[i] === expected[i] for i in eachindex(specials) if !isnan(specials[i]))
+        @test all(isnan, got[isnan.(arr)])
+        # Allow one representable step from the CPU result.
+        ulps(a, b) = abs(Int(reinterpret(Base.uinttype(T), a)) - Int(reinterpret(Base.uinttype(T), b)))
+        @test all(isnan(expected[i]) || ulps(got[i], expected[i]) <= 1 for i in eachindex(arr))
+        @test all(signbit.(got) .== signbit.(expected))
+        if T === Float32
+            # A Float64 reference distinguishes nearly half-ulp errors from a full ulp.
+            @test all(eachindex(arr)) do i
+                !isfinite(arr[i]) && return true
+                ref = cbrt(Float64(arr[i]))
+                abs(Float64(got[i]) - ref) <= 0.51 * Float64(eps(Float32(ref)))
+            end
+        end
+    end
+
     let # rsqrt (Metal-specific, no Base equivalent; compare the GPU intrinsic to 1/sqrt)
         arr = rand(T, 4)
         d = MtlArray(arr)


### PR DESCRIPTION
Base refines Float32 cube roots in Float64, which Metal does not support. Use integer argument reduction, a polynomial estimate, and a compensated Newton correction to keep all arithmetic in Float32 while preserving subnormal inputs.

Test special values, exponent and subnormal boundaries, and accuracy against CPU references for Float32 and Float16.

Fixes #952.