### PR TITLE
Adapt to LLVMDowngrader_jll 0.11 and GPUCompiler 2.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -41,9 +41,6 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 [extensions]
 SpecialFunctionsExt = "SpecialFunctions"
 
-[sources]
-GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/llvm23-jlls"}
-
 [compat]
 AbstractFFTs = "1"
 Adapt = "4.6.1"

--- a/Project.toml
+++ b/Project.toml
@@ -41,6 +41,9 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 [extensions]
 SpecialFunctionsExt = "SpecialFunctions"
 
+[sources]
+GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/llvm23-jlls"}
+
 [compat]
 AbstractFFTs = "1"
 Adapt = "4.6.1"
@@ -50,11 +53,11 @@ CodecBzip2 = "0.8.5"
 Crayons = "4"
 ExprTools = "0.1"
 GPUArrays = "11.5.14"
-GPUCompiler = "2.7"
+GPUCompiler = "2.8"
 GPUToolbox = "3"
 KernelAbstractions = "0.9.38"
 LLVM = "7.2, 8, 9"
-LLVMDowngrader_jll = "0.10"
+LLVMDowngrader_jll = "0.11"
 LinearAlgebra = "1"
 ObjectiveC = "6"
 PrecompileTools = "1"


### PR DESCRIPTION
Bumps the compat bounds to LLVMDowngrader_jll 0.11 (JuliaPackaging/Yggdrasil#14758, built against LLVM 23) and GPUCompiler 2.8 (JuliaGPU/GPUCompiler.jl#931). The downgrader C API is unchanged, so this is compat-only.