### PR TITLE
Support Float64 through software emulation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -72,3 +72,6 @@ SpecialFunctions = "2"
 Statistics = "1"
 UUIDs = "1"
 julia = "1.10"
+
+[sources]
+GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/softfloat"}

--- a/docs/src/api/array.md
+++ b/docs/src/api/array.md
@@ -3,7 +3,7 @@
 The Metal array type, `MtlArray`, generally implements the Base array interface
 and all of its expected methods.
 
-However, there is the special function `mtl` for transferring an array over to the gpu. For compatibility reasons, it will automatically convert arrays of `Float64` to `Float32`.
+However, there is the special function `mtl` for transferring an array over to the gpu. For performance reasons, it will automatically convert arrays of `Float64` to `Float32`, as Apple GPUs do not natively support double precision (see [Float64 support](@ref)).
 
 ```@docs
 mtl

--- a/docs/src/usage/array.md
+++ b/docs/src/usage/array.md
@@ -112,6 +112,28 @@ julia> Base.mapreducedim!(identity, +, b, a)
  6.0
 ```
 
+## Float64 support
+
+Apple GPUs do not support double-precision floating-point arithmetic. Metal.jl
+nevertheless supports `Float64` (and `ComplexF64`) arrays and kernels by emulating the
+arithmetic in software, using 64-bit integer operations. This is transparent: ordinary
+Julia code, including Base's math functions, compiles and computes the same results as on
+the CPU, with round-to-nearest-even arithmetic, subnormals, signed zeros and NaNs.
+
+```jldoctest
+julia> a = MtlArray([1.0, 2.0]);
+
+julia> Array(a .* 0.5 .+ sqrt.(a))
+2-element Vector{Float64}:
+ 1.5
+ 2.414213562373095
+```
+
+Emulated arithmetic is much slower than native `Float32`, however, so the opinionated `mtl`
+conversion function still converts `Float64` arrays to `Float32`. Use `MtlArray` directly
+when double precision is required. Floating-point exception flags, non-default rounding
+modes, and `Float64` atomics are not supported.
+
 ## Random numbers
 
 Base's convenience functions for generating random numbers are available in Metal as well:

--- a/src/MetalKernels.jl
+++ b/src/MetalKernels.jl
@@ -31,7 +31,7 @@ KA.synchronize(::MetalBackend) = synchronize()
 
 KA.functional(::MetalBackend) = Metal.functional()
 
-KA.supports_float64(::MetalBackend) = false
+KA.supports_float64(::MetalBackend) = true
 KA.supports_atomics(::MetalBackend) = metal_support() >= v"4.1"
 KA.supports_unified(::MetalBackend) = true
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -29,7 +29,6 @@ end
 function check_eltype(T)
     Base.allocatedinline(T) || error("MtlArray only supports element types that are stored inline")
     Base.isbitsunion(T) && error("MtlArray does not yet support isbits-union arrays")
-    contains_eltype(T, Float64) && error("Metal does not support Float64 values, try using Float32 instead")
     contains_eltype(T, Int128) && error("Metal does not support Int128 values, try using Int64 instead")
     contains_eltype(T, UInt128) && error("Metal does not support UInt128 values, try using UInt64 instead")
 end
