### PR TITLE
Mark Julia 1.13 as supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ if you want to use it. PRs are very [welcome](#contributing)!
 ## Requirements
 
 -  Mac device with M-series chip
--  Julia 1.10-1.12
+-  Julia 1.10-1.13
 -  macOS 14-27
 
 These requirements are fairly strict, and are due to our limited development


### PR DESCRIPTION
Tests pass locally on a locally compiled julia with the v1.13.0 tag checked out.

TODO in a follow-up once julia 1.13 is actually released: update special CI jobs and check if the precompilation fix that was backported to 1.12 is in 1.13 yet and if so fixup the test to not skip