### PR TITLE
Adapt to the library-based LLVMDowngrader_jll 0.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -41,6 +41,9 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 [extensions]
 SpecialFunctionsExt = "SpecialFunctions"
 
+[sources]
+GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/jll-libraries"}
+
 [compat]
 AbstractFFTs = "1"
 Adapt = "4.6.1"
@@ -50,11 +53,11 @@ CodecBzip2 = "0.8.5"
 Crayons = "4"
 ExprTools = "0.1"
 GPUArrays = "11.5.14"
-GPUCompiler = "2.3"
+GPUCompiler = "2.7"
 GPUToolbox = "3"
 KernelAbstractions = "0.9.38"
 LLVM = "7.2, 8, 9"
-LLVMDowngrader_jll = "0.8.3, 0.9"
+LLVMDowngrader_jll = "0.10"
 LinearAlgebra = "1"
 ObjectiveC = "6"
 PrecompileTools = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -41,9 +41,6 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 [extensions]
 SpecialFunctionsExt = "SpecialFunctions"
 
-[sources]
-GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/jll-libraries"}
-
 [compat]
 AbstractFFTs = "1"
 Adapt = "4.6.1"

--- a/bin/metallib-as
+++ b/bin/metallib-as
@@ -5,7 +5,7 @@ DIR="$(dirname "$(cd "$(dirname "$0")" && pwd)")"
 exec julia --project="$DIR" "$0" "$@"
 =#
 
-using Metal, LLVM, Metal.LLVMDowngrader_jll
+using Metal, LLVM
 
 function main(args)
     # parse arguments
@@ -70,7 +70,7 @@ function main(args)
                 if length(external_functions) > 1
                     error("Multiple external functions found in $input: $(join(LLVM.name.(external_functions), ", ")))")
                 end
-                # llvm-downgrade consumes bitcode, so re-emit the parsed module as bitcode
+                # the downgrader consumes bitcode, so re-emit the parsed module as bitcode
                 LLVM.name(external_functions[1]), let io = IOBuffer()
                     write(io, mod)
                     take!(io)
@@ -81,18 +81,7 @@ function main(args)
                 # use the input as-is
                 read(input)
             else
-                let input=Pipe(), output=Pipe()
-                    cmd = `$(LLVMDowngrader_jll.llvm_downgrade()) --bitcode-version=14.0 -o - -`
-                    proc = run(pipeline(cmd, stdin=input, stdout=output); wait=false)
-                    close(output.in)
-                    writer = @async begin
-                        write(input, bc)
-                        close(input)
-                    end
-                    reader = @async read(output)
-                    wait(proc)
-                    fetch(reader)
-                end
+                Metal.GPUCompiler.downgrade(bc, v"14.0")
             end
 
             let fun = Metal.MetalLibFunction(; name, air_module, air_version, metal_version)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -23,6 +23,9 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[sources]
+GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/jll-libraries"}
+
 [compat]
 FFTW = "1.10"
 FileCheck = "1.2"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -23,9 +23,6 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/jll-libraries"}
-
 [compat]
 FFTW = "1.10"
 FileCheck = "1.2"

--- a/test/device/intrinsics/simd.jl
+++ b/test/device/intrinsics/simd.jl
@@ -475,20 +475,22 @@ end # @testset "shuffle functions"
         # use reflection rather than `@metal launch=false`: the latter still creates a
         # pipeline, and the host runtime may be too old to load a newer library
 
+        # the AIR is disassembled by the in-process LLVM, so pointers are typed or opaque
+        # depending on its version
         # AIR 2.8: dims, strides and origin vectors (always the transposed layout, so
         # the origin is row/column-swapped)
         asm = sprint() do io
             Metal.code_air(io, kernel, tt; kernel=true, macos=v"26")
         end
-        @test occursin(r"call <64 x float> @air\.simdgroup_matrix_8x8_load\.v64f32\.p1f32\(float addrspace\(1\)\* %\S+, <2 x i64> %\S+, <2 x i64> %\S+, <2 x i64> <i64 1, i64 2>\)", asm)
-        @test occursin(r"call void @air\.simdgroup_matrix_8x8_store\.v64f32\.p1f32\(<64 x float> %\S+, float addrspace\(1\)\* %\S+, <2 x i64> %\S+, <2 x i64> %\S+, <2 x i64> <i64 3, i64 1>\)", asm)
+        @test occursin(r"call <64 x float> @air\.simdgroup_matrix_8x8_load\.v64f32\.p1f32\((?:float addrspace\(1\)\*|ptr addrspace\(1\)) %\S+, <2 x i64> %\S+, <2 x i64> %\S+, <2 x i64> <i64 1, i64 2>\)", asm)
+        @test occursin(r"call void @air\.simdgroup_matrix_8x8_store\.v64f32\.p1f32\(<64 x float> %\S+, (?:float addrspace\(1\)\*|ptr addrspace\(1\)) %\S+, <2 x i64> %\S+, <2 x i64> %\S+, <2 x i64> <i64 3, i64 1>\)", asm)
 
         # AIR < 2.8: scalar elements-per-row, unswapped origin, and a transpose flag
         asm = sprint() do io
             Metal.code_air(io, kernel, tt; kernel=true, macos=v"14")
         end
