### PR TITLE
Speed up Float32 cube roots and add a fast-math implementation

### DIFF
--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -460,11 +460,9 @@ end
 ### Cube root
 
 # Base refines cbrt(::Float32) in Float64, which Metal does not support.
-# Reduce the argument to [1, 8), approximate with a polynomial, then apply a
-# compensated Newton step. Integer reduction preserves subnormal inputs despite FTZ.
-# Exhaustive testing of positive finite Float32 inputs on an M3 Pro measured a
-# maximum error of 0.50003 ulp; this is not a correctly rounded implementation.
-@device_override function Base.cbrt(x::Float32)
+# Reduce the argument to [1, 8) and approximate with a polynomial. The accurate
+# path adds a compensated Newton step. Integer reduction preserves subnormals despite FTZ.
+@inline function _cbrt(x::Float32, fast::Bool)
     u = reinterpret(UInt32, x) & 0x7fffffff
     if u == 0 || u >= 0x7f800000
         # Preserve ±0, ±Inf and NaN. Floating-point comparisons would also treat
@@ -486,26 +484,45 @@ end
     e += Int32(23)
     q = e ÷ Int32(3)
     r = e - Int32(3) * q
-    y  = reinterpret(Float32, (((Int32(127) + r) % UInt32) << 23) | m) # in [1, 8)
-    ym = reinterpret(Float32, 0x3f800000 | m)                       # in [1, 2)
+    ym = reinterpret(Float32, 0x3f800000 | m) # in [1, 2)
 
-    # Degree-5 relative minimax fit of cbrt on [1, 2], computed with Remez
-    # in 256-bit arithmetic and rounded to Float32. Scale by cbrt(2)^r.
-    t = fma(0.005348548f0, ym, -0.05038654f0)
-    t = fma(t, ym, 0.20277724f0)
-    t = fma(t, ym, -0.4692287f0)
-    t = fma(t, ym, 0.83816004f0)
-    t = fma(t, ym, 0.47333068f0)
+    if fast
+        # Degree-7 relative minimax fit on [1, 2], centered at 1.5 to reduce
+        # cancellation (see res/cbrt.jl for the Remez fit). No refinement;
+        # measured maximum error is 2.43 ulp over all positive finite Float32
+        # inputs on an M3 Pro.
+        t = evalpoly(ym - 1.5f0, (1.1447142f0, 0.25438076f0, -0.056532383f0,
+                                0.020943526f0, -0.009240592f0, 0.004472713f0,
+                                -0.0027573353f0, 0.0015908186f0))
+    else
+        # Degree-5 relative minimax fit on [1, 2], computed with Remez in
+        # 256-bit arithmetic and rounded to Float32.
+        t = fma(0.005348548f0, ym, -0.05038654f0)
+        t = fma(t, ym, 0.20277724f0)
+        t = fma(t, ym, -0.4692287f0)
+        t = fma(t, ym, 0.83816004f0)
+        t = fma(t, ym, 0.47333068f0)
+    end
+    # Scale by cbrt(2)^r.
     t *= r == 0 ? 1f0 : (r == 1 ? 1.2599211f0 : 1.587401f0)
 
-    # Compensate for the rounding of t*t when computing the Newton residual.
-    s = t * t
-    sl = fma(t, t, -s)          # rounding error in s
-    res = fma(s, t, -y)
-    res = fma(sl, t, res)       # approximates t^3 - y
-    t -= res / (3f0 * s)
+    if !fast
+        y = reinterpret(Float32, (((Int32(127) + r) % UInt32) << 23) | m) # in [1, 8)
+        # Compensate for the rounding of t*t when computing the Newton residual.
+        s = t * t
+        sl = fma(t, t, -s)          # rounding error in s
+        res = fma(s, t, -y)
+        res = fma(sl, t, res)       # approximates t^3 - y
+        # Only the small correction needs division, with a normal divisor near
+        # [3, 12]. Fast division retains the measured maximum error of 0.50003 ulp
+        # on an M3 Pro. The residual above must keep its explicit FMAs.
+        t -= FastMath.div_fast(res, 3f0 * s)
+    end
 
     # Scale by 2^(q-50) and restore the sign. Every nonzero result is normal.
     t = reinterpret(Float32, reinterpret(UInt32, t) + (((q - Int32(50)) % UInt32) << 23))
     return copysign(t, x)
 end