@@ -438,7 +437,7 @@ Adapt.adapt_storage(::Type{<:MtlArray{T,N,S}}, xs::AT) where {T,N,S,AT<:Abstract
 
 ## opinionated gpu array adaptor
 
-# eagerly converts Float64 to Float32, for compatibility reasons
+# eagerly converts Float64 to Float32, for performance reasons (Float64 is emulated)
 
 struct MtlArrayAdaptor{S} end
 

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -58,6 +58,10 @@ GPUCompiler.method_table(::MetalCompilerJob) = method_table
 
 GPUCompiler.kernel_state_type(job::MetalCompilerJob) = KernelState
 
+# Metal does not support double-precision arithmetic, so emulate it in software
+GPUCompiler.device_library_providers(::MetalCompilerJob) =
+    (GPUCompiler.SoftFloat.SoftFloat64Provider(),)
+
 # Keep relocations symbolic. Most kernels are relocation-free, so their metallib is
 # byte-stable across sessions, which restores pkgimage persistence (`can_persist_results`)
 # and lets content-keyed binary archives hit uniformly. Kernels that reference a type tag

--- a/src/device/intrinsics/math.jl
+++ b/src/device/intrinsics/math.jl
@@ -273,6 +273,10 @@ end
 @device_override Base.sin(x::Float32) = ccall("extern air.sin.f32", llvmcall, Cfloat, (Cfloat,), x)
 @device_override Base.sin(x::Float16) = ccall("extern air.sin.f16", llvmcall, Float16, (Float16,), x)
 
+# Base's trigonometric functions use 128-bit integer arithmetic to reduce large arguments,
+# which Metal does not support, so use an equivalent implementation without.
+@device_override Base.Math.paynehanek(x::Float64) = GPUCompiler.SoftFloat.paynehanek(x)
+
 @device_override function FastMath.sincos_fast(x::Float32)
     c = Ref{Cfloat}()
     s = @typed_ccall("air.fast_sincos.f32", llvmcall, Cfloat, (Cfloat, Ptr{Cfloat}), x, c)

--- a/test/array.jl
+++ b/test/array.jl
@@ -76,7 +76,7 @@ end
 
     # Test a few explicitly unsupported types
     @test_throws "MtlArray only supports element types that are stored inline" MtlArray(BigInt[1])
-    @test_throws "Metal does not support Float64 values" MtlArray(Float64[1])
+    @test MtlArray(Float64[1]) isa MtlArray{Float64}
     @test_throws "Metal does not support Int128 values" MtlArray(Int128[1])
     @test_throws "Metal does not support UInt128 values" MtlArray(UInt128[1])
 
@@ -94,8 +94,8 @@ end
         @test mtl(fill(SVector{2, ComplexF32}(1.0f0+1.0f0im, 2.0f0+2.0f0im), 10)) isa MtlArray{SVector{2, ComplexF32}}
 
         # No implicit conversion for MtlArray constructor, only for mtl
-        @test_throws "Metal does not support Float64 values" MtlArray(fill(SVector{2, Float64}(1.0, 2.0), 10))
-        @test_throws "Metal does not support Float64 values" MtlArray(fill(SVector{2, ComplexF64}(1.0, 2.0), 10))
+        @test MtlArray(fill(SVector{2, Float64}(1.0, 2.0), 10)) isa MtlArray{SVector{2, Float64}}
+        @test MtlArray(fill(SVector{2, ComplexF64}(1.0, 2.0), 10)) isa MtlArray{SVector{2, ComplexF64}}
     end
 end
 

--- a/test/float64.jl
+++ b/test/float64.jl
@@ -1,0 +1,132 @@
+using Random
+
+# Float64 arithmetic is emulated in software (see GPUCompiler.SoftFloat); the tests here
+# cover the Metal integration and exercise representative Base functionality on device,
+# comparing against the CPU.
+
+function arithmetic_kernel(out, a, b)
+    i = thread_position_in_grid_1d()
+    i > length(a) && return
+    @inbounds begin
+        x, y = a[i], b[i]
+        out[i, 1] = x + y
+        out[i, 2] = x - y
+        out[i, 3] = x * y
+        out[i, 4] = x / y
+        out[i, 5] = sqrt(abs(x))
+        out[i, 6] = fma(x, y, 1.25)
+        out[i, 7] = x < y ? x : y
+        out[i, 8] = Float64(Int32(i))
+    end
+    return
+end
+
+@generated function repeated_add(x, y, ::Val{N}) where {N}
+    Expr(:block, [:(x = x + y) for _ in 1:N]..., :(x))
+end
+
+@testset "storage" begin
+    @test MtlArray(Float64[1]) isa MtlArray{Float64}
+    @test MtlArray(ComplexF64[1 + 2im]) isa MtlArray{ComplexF64}
+    @test Metal.MetalKernels.KA.supports_float64(MetalBackend())
+    # mtl remains opinionated
+    @test mtl(Float64[1]) isa MtlArray{Float32}
+end
+
+@testset "generated code" begin
+    # arithmetic is a call to a shared helper, not inlined into every user
+    add_ir = sprint(io -> Metal.code_llvm(io, +, (Float64, Float64)))
+    @test occursin("call fastcc i64 @gpu_softfloat_add64", add_ir)
+    @test count(==('\n'), add_ir) <= 10
+    # trivial bit operations do get inlined
+    neg_ir = sprint(io -> Metal.code_llvm(io, -, (Float64,)))
+    @test occursin("xor i64", neg_ir)
+    @test !occursin("call ", neg_ir)
+
+    small_air = sprint(io -> Metal.code_air(io, repeated_add, (Float64, Float64, Val{1});
+                                            dump_module=true, debug_level=0))
+    large_air = sprint(io -> Metal.code_air(io, repeated_add, (Float64, Float64, Val{64});
+                                            dump_module=true, debug_level=0))
+    @test count("define internal fastcc i64 @gpu_softfloat_add64", large_air) == 1
+    @test sizeof(large_air) - sizeof(small_air) < 10_000
+
+    # no double-precision values or 128-bit integers may remain in the generated code
+    out = Metal.zeros(Float64, 3, 8)
+    a, b = Metal.ones(Float64, 3), Metal.ones(Float64, 3)
+    llvm = sprint(io -> (@device_code_llvm io=io dump_module=true @metal launch=false arithmetic_kernel(out, a, b)))
+    air = sprint(io -> (@device_code_air io=io @metal launch=false arithmetic_kernel(out, a, b)))
+    for code in (llvm, air)
+        @test !occursin(r"\bdouble\b", code)
+        @test !occursin(r"\bi128\b", code)
+    end
+end
+
+@testset "arithmetic" begin
+    # random bit patterns and edge cases through the actual kernel ABI, compared bit for
+    # bit against the CPU (except for NaN payloads, which are canonicalized)
+    edges = [-0.0, 0.0, nextfloat(0.0), prevfloat(floatmin(Float64)), floatmin(Float64),
+             -1.0, 1.0, nextfloat(1.0), floatmax(Float64), -Inf, Inf, NaN]
+    rng = Xoshiro(0x5f64)
+    xs = vcat(repeat(edges; inner=length(edges)), reinterpret(Float64, rand(rng, UInt64, 2048)))
+    ys = vcat(repeat(edges; outer=length(edges)), reinterpret(Float64, rand(rng, UInt64, 2048)))
+    out = Metal.zeros(Float64, length(xs), 8)
+    @metal threads=64 groups=cld(length(xs), 64) arithmetic_kernel(out, MtlArray(xs), MtlArray(ys))
+    expected = hcat(xs .+ ys, xs .- ys, xs .* ys, xs ./ ys, sqrt.(abs.(xs)), fma.(xs, ys, 1.25),
+                    map((x, y) -> x < y ? x : y, xs, ys), Float64.(1:length(xs)))
+    canonical(x) = isnan(x) ? reinterpret(UInt64, NaN) : reinterpret(UInt64, x)
+    @test canonical.(Array(out)) == canonical.(expected)
+
+    # many operations in a single kernel
+    av, bv = Float64[1.5, 4.0, 0.25], Float64[2.0, -0.5, 8.0]
+    @test Array(broadcast((x, y) -> repeated_add(x, y, Val(64)), MtlArray(av), MtlArray(bv))) == av .+ 64 .* bv
+
+    # complex numbers
+    ca = ComplexF64[1 + 2im, -0.5 + 4im]
+    cb = ComplexF64[2 - 1im, 3 + 0.25im]
+    @test Array(MtlArray(ca) .* MtlArray(cb) .+ MtlArray(ca)) == ca .* cb .+ ca
+    @test Array(abs.(MtlArray(ca))) == abs.(ca)
+end
+
+@testset "conversions" begin
+    xs = Float64[1.0, -2.0, 42.0, 0.1, -1e300, 1e-310]
+    @test Array(Float32.(MtlArray(xs))) == Float32.(xs)
+    @test Array(Float16.(MtlArray(xs))) == Float16.(xs)
+    @test Array(Float64.(MtlArray(Float32.(xs)))) == Float64.(Float32.(xs))
+    @test Array(Float64.(MtlArray(Float16.(xs)))) == Float64.(Float16.(xs))
+    @test Array(Int64.(MtlArray(xs[1:3]))) == Int64.(xs[1:3])
+    @test Array(round.(Int32, MtlArray(xs[1:4]))) == round.(Int32, xs[1:4])
+    @test Array(Float64.(MtlArray(Int64[1, -2, typemax(Int64)]))) == Float64.(Int64[1, -2, typemax(Int64)])
+    @test Array(Float64.(MtlArray(UInt8[1, 255]))) == Float64.(UInt8[1, 255])
+    # Float16 narrowing rounds directly (rounding through Float32 first would round twice)
+    ties = [nextfloat(1.0 + 2.0^-11), -nextfloat(1.0 + 2.0^-11), nextfloat(2.0^-25), 65520.0, Inf, -Inf, NaN]
+    @test isequal(Array(Float16.(MtlArray(ties))), Float16.(ties))
+    halves = reinterpret(Float16, collect(UInt16(0):typemax(UInt16)))
+    @test isequal(Array(Float64.(MtlArray(halves))), Float64.(halves))
+end
+
+@testset "Base math" begin
+    # Base's pure-Julia math functions compile as-is; the emulated primitives are correctly
+    # rounded, but the CPU contracts `muladd` to FMA where the emulation does not, so allow
+    # a few ulps of difference.
+    approx(a, b) = isequal(a, b) || (isfinite(b) && abs(a - b) <= 4eps(abs(b)) + floatmin(Float64))
+    xs = [-2.0^20, -3.5, -1.0, -0.1, 0.0, 1e-300, 0.5, 1.0, 2.5, 1e5, 1e100]
+    for f in (sin, cos, tan, exp, expm1, sinh, tanh, atan, cbrt, sinpi, cospi, x -> x^2.5, x -> x^3,
+              log, log2, log10, log1p, sqrt, acosh, asin, x -> hypot(x, 2.0), x -> rem(x, 0.3),
+              x -> mod(x, 0.3), floor, ceil, round, trunc, x -> round(x; digits=2), significand,
+              exponent, x -> ldexp(x, 3), abs, sign, x -> clamp(x, -1.0, 1.0), x -> max(x, 0.5),
+              x -> muladd(x, x, x), inv, nextfloat, prevfloat, eps, isfinite, isnan, isinteger)
+        # skip inputs outside the function's domain (or non-finite ones for the strict checks)
+        inputs = filter(x -> try f(x); true catch; false end, xs)
+        @test all(map(approx, Array(f.(MtlArray(inputs))), f.(inputs)))
+    end
+    # trigonometric functions use Payne-Hanek reduction for large arguments
+    big = [2.0^20 * pi, 1e20, -1e100, floatmax(Float64)]
+    for f in (sin, cos, tan)
+        @test Array(f.(MtlArray(big))) == f.(big)
+    end
+    # reductions
+    xs = rand(Xoshiro(1), 1000)
+    @test sum(MtlArray(xs)) ≈ sum(xs)
+    @test maximum(MtlArray(xs)) == maximum(xs)
+    @test Array(cumsum(MtlArray(xs))) ≈ cumsum(xs)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -133,8 +133,8 @@ init_worker_code = quote
 
     const eltypes = [Int16, Int32, Int64,
                      Complex{Int16}, Complex{Int32}, Complex{Int64},
-                     Float16, Float32,
-                     ComplexF16, ComplexF32]
+                     Float16, Float32, Float64,
+                     ComplexF16, ComplexF32, ComplexF64]
     TestSuite.supported_eltypes(::Type{<:MtlArray}) = eltypes
 
     # NOTE: based on test/pkg.jl::capture_stdout, but doesn't discard exceptions