-        @test occursin(r"call <64 x float> @air\.simdgroup_matrix_8x8_load\.v64f32\.p1f32\(float addrspace\(1\)\* %\S+, i64 %\S+, <2 x i64> <i64 2, i64 1>, i1 true\)", asm)
-        @test occursin(r"call void @air\.simdgroup_matrix_8x8_store\.v64f32\.p1f32\(<64 x float> %\S+, float addrspace\(1\)\* %\S+, i64 %\S+, <2 x i64> <i64 1, i64 3>, i1 true\)", asm)
+        @test occursin(r"call <64 x float> @air\.simdgroup_matrix_8x8_load\.v64f32\.p1f32\((?:float addrspace\(1\)\*|ptr addrspace\(1\)) %\S+, i64 %\S+, <2 x i64> <i64 2, i64 1>, i1 true\)", asm)
+        @test occursin(r"call void @air\.simdgroup_matrix_8x8_store\.v64f32\.p1f32\(<64 x float> %\S+, (?:float addrspace\(1\)\*|ptr addrspace\(1\)) %\S+, i64 %\S+, <2 x i64> <i64 1, i64 3>, i1 true\)", asm)
         ## the legacy declarations keep the intrinsic attributes
         attrs = match(r"declare.+@air\.simdgroup_matrix_8x8_load\.v64f32\.p1f32\(.+\).* (#\d+)", asm)
         @test attrs !== nothing
@@ -512,15 +514,15 @@ end # @testset "shuffle functions"
         asm = sprint() do io
             Metal.code_air(io, kernel_nt, tt; kernel=true, macos=v"26")
         end
-        @test occursin(r"call <64 x float> @air\.simdgroup_matrix_8x8_load\.v64f32\.p1f32\(float addrspace\(1\)\* %\S+, <2 x i64> %\S+, <2 x i64> %\S+, <2 x i64> <i64 2, i64 1>\)", asm)
-        @test occursin(r"call void @air\.simdgroup_matrix_8x8_store\.v64f32\.p1f32\(<64 x float> %\S+, float addrspace\(1\)\* %\S+, <2 x i64> %\S+, <2 x i64> %\S+, <2 x i64> <i64 1, i64 3>\)", asm)
+        @test occursin(r"call <64 x float> @air\.simdgroup_matrix_8x8_load\.v64f32\.p1f32\((?:float addrspace\(1\)\*|ptr addrspace\(1\)) %\S+, <2 x i64> %\S+, <2 x i64> %\S+, <2 x i64> <i64 2, i64 1>\)", asm)
+        @test occursin(r"call void @air\.simdgroup_matrix_8x8_store\.v64f32\.p1f32\(<64 x float> %\S+, (?:float addrspace\(1\)\*|ptr addrspace\(1\)) %\S+, <2 x i64> %\S+, <2 x i64> %\S+, <2 x i64> <i64 1, i64 3>\)", asm)
 
         # AIR < 2.8: unswapped origin and a `false` transpose flag
         asm = sprint() do io
             Metal.code_air(io, kernel_nt, tt; kernel=true, macos=v"14")
         end
-        @test occursin(r"call <64 x float> @air\.simdgroup_matrix_8x8_load\.v64f32\.p1f32\(float addrspace\(1\)\* %\S+, i64 %\S+, <2 x i64> <i64 2, i64 1>, i1 false\)", asm)
-        @test occursin(r"call void @air\.simdgroup_matrix_8x8_store\.v64f32\.p1f32\(<64 x float> %\S+, float addrspace\(1\)\* %\S+, i64 %\S+, <2 x i64> <i64 1, i64 3>, i1 false\)", asm)
+        @test occursin(r"call <64 x float> @air\.simdgroup_matrix_8x8_load\.v64f32\.p1f32\((?:float addrspace\(1\)\*|ptr addrspace\(1\)) %\S+, i64 %\S+, <2 x i64> <i64 2, i64 1>, i1 false\)", asm)
+        @test occursin(r"call void @air\.simdgroup_matrix_8x8_store\.v64f32\.p1f32\(<64 x float> %\S+, (?:float addrspace\(1\)\*|ptr addrspace\(1\)) %\S+, i64 %\S+, <2 x i64> <i64 1, i64 3>, i1 false\)", asm)
 
         # the downgraded non-transposed load executes with transpose semantics
         function kernel_nt_exec(a, b)


### PR DESCRIPTION
JuliaPackaging/Yggdrasil#14727 replaced the `llc`, `lld` and `llvm-downgrade` executables in the GPU LLVM JLLs with shared libraries exposing a small C API, moving the back-ends to LLVM 23 at the same time. JuliaGPU/GPUCompiler.jl#930 makes GPUCompiler call those libraries in-process, and bumps its compat to the new JLL majors. Since this package pins the same JLL, it needs its compat bumped in lockstep, which is what this PR does.

Changes: `LLVMDowngrader_jll` compat → 0.10 and `GPUCompiler` compat → 2.7. Metal.jl only imports the JLL so that GPUCompiler can use it. The downgrader no longer ships the legacy `llvm-dis-14`, so `code_native`/`code_air` output is now disassembled by the in-process LLVM: it reads as that LLVM's dialect (opaque pointers) rather than LLVM 14's. The bitcode that goes into the metallib is unchanged. The simdgroup intrinsic ABI tests matched the typed-pointer spelling and now accept either.