+
+@device_override Base.cbrt(x::Float32) = _cbrt(x, false)
+@device_override FastMath.cbrt_fast(x::Float32) = _cbrt(x, true)

--- a/test/device/intrinsics/math.jl
+++ b/test/device/intrinsics/math.jl
@@ -155,6 +155,16 @@ end
     end
 end
 
+# Cube root has an accurate refinement and a division-free fast-math polynomial.
+@testset "cbrt" begin
+    precise_ir = sprint(io -> Metal.code_llvm(io, x -> cbrt(x), Tuple{Float32}))
+    fast_ir = sprint(io -> Metal.code_llvm(io, x -> (@fastmath cbrt(x)), Tuple{Float32}))
+    @test occursin("fdiv fast float", precise_ir)
+    @test !occursin(r"\bfdiv\b", fast_ir)
+    @test !occursin(r"\bdouble\b", precise_ir)
+    @test !occursin(r"\bdouble\b", fast_ir)
+end
+
 # individually-shaped float intrinsics.
 @testset "misc" begin
     @eval begin
@@ -468,8 +478,9 @@ end
         arr = vcat(specials, boundaries, -boundaries,
                    reinterpret.(T, rand(Base.uinttype(T), 1024)))
         if T === Float32
-            # The input with the largest measured error and its neighbors.
-            hard = reinterpret(Float32, UInt32[0x000db5b0, 0x000db5b1, 0x000db5b2])
+            # Inputs with the largest measured errors in the precise and fast paths.
+            hard = reinterpret(Float32, UInt32[0x000db5b0, 0x000db5b1, 0x000db5b2,
+                                               0x40fa9b03, 0x40fa9b04, 0x40fa9b05])
             append!(arr, hard)
             append!(arr, -hard)
         end
@@ -488,6 +499,16 @@ end
                 ref = cbrt(Float64(arr[i]))
                 abs(Float64(got[i]) - ref) <= 0.51 * Float64(eps(Float32(ref)))
             end
+            fastgot = Array(map(x -> (@fastmath cbrt(x)), MtlArray(arr)))
+            @test all(eachindex(arr)) do i
+                x = arr[i]
+                if !isfinite(x) || iszero(x)
+                    return reinterpret(UInt32, fastgot[i]) == reinterpret(UInt32, x)
+                end
+                ref = cbrt(Float64(x))
+                abs(Float64(fastgot[i]) - ref) <= 2.5 * Float64(eps(Float32(ref)))
+            end
+            @test all(signbit.(fastgot) .== signbit.(arr))
         end
     end
 


### PR DESCRIPTION
Following #953, this improves the performance of `cbrt(::Float32)` while retaining its measured accuracy, and adds a faster approximation for `@fastmath cbrt(x)`.

Ordinary `cbrt` keeps its final accuracy correction but uses a cheaper division for that small correction. The new fast-math method evaluates a polynomial without floating-point division or refinement. Both paths share argument reduction, preserve subnormal inputs and special values, and use only Float32 arithmetic. The fast polynomial uses Base's `evalpoly`; Float16 continues to use Julia's existing implementation.

## Performance and accuracy

Measured on an Apple M3 Pro with 14 GPU cores, using Julia 1.12.7:

| Implementation | Median GPU time | Speedup over #953 | Maximum measured error |
|---|---:|---:|---:|
| `cbrt` from #953 | 2.423 ms | 1.00× | 0.500027 ulp |
| Updated `cbrt` | 1.604 ms | 1.51× | 0.500027 ulp |
| New `@fastmath cbrt` | 1.368 ms | 1.77× | 2.429443 ulp |

Ordinary `cbrt` takes about 34% less GPU time than before. Opting into fast math reduces that time by a further 15%, in exchange for lower accuracy. Neither implementation guarantees correct rounding.

Accuracy was checked exhaustively over the reduced interval `[1, 8)` and all positive subnormal inputs. The reduced results cover every normal exponent through exact power-of-two scaling. Ordinary `cbrt` retains the previous maximum error, with incorrectly rounded positive finite results decreasing slightly from 21,091 to 20,748 out of 2,139,095,039 inputs. The fast path's larger error is confined to the opt-in method. These are measured results on the M3 Pro, rather than bounds established for every supported GPU.