### PR DESCRIPTION
Apple GPUs have no double-precision arithmetic, so Metal.jl used to reject `Float64`
arrays and kernels, and `mtl` silently converted to `Float32`. With this PR (which depends
on the GPUCompiler PR adding software Float64 emulation), `Float64` and `ComplexF64` just
work:

```julia
julia> a = MtlArray([1.0, 2.0]);

julia> Array(a .* 0.5 .+ sqrt.(a))
2-element Vector{Float64}:
 1.5
 2.414213562373095

julia> Array(sin.(MtlArray([1e20, floatmax(Float64)]))) == sin.([1e20, floatmax(Float64)])
true
```

This is transparent to user code: arithmetic, comparisons, conversions, Base's math
functions (`exp`, `log`, trigonometry, `^`, `cbrt`, ...), `ComplexF64`, structs and tuples
containing `Float64`, reductions, `rand`, and so on compile unchanged and compute the same
results as the CPU (bit-for-bit for the basic operations, which are correctly rounded; within
an ulp or so for Base's math functions, where the CPU fuses `muladd` and the emulation does
not). KernelAbstractions now reports `supports_float64`.

## How it works

Everything is in https://github.com/JuliaGPU/GPUCompiler.jl/pull/926; Metal.jl selects the emulation provider for its compilation
jobs (`src/compiler/compilation.jl`), stops rejecting `Float64` element types, and overrides
`Base.Math.paynehanek` with GPUCompiler's `UInt128`-free version so that Base's trigonometric
functions compile for large arguments. GPUCompiler then replaces every `double` operation in
the optimized LLVM IR by a call to an integer-only routine, and every `double` value by its
`i64` bits, before the module reaches Metal's AIR back-end. For example,
`Metal.code_llvm(+, (Float64, Float64))` gives:

```llvm
define i64 @julia_+(i64 %"x::Float64", i64 %"y::Float64") {
top:
  %0 = call fastcc i64 @gpu_softfloat_add64(i64 %"x::Float64", i64 %"y::Float64")
  ret i64 %0
}
```

and `-(x::Float64)` compiles to a single `xor`. The expensive routines (add, mul, div, sqrt,
fma) are shared out-of-line functions, so using an operation many times does not duplicate
its implementation, while comparisons, sign operations and conversions inline.

The opinionated `mtl` adaptor keeps converting `Float64` to `Float32` (like `cu`), since
the emulation is much slower than native single precision; use `MtlArray` directly when
double precision is required.

## Limitations

No `Float64` atomics, floating-point exception flags, or rounding modes other than
round-to-nearest-even. `UInt128`/`Int128` remain unsupported, so the few Base functions
using them (e.g. converting `Float64` to `Int128`) still fail to compile.

## Performance

Measured on an Apple M1 (8 GPU cores), Julia 1.12, macOS 27; minimum of several runs.

Broadcast over 2^22 elements (kernel time including launch; the basic operations are
memory-bound, so their cost is mostly the doubled bytes):

| operation | Float32 | Float64 (emulated) | slowdown |
|---|---:|---:|---:|
| `+` | 1.07 ms | 1.94 ms | 1.8x |
| `*` | 1.06 ms | 1.92 ms | 1.8x |
| `/` | 1.06 ms | 1.92 ms | 1.8x |
| `sqrt` | 0.85 ms | 1.40 ms | 1.6x |
| `fma` | 1.35 ms | 2.50 ms | 1.8x |
| `exp` | 0.78 ms | 17.9 ms | 23x |
| `log` | 0.78 ms | 56.8 ms | 73x |
| `sin` | 0.81 ms | 45.1 ms | 56x |
| `^` | 1.06 ms | 84.7 ms | 80x |

The math functions show the actual arithmetic cost: `Float32` uses Metal's hardware
intrinsics, while `Float64` runs Base's pure-Julia implementations on top of the emulated
primitives. A compute-bound dependent chain of 256 additions per thread runs at 3.9 G
additions/s for `Float64` versus 68 G/s for `Float32` (17x).

Code size stays bounded because the routines are compiled once per kernel: a kernel
computing `exp(x) + sqrt(x) * sin(x)` is 2283 lines of AIR for `Float64` versus 100 for
`Float32`, with five shared helper functions (add, mul, sqrt, rint, and Float64-to-Int64).

This is what one would expect from emulating floating point with 64-bit integer
operations; the goal is to make `Float64` code *work*, not to be fast.